### PR TITLE
[DPR-122] Externalisable product definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "1.0.0-rc.5"
+        version = "1.0.0-rc.6"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-mi")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/IsoLocalDateTypeAdaptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/IsoLocalDateTypeAdaptor.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import java.lang.reflect.Type
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class IsoLocalDateTypeAdaptor : LocalDateTypeAdaptor {
+  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+  override fun serialize(
+    date: LocalDate?,
+    typeOfSrc: Type?,
+    context: JsonSerializationContext?,
+  ): JsonElement {
+    return JsonPrimitive(date?.format(formatter))
+  }
+
+  @Throws(JsonParseException::class)
+  override fun deserialize(
+    json: JsonElement,
+    typeOfT: Type?,
+    context: JsonDeserializationContext?,
+  ): LocalDate {
+    return LocalDate.parse(json.asString, formatter)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
@@ -6,14 +6,15 @@ import com.google.gson.reflect.TypeToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import java.time.LocalDate
 
-class JsonFileProductDefinitionRepository (
-  private val localDateTypeAdaptor: LocalDateTypeAdaptor
-) : ProductDefinitionRepository  {
+class JsonFileProductDefinitionRepository(
+  private val localDateTypeAdaptor: LocalDateTypeAdaptor,
+  private val resourceLocation: String,
+) : ProductDefinitionRepository {
 
   override fun getProductDefinitions(): List<ProductDefinition> {
     val gson: Gson = GsonBuilder()
       .registerTypeAdapter(LocalDate::class.java, localDateTypeAdaptor)
       .create()
-    return gson.fromJson(this::class.java.classLoader.getResource("productDefinition.json")?.readText(), object : TypeToken<List<ProductDefinition>>() {}.type)
+    return gson.fromJson(this::class.java.classLoader.getResource(resourceLocation)?.readText(), object : TypeToken<List<ProductDefinition>>() {}.type)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+import java.time.LocalDate
+
+class JsonFileProductDefinitionRepository (
+  private val localDateTypeAdaptor: LocalDateTypeAdaptor
+) : ProductDefinitionRepository  {
+
+  override fun getProductDefinitions(): List<ProductDefinition> {
+    val gson: Gson = GsonBuilder()
+      .registerTypeAdapter(LocalDate::class.java, localDateTypeAdaptor)
+      .create()
+    return gson.fromJson(this::class.java.classLoader.getResource("productDefinition.json")?.readText(), object : TypeToken<List<ProductDefinition>>() {}.type)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/LocalDateTypeAdaptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/LocalDateTypeAdaptor.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonSerializer
+import java.time.LocalDate
+
+interface LocalDateTypeAdaptor : JsonSerializer<LocalDate?>, JsonDeserializer<LocalDate?>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepository.kt
@@ -1,47 +1,9 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonParseException
-import com.google.gson.JsonPrimitive
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
-import com.google.gson.reflect.TypeToken
-import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
-import java.lang.reflect.Type
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
-@Service
-class ProductDefinitionRepository {
+interface ProductDefinitionRepository {
 
-  fun getProductDefinitions(): List<ProductDefinition> {
-    val gson: Gson = GsonBuilder()
-      .registerTypeAdapter(LocalDate::class.java, LocalDateTypeAdapter())
-      .create()
-    return gson.fromJson(this::class.java.classLoader.getResource("productDefinition.json")?.readText(), object : TypeToken<List<ProductDefinition>>() {}.type)
-  }
-}
-class LocalDateTypeAdapter : JsonSerializer<LocalDate?>, JsonDeserializer<LocalDate?> {
-  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-  override fun serialize(
-    date: LocalDate?,
-    typeOfSrc: Type?,
-    context: JsonSerializationContext?,
-  ): JsonElement {
-    return JsonPrimitive(date?.format(formatter))
-  }
+  fun getProductDefinitions(): List<ProductDefinition>
 
-  @Throws(JsonParseException::class)
-  override fun deserialize(
-    json: JsonElement,
-    typeOfT: Type?,
-    context: JsonDeserializationContext?,
-  ): LocalDate {
-    return LocalDate.parse(json.asString, formatter)
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepository.kt
@@ -5,5 +5,4 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Product
 interface ProductDefinitionRepository {
 
   fun getProductDefinitions(): List<ProductDefinition>
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ProductDefinitionRepositoryAutoConfig {
+
+  @Bean
+  @ConditionalOnMissingBean(ProductDefinitionRepository::class)
+  fun productDefinitionRepository (
+    localDateTypeAdaptor: LocalDateTypeAdaptor
+  ) : ProductDefinitionRepository  {
+
+    return JsonFileProductDefinitionRepository(localDateTypeAdaptor)
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(LocalDateTypeAdaptor::class)
+  fun localDateTypeAdaptor (
+  ) : LocalDateTypeAdaptor  {
+    return IsoLocalDateTypeAdaptor()
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
@@ -1,26 +1,26 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class ProductDefinitionRepositoryAutoConfig {
+class ProductDefinitionRepositoryAutoConfig(
+  @Value("\${lib.definition.location:productDefinition.json}") private val definitionResourceLocation: String,
+) {
 
   @Bean
   @ConditionalOnMissingBean(ProductDefinitionRepository::class)
-  fun productDefinitionRepository (
-    localDateTypeAdaptor: LocalDateTypeAdaptor
-  ) : ProductDefinitionRepository  {
-
-    return JsonFileProductDefinitionRepository(localDateTypeAdaptor)
+  fun productDefinitionRepository(
+    localDateTypeAdaptor: LocalDateTypeAdaptor,
+  ): ProductDefinitionRepository {
+    return JsonFileProductDefinitionRepository(localDateTypeAdaptor, definitionResourceLocation)
   }
 
   @Bean
   @ConditionalOnMissingBean(LocalDateTypeAdaptor::class)
-  fun localDateTypeAdaptor (
-  ) : LocalDateTypeAdaptor  {
+  fun localDateTypeAdaptor(): LocalDateTypeAdaptor {
     return IsoLocalDateTypeAdaptor()
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SchemaField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SchemaField.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 data class SchemaField(
   val name: String,
   val type: ParameterType,
-  val caseload: Boolean = false
+  val caseload: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SchemaField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SchemaField.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 data class SchemaField(
   val name: String,
   val type: ParameterType,
+  val caseload: Boolean = false
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -42,6 +42,7 @@ class ConfiguredApiService(
     validateFilters(reportId, reportVariantId, filters, dataSet)
     val (rangeFilters, filtersExcludingRange) = filters.entries.partition { (k, _) -> k.endsWith(RANGE_FILTER_START_SUFFIX) || k.endsWith(RANGE_FILTER_END_SUFFIX) }
     val validatedSortColumn = validateSortColumnOrGetDefault(sortColumn, reportId, dataSet, reportVariantId)
+
     return formatToSchemaFieldsCasing(
       configuredApiRepository
         .executeQuery(
@@ -53,10 +54,14 @@ class ConfiguredApiService(
           validatedSortColumn,
           sortedAsc,
           caseloads,
+          getCaseloadFields(dataSet),
         ),
       dataSet.schema.field,
     )
   }
+
+  private fun getCaseloadFields(dataSet: DataSet) =
+    dataSet.schema.field.filter { it.caseload }.map { it.name }
 
   fun validateAndCount(
     reportId: String,
@@ -73,6 +78,7 @@ class ConfiguredApiService(
         filtersExcludingRange.associate(transformMapEntryToPair()),
         dataSet.query,
         caseloads,
+        getCaseloadFields(dataSet),
       ),
     )
   }

--- a/src/main/resources/productDefinition.json
+++ b/src/main/resources/productDefinition.json
@@ -31,13 +31,15 @@
         "type" : "String"
       }, {
         "name" : "origin_code",
-        "type" : "String"
+        "type" : "String",
+        "caseload" : true
       }, {
         "name" : "destination",
         "type" : "String"
       },{
         "name" : "destination_code",
-        "type" : "String"
+        "type" : "String",
+        "caseload" : true
       }, {
         "name" : "direction",
         "type" : "String"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -60,37 +60,38 @@ class ConfiguredApiRepositoryTest {
     "ON movements.prisoner = prisoners.id"
 
   private val caseloads = listOf("BOLTCC", "WWI", "NSI", "LEICCC", "PTI")
+  private val caseloadFields = listOf("origin_code", "destination_code")
 
   @Test
   fun `should return 2 external movements for the selected page 2 and pageSize 2 sorted by date in ascending order`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 2, 2, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 2, 2, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner3, movementPrisoner4), actual)
     Assertions.assertEquals(2, actual.size)
   }
 
   @Test
   fun `should return 1 row for the selected page 3 and pageSize 2 sorted by date in ascending order`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 3, 2, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 3, 2, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner5), actual)
     Assertions.assertEquals(1, actual.size)
   }
 
   @Test
   fun `should return 5 rows for the selected page 1 and pageSize 5 sorted by date in ascending order`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner1, movementPrisoner2, movementPrisoner3, movementPrisoner4, movementPrisoner5), actual)
     Assertions.assertEquals(5, actual.size)
   }
 
   @Test
   fun `should return an empty list for the selected page 2 and pageSize 5 sorted by date in ascending order`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 2, 5, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 2, 5, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should return an empty list for the selected page 6 and pageSize 1 sorted by date in ascending order`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 6, 1, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 6, 1, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
@@ -136,80 +137,80 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return a list of all results with no filters`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 20, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 20, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(5, actual.size)
   }
 
   @Test
   fun `should return a list of rows filtered by an in direction filter`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "In"), 1, 20, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "In"), 1, 20, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(4, actual.size)
   }
 
   @Test
   fun `should return a list of inwards movements with an in direction filter regardless of the casing`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "in"), 1, 20, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "in"), 1, 20, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(4, actual.size)
   }
 
   @Test
   fun `should return a list of rows filtered by out direction filter`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "Out"), 1, 20, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "Out"), 1, 20, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(1, actual.size)
   }
 
   @Test
   fun `should return a list of outwards movements with an out direction filter regardless of the casing`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "out"), 1, 20, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), Collections.singletonMap("direction", "out"), 1, 20, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(1, actual.size)
   }
 
   @Test
   fun `should return all the rows on or after the provided start date`() {
-    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-04-30"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-04-30"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3), actual)
   }
 
   @Test
   fun `should return all the rows on or before the provided end date`() {
-    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-04-25"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-04-25"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner2, movementPrisoner1), actual)
   }
 
   @Test
   fun `should return all the rows between the provided start and end dates`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3, movementPrisoner2), actual)
   }
 
   @Test
   fun `should return all the rows between the provided start and end dates matching the direction filter`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), mapOf("direction" to "in"), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), mapOf("direction" to "in"), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner3, movementPrisoner2), actual)
   }
 
   @Test
   fun `should return no rows if the start date is after the latest table date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2025-01-01"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2025-01-01"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should return no rows if the end date is before the earliest table date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_END_SUFFIX" to "2015-01-01"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_END_SUFFIX" to "2015-01-01"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should return no rows if the start date is after the end date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-05-01", "date$RANGE_FILTER_END_SUFFIX" to "2023-04-25"), emptyMap(), 1, 10, "date", false, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-05-01", "date$RANGE_FILTER_END_SUFFIX" to "2023-04-25"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should throw an exception if a range filter does not have a start or end suffix`() {
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiRepository.executeQuery(query, mapOf("date" to "2023-05-01"), emptyMap(), 1, 10, "date", false, caseloads)
+      configuredApiRepository.executeQuery(query, mapOf("date" to "2023-05-01"), emptyMap(), 1, 10, "date", false, caseloads, caseloadFields)
     }
     Assertions.assertEquals("Range filter does not have a .start or .end suffix: date", e.message)
   }
@@ -255,6 +256,7 @@ class ConfiguredApiRepositoryTest {
         "date",
         true,
         caseloads,
+        caseloadFields,
       )
       Assertions.assertEquals(listOf(movementPrisonerNullValues), actual)
       Assertions.assertEquals(1, actual.size)
@@ -267,69 +269,69 @@ class ConfiguredApiRepositoryTest {
   @Test
   fun `should return only the rows whose origin or destination is in the caseloads list`() {
     val caseloads = listOf("LWSTMC")
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, caseloads)
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, caseloads, caseloadFields)
     Assertions.assertEquals(listOf(movementPrisoner4), actual)
     Assertions.assertEquals(1, actual.size)
   }
 
   @Test
   fun `should return no rows for an empty caseloads list`() {
-    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, emptyList())
+    val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 5, "date", true, emptyList(), caseloadFields)
     Assertions.assertEquals(emptyList<Map<String, String>>(), actual)
     Assertions.assertEquals(0, actual.size)
   }
 
   @Test
   fun `should return a count of all rows with no filters`() {
-    val actual = configuredApiRepository.count(emptyMap(), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(emptyMap(), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(5L, actual)
   }
 
   @Test
   fun `should return a count of rows with an in direction filter`() {
-    val actual = configuredApiRepository.count(emptyMap(), Collections.singletonMap("direction", "in"), query, caseloads)
+    val actual = configuredApiRepository.count(emptyMap(), Collections.singletonMap("direction", "in"), query, caseloads, caseloadFields)
     Assertions.assertEquals(4L, actual)
   }
 
   @Test
   fun `should return a count of rows with an out direction filter`() {
-    val actual = configuredApiRepository.count(emptyMap(), Collections.singletonMap("direction", "out"), query, caseloads)
+    val actual = configuredApiRepository.count(emptyMap(), Collections.singletonMap("direction", "out"), query, caseloads, caseloadFields)
     Assertions.assertEquals(1L, actual)
   }
 
   @Test
   fun `should return a count of rows with a startDate filter`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-05-01"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-05-01"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of rows with an endDate filter`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-01-31"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-01-31"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(1, actual)
   }
 
   @Test
   fun `should return a count of movements with a startDate and an endDate filter`() {
-    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-01"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-01"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of zero with a date start greater than the latest movement date`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2025-04-30"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2025-04-30"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero with a date end less than the earliest movement date`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2019-04-30"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2019-04-30"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero if the start date is after the end date`() {
-    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2019-05-01"), emptyMap(), query, caseloads)
+    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2019-05-01"), emptyMap(), query, caseloads, caseloadFields)
     Assertions.assertEquals(0, actual)
   }
 
@@ -340,7 +342,7 @@ class ConfiguredApiRepositoryTest {
     )
       .map { (sortedAsc, expected) ->
         DynamicTest.dynamicTest("When sorting by $sortColumn and sortedAsc is $sortedAsc the result is $expected") {
-          val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 1, sortColumn, sortedAsc, caseloads)
+          val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 1, 1, sortColumn, sortedAsc, caseloads, caseloadFields)
           Assertions.assertEquals(expected, actual)
           Assertions.assertEquals(1, actual.size)
         }
@@ -422,16 +424,6 @@ class ConfiguredApiRepositoryTest {
     )
   }
   object AllPrisoners {
-    val prisoner8894 = mapOf("id" to 8894, "number" to "G2504UV", "firstName" to "FirstName2", "lastName" to "LastName1", "livingUnitReference" to null)
-
-    val prisoner5207 = mapOf("id" to 5207, "number" to "G2927UV", "firstName" to "FirstName1", "lastName" to "LastName1", "livingUnitReference" to null)
-
-    val prisoner4800 = mapOf("id" to 4800, "number" to "G3418VR", "firstName" to "FirstName3", "lastName" to "LastName3", "livingUnitReference" to null)
-
-    val prisoner7849 = mapOf("id" to 7849, "number" to "G3411VR", "firstName" to "FirstName4", "lastName" to "LastName5", "livingUnitReference" to 142595)
-
-    val prisoner6851 = mapOf("id" to 6851, "number" to "G3154UG", "firstName" to "FirstName5", "lastName" to "LastName5", "livingUnitReference" to null)
-
     val allPrisoners = listOf(
       PrisonerEntity(8894, "G2504UV", "FirstName2", "LastName1", null),
       PrisonerEntity(5207, "G2927UV", "FirstName1", "LastName1", null),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -11,11 +11,12 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.*
 
 class ConfiguredApiServiceTest {
-  private val productDefinitionRepository: ProductDefinitionRepository = ProductDefinitionRepository()
+  private val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+    IsoLocalDateTypeAdaptor()
+  )
   private val configuredApiRepository: ConfiguredApiRepository = mock<ConfiguredApiRepository>()
   private val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository)
   private val expectedRepositoryResult = listOf(
@@ -39,6 +40,7 @@ class ConfiguredApiServiceTest {
     mapOf("reason" to "normal transfer"),
   )
   private val caseloads = listOf("WWI")
+  private val caseloadFields = listOf("origin_code", "destination_code")
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows when both range and non range filters are provided`() {
@@ -53,11 +55,11 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(expectedRepositoryResult)
+    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)
     assertEquals(expectedServiceResult, actual)
   }
 
@@ -70,11 +72,11 @@ class ConfiguredApiServiceTest {
     val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads)).thenReturn(4)
+    whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads, caseloadFields)).thenReturn(4)
 
     val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
 
-    verify(configuredApiRepository, times(1)).count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads)
+    verify(configuredApiRepository, times(1)).count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads, caseloadFields)
     assertEquals(Count(4), actual)
   }
 
@@ -90,11 +92,11 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(expectedRepositoryResult)
+    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)
     assertEquals(expectedServiceResult, actual)
   }
 
@@ -106,11 +108,11 @@ class ConfiguredApiServiceTest {
     val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.count(rangeFilters, emptyMap(), dataSet.query, caseloads)).thenReturn(4)
+    whenever(configuredApiRepository.count(rangeFilters, emptyMap(), dataSet.query, caseloads, caseloadFields)).thenReturn(4)
 
     val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
 
-    verify(configuredApiRepository, times(1)).count(rangeFilters, emptyMap(), dataSet.query, caseloads)
+    verify(configuredApiRepository, times(1)).count(rangeFilters, emptyMap(), dataSet.query, caseloads, caseloadFields)
     assertEquals(Count(4), actual)
   }
 
@@ -125,11 +127,11 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, emptyMap(), filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(expectedRepositoryResult)
+    whenever(configuredApiRepository.executeQuery(dataSet.query, emptyMap(), filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, emptyMap(), filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, emptyMap(), filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)
     assertEquals(expectedServiceResult, actual)
   }
 
@@ -141,11 +143,11 @@ class ConfiguredApiServiceTest {
     val filtersExcludingRange = mapOf("direction" to "in")
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.count(emptyMap(), filtersExcludingRange, dataSet.query, caseloads)).thenReturn(4)
+    whenever(configuredApiRepository.count(emptyMap(), filtersExcludingRange, dataSet.query, caseloads, caseloadFields)).thenReturn(4)
 
     val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
 
-    verify(configuredApiRepository, times(1)).count(emptyMap(), filtersExcludingRange, dataSet.query, caseloads)
+    verify(configuredApiRepository, times(1)).count(emptyMap(), filtersExcludingRange, dataSet.query, caseloads, caseloadFields)
     assertEquals(Count(4), actual)
   }
 
@@ -162,11 +164,11 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(expectedRepositoryResult)
+    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)
     assertEquals(expectedServiceResult, actual)
   }
 
@@ -179,11 +181,11 @@ class ConfiguredApiServiceTest {
     val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads)).thenReturn(4)
+    whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads, caseloadFields)).thenReturn(4)
 
     val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
 
-    verify(configuredApiRepository, times(1)).count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads)
+    verify(configuredApiRepository, times(1)).count(rangeFilters, filtersExcludingRange, dataSet.query, caseloads, caseloadFields)
     assertEquals(Count(4), actual)
   }
 
@@ -197,7 +199,7 @@ class ConfiguredApiServiceTest {
     val sortColumn = "date"
     val sortedAsc = true
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, emptyMap(), emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(
+    whenever(configuredApiRepository.executeQuery(dataSet.query, emptyMap(), emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(
       listOf(
         mapOf("PRISONNUMBER" to "1"),
       ),
@@ -205,7 +207,7 @@ class ConfiguredApiServiceTest {
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, emptyMap(), emptyMap(), 1, 10, "date", true, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, emptyMap(), emptyMap(), 1, 10, "date", true, caseloads, caseloadFields)
     assertEquals(
       listOf(
         mapOf("prisonNumber" to "1"),
@@ -220,11 +222,11 @@ class ConfiguredApiServiceTest {
     val reportVariantId = "last-month"
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.count(emptyMap(), emptyMap(), dataSet.query, caseloads)).thenReturn(4)
+    whenever(configuredApiRepository.count(emptyMap(), emptyMap(), dataSet.query, caseloads, caseloadFields)).thenReturn(4)
 
     val actual = configuredApiService.validateAndCount(reportId, reportVariantId, emptyMap(), caseloads)
 
-    verify(configuredApiRepository, times(1)).count(emptyMap(), emptyMap(), dataSet.query, caseloads)
+    verify(configuredApiRepository, times(1)).count(emptyMap(), emptyMap(), dataSet.query, caseloads, caseloadFields)
     assertEquals(Count(4), actual)
   }
 
@@ -242,7 +244,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_ID_MESSAGE} $reportId", e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -255,7 +257,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_ID_MESSAGE} $reportId", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -272,7 +274,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_VARIANT_ID_MESSAGE} $reportVariantId", e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -285,7 +287,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_VARIANT_ID_MESSAGE} $reportVariantId", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -302,7 +304,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals("Invalid sortColumn provided: abc", e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -319,7 +321,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -332,7 +334,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -349,7 +351,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -362,7 +364,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -379,7 +381,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -392,7 +394,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -409,7 +411,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -422,7 +424,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -439,7 +441,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
     }
     assertEquals("Invalid value abc for filter date. Cannot be parsed as a date.", e.message)
-    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -452,7 +454,7 @@ class ConfiguredApiServiceTest {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
     }
     assertEquals("Invalid value abc for filter date. Cannot be parsed as a date.", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -468,11 +470,11 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
-    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)).thenReturn(expectedRepositoryResult)
+    whenever(configuredApiRepository.executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, null, sortedAsc, caseloads)
 
-    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    verify(configuredApiRepository, times(1)).executeQuery(dataSet.query, rangeFilters, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads, caseloadFields)
     assertEquals(expectedServiceResult, actual)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -11,11 +11,15 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.*
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IsoLocalDateTypeAdaptor
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.JsonFileProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 
 class ConfiguredApiServiceTest {
   private val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-    IsoLocalDateTypeAdaptor()
+    IsoLocalDateTypeAdaptor(),
+    "productDefinition.json",
   )
   private val configuredApiRepository: ConfiguredApiRepository = mock<ConfiguredApiRepository>()
   private val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository)


### PR DESCRIPTION
This PR changes the Product Definition Repository and its date converter into default implementations of interfaces, which are autoconfigured in the absence of other beans that fulfil the interface.

This means that the client application should be able to provide its own implementation (e.g. sourced from DDB, hardcoded in the app) while leaving the existing API usage of the library's definitions unchanged.

Alternatively, the client can set the property `lib.definition.location` to use the default repository implementation with their own JSON production definition.