### PR TITLE
DPR2-177 use token value instead of token object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CaseloadService.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Case
 class CaseloadService(val webClient: WebClient) {
 
   fun getActiveCaseloadIds(jwt: Jwt): List<String> {
-    val caseloadResponse = webClient.get().header("Authorization", "Bearer $jwt").retrieve().bodyToMono(CaseloadResponse::class.java).block()
+    val caseloadResponse = webClient.get().header("Authorization", "Bearer ${jwt.tokenValue}").retrieve().bodyToMono(CaseloadResponse::class.java).block()
     if (caseloadResponse.accountType != "GENERAL") {
       return emptyList()
     }


### PR DESCRIPTION
Fix the 401 response we receive when calling the /me/caseloads endpoint.