### PR TITLE
Dpr2-190 - In/Out filter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "1.0.1"
+        version = "1.0.3"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -86,7 +86,8 @@ class ConfiguredApiRepository {
     val whereNoRange = filtersExcludingRange.keys.joinToString(" AND ") { k -> "lower($k) = :$k" }.ifEmpty { null }
     val whereRange = buildWhereRangeCondition(rangeFilters)
     val allFilters = whereNoRange?.plus(whereRange?.let { " AND $it" } ?: "") ?: whereRange
-    val caseloadsWhereClause = buildCaseloadsWhereClause(caseloads, caseloadFields)
+    val caseloadsStringArray = "(${caseloads.map { "\'$it\'" }.joinToString()})"
+    val caseloadsWhereClause = "(origin_code IN $caseloadsStringArray AND lower(direction)='out') OR (destination_code IN $caseloadsStringArray AND lower(direction)='in')"
     val whereClause = allFilters?.let { "WHERE $it AND ($caseloadsWhereClause)" } ?: "WHERE $caseloadsWhereClause"
     return Pair(preparedStatementNamedParams, whereClause)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -53,7 +53,7 @@ abstract class IntegrationTestBase {
 
   @BeforeEach
   fun setup() {
-    stubMeCaseloadsResponse(createCaseloadJsonResponse("WWI"))
+    stubMeCaseloadsResponse(createCaseloadJsonResponse("LWSTMC"))
   }
 
   protected fun stubMeCaseloadsResponse(jsonNode: JsonNode) {
@@ -62,7 +62,7 @@ abstract class IntegrationTestBase {
         WireMock.aResponse()
           .withStatus(HttpStatus.OK.value())
           .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-          .withJsonBody(createCaseloadJsonResponse("WWI")),
+          .withJsonBody(jsonNode),
       ),
     )
   }


### PR DESCRIPTION
This PR changes the caseload filter 
from:

```
(origin_code IN ${caseloads} or destination_code IN ${caseloads});
```
To:
```
(origin_code IN ${caseloads} AND direction='OUT') 
OR
(destination_code IN ${caseloads} AND direction='IN');
```

Tests have been modified and new added accordingly.