### PR TITLE
Dpr2 221 align model with report builder

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldDefinition.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
 data class FieldDefinition(
   val name: String,
-  val displayName: String,
+  val display: String,
   val wordWrap: WordWrap? = null,
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterOption.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterOption.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
 data class FilterOption(
   val name: String,
-  val displayName: String,
+  val display: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
-enum class FilterType(val type: String) {
-  Radio("Radio"),
-  Select("Select"),
-  DATE_RANGE("date-range"),
+enum class FilterType {
+  Radio,
+  Select,
+  DateRange,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
-enum class FilterType {
-  Radio,
-  Select,
-  DateRange,
+enum class FilterType(val type: String) {
+  Radio("Radio"),
+  Select("Select"),
+  DATE_RANGE("date-range"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
@@ -27,7 +27,7 @@ class JsonFileProductDefinitionRepository(
       .registerTypeAdapter(LocalDate::class.java, localDateTypeAdaptor)
       .registerTypeAdapter(FilterType::class.java, FilterTypeDeserializer())
       .create()
-    return gson.fromJson(this::class.java.classLoader.getResource(resourceLocation)?.readText(), object : TypeToken<List<ProductDefinition>>() {}.type)
+    return listOf(gson.fromJson(this::class.java.classLoader.getResource(resourceLocation)?.readText(), object : TypeToken<ProductDefinition>() {}.type))
   }
 
   override fun getProductDefinition(definitionId: String): ProductDefinition = getProductDefinitions()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Condition.kt
@@ -1,6 +1,3 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class FilterOption(
-  val name: String,
-  val display: String,
-)
+class Condition(val match: Match)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DataSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DataSource.kt
@@ -3,5 +3,4 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 data class DataSource(
   val id: String,
   val name: String,
-  val connection: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class DataSet(
+data class Dataset(
   val id: String,
   val name: String,
   val query: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-import com.fasterxml.jackson.annotation.JsonValue
-
-enum class FilterType(@JsonValue val type: String) {
+enum class FilterType(val type: String) {
   Radio("Radio"),
-  DATE_RANGE("date-range"),
+  DateRange("date-range"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-enum class FilterType {
-  Radio,
-  DateRange,
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class FilterType(@JsonValue val type: String) {
+  Radio("Radio"),
+  DATE_RANGE("date-range"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Match.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Match.kt
@@ -1,6 +1,3 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class FilterOption(
-  val name: String,
-  val display: String,
-)
+data class Match(val caseload: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Policy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Policy.kt
@@ -1,6 +1,3 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class FilterOption(
-  val name: String,
-  val display: String,
-)
+data class Policy(val id: String, val type: String, val rules: List<Rule>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
@@ -4,8 +4,9 @@ data class ProductDefinition(
   val id: String,
   val name: String,
   val description: String? = null,
-  val metaData: MetaData,
+  val metadata: MetaData,
   val dataSource: List<DataSource> = emptyList(),
-  val dataSet: List<DataSet> = emptyList(),
+  val dataset: List<Dataset> = emptyList(),
   val report: List<Report> = emptyList(),
+  val policy: List<Policy> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
@@ -14,4 +14,5 @@ data class Report(
   val schedule: String? = null,
   val specification: Specification? = null,
   val destination: List<Map<String, String>> = emptyList(),
+  val classification: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
 data class ReportField(
-  val schemaField: String,
-  val displayName: String,
+  val name: String,
+  val display: String,
   val wordWrap: WordWrap? = null,
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,
-  val defaultSortColumn: Boolean = false,
+  val `default-sort`: Boolean = false,
+  val formula: String? = null,
+  val visible: Boolean?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Rule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Rule.kt
@@ -1,6 +1,3 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class FilterOption(
-  val name: String,
-  val display: String,
-)
+data class Rule(val effect: String, val condition: List<Condition>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
@@ -4,8 +4,8 @@ data class SingleReportProductDefinition(
   val id: String,
   val name: String,
   val description: String? = null,
-  val metaData: MetaData,
+  val metadata: MetaData,
   val dataSource: DataSource,
-  val dataSet: DataSet,
+  val dataset: Dataset,
   val report: Report,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -118,7 +118,7 @@ class ConfiguredApiService(
   }
 
   private fun mapFilterType(filterDefinition: FilterDefinition, key: String): ConfiguredApiRepository.FilterType {
-    if (filterDefinition.type == FilterType.DATE_RANGE) {
+    if (filterDefinition.type == FilterType.DateRange) {
       if (key.endsWith(RANGE_FILTER_START_SUFFIX)) {
         return ConfiguredApiRepository.FilterType.DATE_RANGE_START
       } else if (key.endsWith(RANGE_FILTER_END_SUFFIX)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.S
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.VariantDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.WordWrap
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DataSet
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
@@ -34,12 +34,12 @@ class ReportDefinitionMapper {
     description = productDefinition.description,
     variants = productDefinition.report
       .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
-      .map { map(productDefinition.id, it, productDefinition.dataSet) },
+      .map { map(productDefinition.id, it, productDefinition.dataset) },
   )
 
-  private fun map(productDefinitionId: String, report: Report, dataSets: List<DataSet>): VariantDefinition {
+  private fun map(productDefinitionId: String, report: Report, datasets: List<Dataset>): VariantDefinition {
     val dataSetRef = report.dataset.removePrefix("\$ref:")
-    val dataSet = dataSets.find { it.id == dataSetRef }
+    val dataSet = datasets.find { it.id == dataSetRef }
       ?: throw IllegalArgumentException("Could not find matching DataSet '$dataSetRef'")
 
     return map(report, dataSet, productDefinitionId)
@@ -47,7 +47,7 @@ class ReportDefinitionMapper {
 
   private fun map(
     report: Report,
-    dataSet: DataSet,
+    dataSet: Dataset,
     productDefinitionId: String,
   ): VariantDefinition {
     return VariantDefinition(
@@ -75,17 +75,17 @@ class ReportDefinitionMapper {
   }
 
   private fun map(field: ReportField, schemaFields: List<SchemaField>): FieldDefinition {
-    val schemaFieldRef = field.schemaField.removePrefix("\$ref:")
+    val schemaFieldRef = field.name.removePrefix("\$ref:")
     val schemaField = schemaFields.find { it.name == schemaFieldRef }
       ?: throw IllegalArgumentException("Could not find matching Schema Field '$schemaFieldRef'")
 
     return FieldDefinition(
       name = schemaField.name,
-      displayName = field.displayName,
+      display = field.display,
       wordWrap = field.wordWrap?.toString()?.let(WordWrap::valueOf),
       filter = field.filter?.let(this::map),
       sortable = field.sortable,
-      defaultSortColumn = field.defaultSortColumn,
+      defaultSortColumn = field.`default-sort`,
       type = schemaField.type.toString().let(FieldType::valueOf),
     )
   }
@@ -117,7 +117,7 @@ class ReportDefinitionMapper {
 
   private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterOption): FilterOption = FilterOption(
     name = definition.name,
-    displayName = definition.displayName,
+    display = definition.display,
   )
 
   fun map(definition: SingleReportProductDefinition): SingleVariantReportDefinition {
@@ -125,7 +125,7 @@ class ReportDefinitionMapper {
       id = definition.id,
       name = definition.name,
       description = definition.description,
-      variant = map(definition.report, definition.dataSet, definition.id),
+      variant = map(definition.report, definition.dataset, definition.id),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -23,7 +23,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       .returnResult()
 
     assertThat(result.responseBody).isNotNull
-    assertThat(result.responseBody).hasSize(2)
+    assertThat(result.responseBody).hasSize(1)
     assertThat(result.responseBody).first().isNotNull
 
     val definition = result.responseBody!!.first()
@@ -71,7 +71,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       .returnResult()
 
     assertThat(result.responseBody).isNotNull
-    assertThat(result.responseBody).hasSize(2)
+    assertThat(result.responseBody).hasSize(1)
     assertThat(result.responseBody).first().isNotNull
 
     val definition = result.responseBody!!.first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -61,7 +61,7 @@ class ConfiguredApiServiceTest {
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(
       configuredApiRepository.executeQuery(
@@ -98,7 +98,7 @@ class ConfiguredApiServiceTest {
     val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "in"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
 
@@ -123,7 +123,7 @@ class ConfiguredApiServiceTest {
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(
       configuredApiRepository.executeQuery(
@@ -160,7 +160,7 @@ class ConfiguredApiServiceTest {
     val reportVariantId = "last-month"
     val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
 
@@ -186,7 +186,7 @@ class ConfiguredApiServiceTest {
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(
       configuredApiRepository.executeQuery(
@@ -223,7 +223,7 @@ class ConfiguredApiServiceTest {
     val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in")
     val repositoryFilters = listOf(Filter("direction", "in"))
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
 
@@ -248,7 +248,7 @@ class ConfiguredApiServiceTest {
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(
       configuredApiRepository.executeQuery(
@@ -285,7 +285,7 @@ class ConfiguredApiServiceTest {
     val reportVariantId = "last-month"
     val filters = mapOf("direction" to "In", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "In"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
 
@@ -304,7 +304,7 @@ class ConfiguredApiServiceTest {
   @Test
   fun `the service calls the repository without filters if no filters are provided`() {
     val reportVariantId = "last-month"
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -352,7 +352,7 @@ class ConfiguredApiServiceTest {
   @Test
   fun `the service count method calls the repository without filters if no filters are provided`() {
     val reportVariantId = "last-month"
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(configuredApiRepository.count(emptyList(), dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
 
@@ -665,7 +665,7 @@ class ConfiguredApiServiceTest {
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
-    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataSet.first()
+    val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
     whenever(
       configuredApiRepository.executeQuery(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod.HTML
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DataSet
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DataSource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
@@ -29,7 +29,7 @@ import java.util.Collections.singletonMap
 
 class ReportDefinitionMapperTest {
 
-  private val fullDataSet = DataSet(
+  private val fullDataset = Dataset(
     id = "10",
     name = "11",
     query = "12",
@@ -46,7 +46,6 @@ class ReportDefinitionMapperTest {
   private val fullDataSource = DataSource(
     id = "18",
     name = "19",
-    connection = "20",
   )
 
   private val fullReport = Report(
@@ -63,31 +62,33 @@ class ReportDefinitionMapperTest {
       template = "27",
       field = listOf(
         ReportField(
-          schemaField = "\$ref:13",
-          displayName = "14",
+          name = "\$ref:13",
+          display = "14",
           wordWrap = WordWrap.None,
           filter = FilterDefinition(
             type = FilterType.Radio,
             staticOptions = listOf(
               FilterOption(
                 name = "16",
-                displayName = "17",
+                display = "17",
               ),
             ),
           ),
           sortable = true,
-          defaultSortColumn = true,
+          `default-sort` = true,
+          formula = null,
+          visible = true,
         ),
       ),
     ),
-    destination = listOf(singletonMap("28", "29")),
+    destination = listOf(singletonMap("28", "29")), classification = "someClassification",
   )
 
   private val fullProductDefinition: ProductDefinition = ProductDefinition(
     id = "1",
     name = "2",
     description = "3",
-    metaData = MetaData(
+    metadata = MetaData(
       author = "4",
       version = "5",
       owner = "6",
@@ -95,7 +96,7 @@ class ReportDefinitionMapperTest {
       profile = "8",
       dqri = "9",
     ),
-    dataSet = listOf(fullDataSet),
+    dataset = listOf(fullDataset),
     dataSource = listOf(fullDataSource),
     report = listOf(fullReport),
   )
@@ -104,7 +105,7 @@ class ReportDefinitionMapperTest {
     id = "1",
     name = "2",
     description = "3",
-    metaData = MetaData(
+    metadata = MetaData(
       author = "4",
       version = "5",
       owner = "6",
@@ -112,7 +113,7 @@ class ReportDefinitionMapperTest {
       profile = "8",
       dqri = "9",
     ),
-    dataSet = fullDataSet,
+    dataset = fullDataset,
     dataSource = fullDataSource,
     report = fullReport,
   )
@@ -142,14 +143,14 @@ class ReportDefinitionMapperTest {
     assertThat(variant.specification?.fields).hasSize(1)
 
     val field = variant.specification!!.fields.first()
-    val sourceSchemaField = fullProductDefinition.dataSet.first().schema.field.first()
+    val sourceSchemaField = fullProductDefinition.dataset.first().schema.field.first()
     val sourceReportField = fullProductDefinition.report.first().specification!!.field.first()
 
     assertThat(field.name).isEqualTo(sourceSchemaField.name)
-    assertThat(field.displayName).isEqualTo(sourceReportField.displayName)
+    assertThat(field.display).isEqualTo(sourceReportField.display)
     assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
     assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
-    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.defaultSortColumn)
+    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.`default-sort`)
     assertThat(field.filter).isNotNull
     assertThat(field.filter?.type.toString()).isEqualTo(sourceReportField.filter?.type.toString())
     assertThat(field.filter?.staticOptions).isNotEmpty
@@ -160,7 +161,7 @@ class ReportDefinitionMapperTest {
     val sourceFilterOption = sourceReportField.filter?.staticOptions?.first()
 
     assertThat(filterOption?.name).isEqualTo(sourceFilterOption?.name)
-    assertThat(filterOption?.displayName).isEqualTo(sourceFilterOption?.displayName)
+    assertThat(filterOption?.display).isEqualTo(sourceFilterOption?.display)
   }
 
   @Test
@@ -168,7 +169,7 @@ class ReportDefinitionMapperTest {
     val productDefinition = ProductDefinition(
       id = "1",
       name = "2",
-      metaData = MetaData(
+      metadata = MetaData(
         author = "3",
         owner = "4",
         version = "5",
@@ -187,7 +188,7 @@ class ReportDefinitionMapperTest {
     val productDefinition = ProductDefinition(
       id = "1",
       name = "2",
-      metaData = MetaData(
+      metadata = MetaData(
         author = "3",
         owner = "4",
         version = "5",
@@ -200,6 +201,7 @@ class ReportDefinitionMapperTest {
           version = "8",
           dataset = "\$ref:9",
           render = RenderMethod.SVG,
+          classification = "someClassification",
         ),
       ),
     )
@@ -217,13 +219,13 @@ class ReportDefinitionMapperTest {
     val productDefinition = ProductDefinition(
       id = "1",
       name = "2",
-      metaData = MetaData(
+      metadata = MetaData(
         author = "3",
         owner = "4",
         version = "5",
       ),
-      dataSet = listOf(
-        DataSet(
+      dataset = listOf(
+        Dataset(
           id = "10",
           name = "11",
           query = "12",
@@ -240,6 +242,7 @@ class ReportDefinitionMapperTest {
           version = "15",
           dataset = "\$ref:10",
           render = RenderMethod.SVG,
+          classification = "someClassification",
         ),
         Report(
           id = "16",
@@ -248,6 +251,7 @@ class ReportDefinitionMapperTest {
           version = "18",
           dataset = "\$ref:10",
           render = RenderMethod.HTML,
+          classification = "someClassification",
         ),
       ),
     )
@@ -326,14 +330,14 @@ class ReportDefinitionMapperTest {
     assertThat(variant.specification?.fields).hasSize(1)
 
     val field = variant.specification!!.fields.first()
-    val sourceSchemaField = fullSingleReportProductDefinition.dataSet.schema.field.first()
+    val sourceSchemaField = fullSingleReportProductDefinition.dataset.schema.field.first()
     val sourceReportField = fullSingleReportProductDefinition.report.specification!!.field.first()
 
     assertThat(field.name).isEqualTo(sourceSchemaField.name)
-    assertThat(field.displayName).isEqualTo(sourceReportField.displayName)
+    assertThat(field.display).isEqualTo(sourceReportField.display)
     assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
     assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
-    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.defaultSortColumn)
+    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.`default-sort`)
     assertThat(field.filter).isNotNull
     assertThat(field.filter?.type.toString()).isEqualTo(sourceReportField.filter?.type.toString())
     assertThat(field.filter?.staticOptions).isNotEmpty
@@ -344,7 +348,7 @@ class ReportDefinitionMapperTest {
     val sourceFilterOption = sourceReportField.filter?.staticOptions?.first()
 
     assertThat(filterOption?.name).isEqualTo(sourceFilterOption?.name)
-    assertThat(filterOption?.displayName).isEqualTo(sourceFilterOption?.displayName)
+    assertThat(filterOption?.display).isEqualTo(sourceFilterOption?.display)
   }
 
   private fun getExpectedDate(offset: Long, magnitude: ChronoUnit): String? {
@@ -362,13 +366,13 @@ class ReportDefinitionMapperTest {
     return ProductDefinition(
       id = "1",
       name = "2",
-      metaData = MetaData(
+      metadata = MetaData(
         author = "3",
         owner = "4",
         version = "5",
       ),
-      dataSet = listOf(
-        DataSet(
+      dataset = listOf(
+        Dataset(
           id = "10",
           name = "11",
           query = "12",
@@ -394,15 +398,18 @@ class ReportDefinitionMapperTest {
             template = "19",
             field = listOf(
               ReportField(
-                schemaField = "\$ref:13",
-                displayName = "20",
+                name = "\$ref:13",
+                display = "20",
                 filter = FilterDefinition(
-                  type = FilterType.DateRange,
+                  type = FilterType.DATE_RANGE,
                   defaultValue = defaultFilterValue,
                 ),
+                formula = null,
+                visible = true,
               ),
             ),
           ),
+          classification = "someClassification",
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -401,7 +401,7 @@ class ReportDefinitionMapperTest {
                 name = "\$ref:13",
                 display = "20",
                 filter = FilterDefinition(
-                  type = FilterType.DATE_RANGE,
+                  type = FilterType.DateRange,
                   defaultValue = defaultFilterValue,
                 ),
                 formula = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -11,8 +11,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.R
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.VariantDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DataSet
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DataSource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetaData
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.RenderMethod.HTML
@@ -26,7 +26,7 @@ class ReportDefinitionServiceTest {
   val minimalDefinition = ProductDefinition(
     id = "1",
     name = "2",
-    metaData = MetaData(
+    metadata = MetaData(
       author = "3",
       owner = "4",
       version = "5",
@@ -41,11 +41,11 @@ class ReportDefinitionServiceTest {
       id = "3",
       name = "4",
       created = LocalDate.now(),
+      version = "5",
       dataset = "\$ref:10",
       render = HTML,
-      version = "5",
     ),
-    dataSet = DataSet(
+    dataset = Dataset(
       id = "10",
       name = "11",
       query = "12",
@@ -54,9 +54,8 @@ class ReportDefinitionServiceTest {
     dataSource = DataSource(
       id = "20",
       name = "21",
-      connection = "22",
     ),
-    metaData = MetaData(
+    metadata = MetaData(
       author = "30",
       version = "31",
       owner = "32",

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -2,17 +2,17 @@
   "id" : "external-movements",
   "name" : "External Movements",
   "description" : "Reports about prisoner external movements",
-  "metaData" : {
+  "metadata" : {
     "author" : "Adam",
     "version" : "1.2.3",
     "owner" : "Eve"
   },
-  "dataSource" : [ {
-    "id" : "redshift",
-    "name" : "RedShift",
-    "connection" : "redshift"
-  } ],
-  "dataSet" : [ {
+  "dataSource" : [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }],
+  "dataset" : [ {
     "id" : "external-movements",
     "name" : "All movements",
     "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM movements_movements as movements\nJOIN prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
@@ -52,11 +52,30 @@
       } ]
     }
   } ],
+  "policy": [
+    {
+      "id": "case",
+      "type": "row-level",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "match": {
+                "caseload": "$caseload"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "report" : [ {
     "id" : "last-month",
     "name" : "Last month",
     "description" : "All movements in the past month",
     "created" : "2023-09-20",
+    "classification": "report classification",
     "version" : "1.2.3",
     "dataset" : "$ref:external-movements",
     "policy" : [ ],
@@ -64,70 +83,73 @@
     "specification" : {
       "template" : "list",
       "field" : [ {
-        "schemaField" : "$ref:prisonNumber",
-        "displayName" : "Prison Number",
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:name",
-        "displayName" : "Name",
+        "name" : "$ref:name",
+        "display" : "Name",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:date",
-        "displayName" : "Date",
+        "name" : "$ref:date",
+        "display" : "Date",
         "filter" : {
-          "type" : "DateRange",
+          "type" : "date-range",
           "defaultValue" : "today(-1,months) - today()"
         },
         "sortable" : true,
-        "defaultSortColumn" : true
+        "default-sort" : true
       }, {
-        "schemaField" : "$ref:origin",
-        "displayName" : "From",
+        "name" : "$ref:origin",
+        "display" : "From",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:destination",
-        "displayName" : "To",
+        "name" : "$ref:destination",
+        "display" : "To",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:direction",
-        "displayName" : "Direction",
+        "name" : "$ref:direction",
+        "display" : "Direction",
         "filter" : {
           "type" : "Radio",
           "staticOptions" : [ {
             "name" : "in",
-            "displayName" : "In"
+            "display" : "In"
           }, {
             "name" : "out",
-            "displayName" : "Out"
+            "display" : "Out"
           } ]
         },
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:type",
-        "displayName" : "Type",
+        "name" : "$ref:type",
+        "display" : "Type",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:reason",
-        "displayName" : "Reason",
+        "name" : "$ref:reason",
+        "display" : "Reason",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       } ]
     },
-    "destination" : [ ]
+    "destination" : [ ],
+    "visible": "report visibility",
+    "formula": "formula placeholder"
   }, {
     "id" : "last-week",
     "name" : "Last week",
     "description" : "All movements in the past week",
     "created" : "2023-09-20",
+    "classification": "report classification",
     "version" : "1.2.3",
     "dataset" : "$ref:external-movements",
     "policy" : [ ],
@@ -135,263 +157,65 @@
     "specification" : {
       "template" : "list",
       "field" : [ {
-        "schemaField" : "$ref:prisonNumber",
-        "displayName" : "Prison Number",
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:name",
-        "displayName" : "Name",
+        "name" : "$ref:name",
+        "display" : "Name",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:date",
-        "displayName" : "Date",
+        "name" : "$ref:date",
+        "display" : "Date",
         "filter" : {
-          "type" : "DateRange",
+          "type" : "date-range",
           "defaultValue" : "today(-1,weeks) - today()"
         },
         "sortable" : true,
-        "defaultSortColumn" : true
+        "default-sort" : true
       }, {
-        "schemaField" : "$ref:origin",
-        "displayName" : "From",
+        "name" : "$ref:origin",
+        "display" : "From",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:destination",
-        "displayName" : "To",
+        "name" : "$ref:destination",
+        "display" : "To",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:direction",
-        "displayName" : "Direction",
+        "name" : "$ref:direction",
+        "display" : "Direction",
         "filter" : {
           "type" : "Radio",
           "staticOptions" : [ {
             "name" : "in",
-            "displayName" : "In"
+            "display" : "In"
           }, {
             "name" : "out",
-            "displayName" : "Out"
+            "display" : "Out"
           } ]
         },
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:type",
-        "displayName" : "Type",
+        "name" : "$ref:type",
+        "display" : "Type",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       }, {
-        "schemaField" : "$ref:reason",
-        "displayName" : "Reason",
+        "name" : "$ref:reason",
+        "display" : "Reason",
         "sortable" : true,
-        "defaultSortColumn" : false
+        "default-sort" : false
       } ]
     },
     "destination" : [ ]
   } ]
-},
-  {
-    "id" : "product2-id",
-    "name" : "External Movements",
-    "description" : "Reports about prisoner external movements",
-    "metaData" : {
-      "author" : "Adam",
-      "version" : "1.2.3",
-      "owner" : "Eve"
-    },
-    "dataSource" : [ {
-      "id" : "redshift",
-      "name" : "RedShift",
-      "connection" : "redshift"
-    } ],
-    "dataSet" : [ {
-      "id" : "external-movements",
-      "name" : "All movements",
-      "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM movements_movements as movements\nJOIN prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
-      "schema" : {
-        "field" : [ {
-          "name" : "prisonNumber",
-          "type" : "String"
-        }, {
-          "name" : "name",
-          "type" : "String"
-        }, {
-          "name" : "date",
-          "type" : "Date"
-        }, {
-          "name" : "origin",
-          "type" : "String"
-        }, {
-          "name" : "origin_code",
-          "type" : "String",
-          "caseload" : true
-        }, {
-          "name" : "destination",
-          "type" : "String"
-        },{
-          "name" : "destination_code",
-          "type" : "String",
-          "caseload" : true
-        }, {
-          "name" : "direction",
-          "type" : "String"
-        }, {
-          "name" : "type",
-          "type" : "String"
-        }, {
-          "name" : "reason",
-          "type" : "String"
-        } ]
-      }
-    } ],
-    "report" : [ {
-      "id" : "last-month",
-      "name" : "Last month",
-      "description" : "All movements in the past month",
-      "created" : "2023-09-20",
-      "version" : "1.2.3",
-      "dataset" : "$ref:external-movements",
-      "policy" : [ ],
-      "render" : "HTML",
-      "specification" : {
-        "template" : "list",
-        "field" : [ {
-          "schemaField" : "$ref:prisonNumber",
-          "displayName" : "Prison Number",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:name",
-          "displayName" : "Name",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:date",
-          "displayName" : "Date",
-          "filter" : {
-            "type" : "DateRange",
-            "defaultValue" : "today(-1,months) - today()"
-          },
-          "sortable" : true,
-          "defaultSortColumn" : true
-        }, {
-          "schemaField" : "$ref:origin",
-          "displayName" : "From",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:destination",
-          "displayName" : "To",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:direction",
-          "displayName" : "Direction",
-          "filter" : {
-            "type" : "Radio",
-            "staticOptions" : [ {
-              "name" : "in",
-              "displayName" : "In"
-            }, {
-              "name" : "out",
-              "displayName" : "Out"
-            } ]
-          },
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:type",
-          "displayName" : "Type",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:reason",
-          "displayName" : "Reason",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        } ]
-      },
-      "destination" : [ ]
-    }, {
-      "id" : "last-week",
-      "name" : "Last week",
-      "description" : "All movements in the past week",
-      "created" : "2023-09-20",
-      "version" : "1.2.3",
-      "dataset" : "$ref:external-movements",
-      "policy" : [ ],
-      "render" : "HTML",
-      "specification" : {
-        "template" : "list",
-        "field" : [ {
-          "schemaField" : "$ref:prisonNumber",
-          "displayName" : "Prison Number",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:name",
-          "displayName" : "Name",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:date",
-          "displayName" : "Date",
-          "filter" : {
-            "type" : "DateRange",
-            "defaultValue" : "today(-1,weeks) - today()"
-          },
-          "sortable" : true,
-          "defaultSortColumn" : true
-        }, {
-          "schemaField" : "$ref:origin",
-          "displayName" : "From",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:destination",
-          "displayName" : "To",
-          "wordWrap" : "None",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:direction",
-          "displayName" : "Direction",
-          "filter" : {
-            "type" : "Radio",
-            "staticOptions" : [ {
-              "name" : "in",
-              "displayName" : "In"
-            }, {
-              "name" : "out",
-              "displayName" : "Out"
-            } ]
-          },
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:type",
-          "displayName" : "Type",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        }, {
-          "schemaField" : "$ref:reason",
-          "displayName" : "Reason",
-          "sortable" : true,
-          "defaultSortColumn" : false
-        } ]
-      },
-      "destination" : [ ]
-    } ]
-  }
+}
 ]

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -1,4 +1,4 @@
-[ {
+{
   "id" : "external-movements",
   "name" : "External Movements",
   "description" : "Reports about prisoner external movements",
@@ -218,4 +218,3 @@
     "destination" : [ ]
   } ]
 }
-]


### PR DESCRIPTION
This PR includes changes to align the product definition model with the model the report builder produces.

The main changes are:
- Changes to some of the json field names.
- A change to parse the report definition as a json object instead of an array.

There are some **questions** coming up as part of this PR and DPR2-221:
1. Should the field name changes of the data model be reflected also to the controller model? For example the date range filter type is defined as date-range in the data model while the json response the library produces defines it as "dateRange". There are similar examples for other fields that were changed to align with the report builder.
My thoughts are that they should be the same both in the data model and in the controller model for consistency. 
Also I would be in favour of changing the report builder to produce camel case rather than kebab-case. 
Google suggest this as well:
https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format
2. Currently there is a /definitions endpoint. After the changes to read from a single report definition should this endpoint be deleted? Do we still need an endpoint to return the single report definition? i.e. `/definition`