### PR TITLE
DPR2-72 dynamic filter implementation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -67,6 +69,50 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       sortColumn,
       sortedAsc,
       authentication.getCaseLoads(),
+    )
+  }
+
+  @GetMapping("/reports/{reportId}/{reportVariantId}/{fieldId}")
+  @Operation(
+    description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+  )
+  fun configuredApiDynamicFilter(
+    @RequestParam(defaultValue = "1")
+    @Min(1)
+    selectedPage: Long,
+    @RequestParam(defaultValue = "10")
+    @Min(1)
+    pageSize: Long,
+    @RequestParam sortColumn: String?,
+    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @RequestParam
+    prefix: String,
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @PathVariable("fieldId")
+    @NotNull
+    @NotEmpty
+    fieldId: String,
+    authentication: AuthAwareAuthenticationToken,
+  ): List<Map<String, Any>> {
+    return configuredApiService.validateAndFetchData(
+      reportId,
+      reportVariantId,
+      filtersOnly(filters),
+      selectedPage,
+      pageSize,
+      sortColumn,
+      sortedAsc,
+      authentication.getCaseLoads(),
+      fieldId,
+      prefix,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterDefinition.kt
@@ -1,7 +1,12 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
+import com.google.gson.annotations.SerializedName
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DynamicFilterOption
+
 data class FilterDefinition(
   val type: FilterType,
   val staticOptions: List<FilterOption>? = null,
+  @SerializedName("dynamicoptions")
+  val dynamicOptions: DynamicFilterOption? = null,
   val defaultValue: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -6,4 +6,5 @@ enum class FilterType(@JsonValue val type: String) {
   Radio("Radio"),
   Select("Select"),
   DateRange("daterange"),
+  AutoComplete("autocomplete"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -105,6 +105,7 @@ class ConfiguredApiRepository {
       FilterType.DATE_RANGE_START -> "${filter.field} >= CAST(:$key AS timestamp)"
       FilterType.RANGE_END -> "$lowerCaseField <= :$key"
       FilterType.DATE_RANGE_END -> "${filter.field} < (CAST(:$key AS timestamp) + INTERVAL '1' day)"
+      FilterType.DYNAMIC -> "${filter.field} LIKE '${filter.value}%'"
     }
   }
 
@@ -124,11 +125,12 @@ class ConfiguredApiRepository {
     fun getKey(): String = "${this.field}${this.type.suffix}".lowercase()
   }
 
-  enum class FilterType(val suffix: String) {
-    STANDARD(""),
+  enum class FilterType(val suffix: String = "") {
+    STANDARD,
     RANGE_START(".start"),
     RANGE_END(".end"),
     DATE_RANGE_START(".start"),
     DATE_RANGE_END(".end"),
+    DYNAMIC,
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class DynamicFilterOption(
+  val minimumLength: Int,
+  val returnAsStaticOptions: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterDefinition.kt
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName
 data class FilterDefinition(
   val type: FilterType,
   @SerializedName("staticoptions")
-  val staticOptions: List<FilterOption>? = null,
+  val staticOptions: List<StaticFilterOption>? = null,
+  @SerializedName("dynamicoptions")
+  val dynamicOptions: DynamicFilterOption? = null,
   val default: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 enum class FilterType(val type: String) {
   Radio("Radio"),
   DateRange("daterange"),
+  AutoComplete("autocomplete"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/StaticFilterOption.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/StaticFilterOption.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class FilterOption(
+data class StaticFilterOption(
   val name: String,
   val display: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -93,6 +93,7 @@ class ReportDefinitionMapper {
   private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition): FilterDefinition = FilterDefinition(
     type = FilterType.valueOf(definition.type.toString()),
     staticOptions = definition.staticOptions?.map(this::map),
+    dynamicOptions = definition.dynamicOptions,
     defaultValue = replaceTokens(definition.default),
   )
 
@@ -115,7 +116,7 @@ class ReportDefinitionMapper {
     return result
   }
 
-  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterOption): FilterOption = FilterOption(
+  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption): FilterOption = FilterOption(
     name = definition.name,
     display = definition.display,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.Filter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.FilterType.DATE_RANGE_END
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.FilterType.DATE_RANGE_START
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.FilterType.DYNAMIC
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner1
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner2
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner3
@@ -341,6 +342,48 @@ class ConfiguredApiRepositoryTest {
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
     )
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner3, movementPrisoner2), actual)
+  }
+
+  @Test
+  fun `should return all the rows matching the dynamic filter between the provided start and end dates and given direction `() {
+    val actual = configuredApiRepository.executeQuery(
+      query,
+      listOf(
+        Filter("date", "2023-04-25", DATE_RANGE_START),
+        Filter("date", "2023-05-20", DATE_RANGE_END),
+        Filter("direction", "in"),
+        Filter("name", "La", DYNAMIC),
+      ),
+      1,
+      10,
+      "date",
+      false,
+      caseloads,
+      caseloadFields,
+      EXTERNAL_MOVEMENTS_PRODUCT_ID,
+    )
+    Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner3, movementPrisoner2), actual)
+  }
+
+  @Test
+  fun `should return no the rows if the dynamic filter does not match anything`() {
+    val actual = configuredApiRepository.executeQuery(
+      query,
+      listOf(
+        Filter("date", "2023-04-25", DATE_RANGE_START),
+        Filter("date", "2023-05-20", DATE_RANGE_END),
+        Filter("direction", "in"),
+        Filter("name", "Ab", DYNAMIC),
+      ),
+      1,
+      10,
+      "date",
+      false,
+      caseloads,
+      caseloadFields,
+      EXTERNAL_MOVEMENTS_PRODUCT_ID,
+    )
+    Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
@@ -136,6 +136,33 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Configured API returns value matching the dynamic filters provided`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/reports/external-movements/last-week/name")
+          .queryParam("${FILTERS_PREFIX}date$RANGE_FILTER_START_SUFFIX", "2023-04-25")
+          .queryParam("${FILTERS_PREFIX}date$RANGE_FILTER_END_SUFFIX", "2023-05-20")
+          .queryParam("${FILTERS_PREFIX}direction", "out")
+          .queryParam("prefix", "La")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody()
+      .json(
+        """[
+         {"prisonNumber": "${movementPrisoner4[PRISON_NUMBER]}", "name": "${movementPrisoner4[NAME]}", "date": "${dateTimeWithSeconds(movementPrisoner4[DATE])}",
+          "origin": "${movementPrisoner4[ORIGIN]}", "origin_code": "${movementPrisoner4[ORIGIN_CODE]}", "destination": "${movementPrisoner4[DESTINATION]}", "destination_code": "${movementPrisoner4[DESTINATION_CODE]}", 
+          "direction": "${movementPrisoner4[DIRECTION]}", "type": "${movementPrisoner4[TYPE]}", "reason": "${movementPrisoner4[REASON]}"}
+      ]       
+      """,
+      )
+  }
+
+  @Test
   fun `Configured API call without query params defaults to preset query params`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -228,12 +255,12 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Configured API returns 400 for a report field which is not a filter`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}name", "some name", "/reports/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}prisonNumber", "some name", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API count returns 400 for a report field which is not a filter`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}name", "some name", "/reports/external-movements/last-month/count")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}prisonNumber", "some name", "/reports/external-movements/last-month/count")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -224,7 +224,13 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                         {
                             "defaultsort": false,
                             "display": "Name",
-                            "filter": null,
+                            "filter": {   
+                               "dynamicOptions": {
+                                  "minimumLength": 2,
+                                  "returnAsStaticOptions": false
+                              },
+                               "type": "autocomplete"
+                            },
                             "name": "name",
                             "sortable": true,
                             "type": "string",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.R
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetaData
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
@@ -21,6 +20,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.WordWrap
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -68,7 +68,7 @@ class ReportDefinitionMapperTest {
           filter = FilterDefinition(
             type = FilterType.Radio,
             staticOptions = listOf(
-              FilterOption(
+              StaticFilterOption(
                 name = "16",
                 display = "17",
               ),

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -92,7 +92,14 @@
         "display" : "Name",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
       }, {
         "name" : "$ref:date",
         "display" : "Date",
@@ -166,7 +173,14 @@
         "display" : "Name",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
       }, {
         "name" : "$ref:date",
         "display" : "Date",


### PR DESCRIPTION
Changes to add a new endpoint for dynamic filtering. 

Note: This PR does not fulfil the below AC:

> If returnAsStaticOptions is true:
> The unique values for the field are requested when the definition is requested, and included as staticOptions (as with the existing ones).

There will be a separate PR for this in order to have smaller PRs with fewer changes in each.