### PR TITLE
DPR2-72 return static options from definition endpoint when returnAsStaticOptions is true

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "1.1.2"
+        version = "1.1.3"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Min
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -32,9 +33,16 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     )
     @RequestParam("renderMethod")
     renderMethod: RenderMethod?,
+    @Parameter(
+      description = "This optional parameter sets the maximum number of static options returned when there is a dynamic filter and returnAsStaticOptions is true.",
+      example = "30",
+    )
+    @RequestParam("maxStaticOptions", defaultValue = "20")
+    @Min(1)
+    maxStaticOptions: Long,
     authentication: AuthAwareAuthenticationToken,
   ): List<ReportDefinition> {
-    return reportDefinitionService.getListForUser(renderMethod, authentication.getCaseLoads())
+    return reportDefinitionService.getListForUser(renderMethod, maxStaticOptions, authentication.getCaseLoads())
   }
 
   @GetMapping("/definitions/{reportId}/{variantId}")
@@ -55,8 +63,15 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     )
     @PathVariable("variantId")
     variantId: String,
+    @Parameter(
+      description = "This optional parameter sets the maximum number of static options returned when there is a dynamic filter and returnAsStaticOptions is true.",
+      example = "30",
+    )
+    @RequestParam("maxStaticOptions", defaultValue = "20")
+    @Min(1)
+    maxStaticOptions: Long,
     authentication: AuthAwareAuthenticationToken,
   ): SingleVariantReportDefinition {
-    return reportDefinitionService.getDefinition(reportId, variantId, authentication.getCaseLoads())
+    return reportDefinitionService.getDefinition(reportId, variantId, maxStaticOptions, authentication.getCaseLoads())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionService
 
 @Validated
@@ -31,8 +32,9 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     )
     @RequestParam("renderMethod")
     renderMethod: RenderMethod?,
+    authentication: AuthAwareAuthenticationToken,
   ): List<ReportDefinition> {
-    return reportDefinitionService.getListForUser(renderMethod)
+    return reportDefinitionService.getListForUser(renderMethod, authentication.getCaseLoads())
   }
 
   @GetMapping("/definitions/{reportId}/{variantId}")
@@ -53,7 +55,8 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     )
     @PathVariable("variantId")
     variantId: String,
+    authentication: AuthAwareAuthenticationToken,
   ): SingleVariantReportDefinition {
-    return reportDefinitionService.getDefinition(reportId, variantId)
+    return reportDefinitionService.getDefinition(reportId, variantId, authentication.getCaseLoads())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -18,43 +18,45 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 import java.time.temporal.ChronoUnit
 
 @Component
-class ReportDefinitionMapper {
+class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
 
   val todayRegex: Regex = Regex("today\\(\\)")
   val dateRegex: Regex = Regex("today\\((-?\\d+), ?([a-z]+)\\)", RegexOption.IGNORE_CASE)
 
-  fun map(productDefinition: ProductDefinition, renderMethod: RenderMethod?): ReportDefinition = ReportDefinition(
+  fun map(productDefinition: ProductDefinition, renderMethod: RenderMethod?, caseLoads: List<String>): ReportDefinition = ReportDefinition(
     id = productDefinition.id,
     name = productDefinition.name,
     description = productDefinition.description,
     variants = productDefinition.report
       .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
-      .map { map(productDefinition.id, it, productDefinition.dataset) },
+      .map { map(productDefinition.id, it, productDefinition.dataset, caseLoads) },
   )
 
-  private fun map(productDefinitionId: String, report: Report, datasets: List<Dataset>): VariantDefinition {
+  private fun map(productDefinitionId: String, report: Report, datasets: List<Dataset>, caseloads: List<String>): VariantDefinition {
     val dataSetRef = report.dataset.removePrefix("\$ref:")
     val dataSet = datasets.find { it.id == dataSetRef }
       ?: throw IllegalArgumentException("Could not find matching DataSet '$dataSetRef'")
 
-    return map(report, dataSet, productDefinitionId)
+    return map(report, dataSet, productDefinitionId, caseloads)
   }
 
   private fun map(
     report: Report,
     dataSet: Dataset,
     productDefinitionId: String,
+    caseLoads: List<String>,
   ): VariantDefinition {
     return VariantDefinition(
       id = report.id,
       name = report.name,
       description = report.description,
-      specification = map(report.specification, dataSet.schema.field),
+      specification = map(report.specification, dataSet.schema.field, productDefinitionId, report.id, caseLoads),
       resourceName = "reports/$productDefinitionId/${report.id}",
     )
   }
@@ -62,7 +64,9 @@ class ReportDefinitionMapper {
   private fun map(
     specification: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification?,
     schemaFields: List<SchemaField>,
-
+    productDefinitionId: String,
+    reportVariantId: String,
+    caseLoads: List<String>,
   ): Specification? {
     if (specification == null) {
       return null
@@ -70,11 +74,17 @@ class ReportDefinitionMapper {
 
     return Specification(
       template = specification.template,
-      fields = specification.field.map { map(it, schemaFields) },
+      fields = specification.field.map { map(it, schemaFields, productDefinitionId, reportVariantId, caseLoads) },
     )
   }
 
-  private fun map(field: ReportField, schemaFields: List<SchemaField>): FieldDefinition {
+  private fun map(
+    field: ReportField,
+    schemaFields: List<SchemaField>,
+    productDefinitionId: String,
+    reportVariantId: String,
+    caseLoads: List<String>,
+  ): FieldDefinition {
     val schemaFieldRef = field.name.removePrefix("\$ref:")
     val schemaField = schemaFields.find { it.name == schemaFieldRef }
       ?: throw IllegalArgumentException("Could not find matching Schema Field '$schemaFieldRef'")
@@ -83,19 +93,42 @@ class ReportDefinitionMapper {
       name = schemaField.name,
       display = field.display,
       wordWrap = field.wordWrap?.toString()?.let(WordWrap::valueOf),
-      filter = field.filter?.let(this::map),
+      filter = field.filter?.let { map(it, productDefinitionId, reportVariantId, schemaField.name, caseLoads) },
       sortable = field.sortable,
       defaultsort = field.defaultSort,
       type = schemaField.type.toString().let(FieldType::valueOf),
     )
   }
 
-  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition): FilterDefinition = FilterDefinition(
-    type = FilterType.valueOf(definition.type.toString()),
-    staticOptions = definition.staticOptions?.map(this::map),
-    dynamicOptions = definition.dynamicOptions,
-    defaultValue = replaceTokens(definition.default),
-  )
+  private fun map(
+    filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition,
+    productDefinitionId: String,
+    reportVariantId: String,
+    schemaFieldName: String,
+    caseLoads: List<String>,
+  ): FilterDefinition {
+    return FilterDefinition(
+      type = FilterType.valueOf(filterDefinition.type.toString()),
+      staticOptions = populateStaticOptions(filterDefinition, productDefinitionId, reportVariantId, schemaFieldName, caseLoads),
+      dynamicOptions = filterDefinition.dynamicOptions,
+      defaultValue = replaceTokens(filterDefinition.default),
+    )
+  }
+
+  private fun populateStaticOptions(
+    filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition,
+    productDefinitionId: String,
+    reportVariantId: String,
+    schemaFieldName: String,
+    caseLoads: List<String>,
+  ): List<FilterOption>? {
+    return filterDefinition.dynamicOptions?.takeIf { it.returnAsStaticOptions }?.let {
+      configuredApiService.validateAndFetchData(
+        productDefinitionId,
+        reportVariantId, emptyMap(), 1, 10, schemaFieldName, true, caseLoads, schemaFieldName,
+      ).flatMap { it.entries }.map { FilterOption(it.value as String, it.value as String) }
+    } ?: filterDefinition.staticOptions?.map(this::map)
+  }
 
   private fun replaceTokens(defaultValue: String?): String? {
     if (defaultValue == null) {
@@ -116,17 +149,17 @@ class ReportDefinitionMapper {
     return result
   }
 
-  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption): FilterOption = FilterOption(
+  private fun map(definition: StaticFilterOption): FilterOption = FilterOption(
     name = definition.name,
     display = definition.display,
   )
 
-  fun map(definition: SingleReportProductDefinition): SingleVariantReportDefinition {
+  fun map(definition: SingleReportProductDefinition, caseLoads: List<String>): SingleVariantReportDefinition {
     return SingleVariantReportDefinition(
       id = definition.id,
       name = definition.name,
       description = definition.description,
-      variant = map(definition.report, definition.dataset, definition.id),
+      variant = map(definition.report, definition.dataset, definition.id, caseLoads),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
@@ -12,13 +12,13 @@ class ReportDefinitionService(
   val mapper: ReportDefinitionMapper,
 ) {
 
-  fun getListForUser(renderMethod: RenderMethod?): List<ReportDefinition> {
+  fun getListForUser(renderMethod: RenderMethod?, caseLoads: List<String>): List<ReportDefinition> {
     return productDefinitionRepository.getProductDefinitions()
-      .map { mapper.map(it, renderMethod) }
+      .map { mapper.map(it, renderMethod, caseLoads) }
       .filter { it.variants.isNotEmpty() }
   }
 
-  fun getDefinition(reportId: String, variantId: String): SingleVariantReportDefinition {
-    return mapper.map(productDefinitionRepository.getSingleReportProductDefinition(reportId, variantId))
+  fun getDefinition(reportId: String, variantId: String, caseLoads: List<String>): SingleVariantReportDefinition {
+    return mapper.map(productDefinitionRepository.getSingleReportProductDefinition(reportId, variantId), caseLoads)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
@@ -12,13 +12,17 @@ class ReportDefinitionService(
   val mapper: ReportDefinitionMapper,
 ) {
 
-  fun getListForUser(renderMethod: RenderMethod?, caseLoads: List<String>): List<ReportDefinition> {
+  fun getListForUser(renderMethod: RenderMethod?, maxStaticOptions: Long, caseLoads: List<String>): List<ReportDefinition> {
     return productDefinitionRepository.getProductDefinitions()
-      .map { mapper.map(it, renderMethod, caseLoads) }
+      .map { mapper.map(it, renderMethod, maxStaticOptions, caseLoads) }
       .filter { it.variants.isNotEmpty() }
   }
 
-  fun getDefinition(reportId: String, variantId: String, caseLoads: List<String>): SingleVariantReportDefinition {
-    return mapper.map(productDefinitionRepository.getSingleReportProductDefinition(reportId, variantId), caseLoads)
+  fun getDefinition(reportId: String, variantId: String, maxStaticOptions: Long, caseLoads: List<String>): SingleVariantReportDefinition {
+    return mapper.map(
+      productDefinitionRepository.getSingleReportProductDefinition(reportId, variantId),
+      maxStaticOptions,
+      caseLoads,
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
@@ -2,17 +2,14 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.integration
 
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_PREFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION_CODE
@@ -24,27 +21,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.REASON
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.TYPE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner4
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ExternalMovementRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PrisonerRepository
 
 class ConfiguredApiIntegrationTest : IntegrationTestBase() {
-
-  @Autowired
-  lateinit var externalMovementRepository: ExternalMovementRepository
-
-  @Autowired
-  lateinit var prisonerRepository: PrisonerRepository
-
-  @BeforeEach
-  override fun setup() {
-    super.setup()
-    ConfiguredApiRepositoryTest.AllMovements.allExternalMovements.forEach {
-      externalMovementRepository.save(it)
-    }
-    ConfiguredApiRepositoryTest.AllPrisoners.allPrisoners.forEach {
-      prisonerRepository.save(it)
-    }
-  }
 
   @Test
   fun `Configured API returns value from the repository`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -67,7 +67,6 @@ abstract class IntegrationTestBase {
     private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:latest")
 
     @DynamicPropertySource
-    @JvmStatic
     fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
       registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl)
       registry.add("spring.datasource.username", postgreSQLContainer::getUsername)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -20,6 +20,9 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ExternalMovementRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PrisonerRepository
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -34,6 +37,12 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper
+
+  @Autowired
+  lateinit var externalMovementRepository: ExternalMovementRepository
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
 
   companion object {
 
@@ -72,6 +81,12 @@ abstract class IntegrationTestBase {
   fun setup() {
     wireMockServer.resetAll()
     stubMeCaseloadsResponse(createCaseloadJsonResponse("LWSTMC"))
+    ConfiguredApiRepositoryTest.AllMovements.allExternalMovements.forEach {
+      externalMovementRepository.save(it)
+    }
+    ConfiguredApiRepositoryTest.AllPrisoners.allPrisoners.forEach {
+      prisonerRepository.save(it)
+    }
   }
 
   protected fun stubMeCaseloadsResponse(body: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -69,7 +69,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       assertThat(lastWeekVariant.specification).isNotNull
       assertThat(lastWeekVariant.specification?.fields).hasSize(8)
 
-      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(0)
+      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(1)
     }
   }
 
@@ -186,6 +186,15 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     val lastMonth = now().minusMonths(1).format(DateTimeFormatter.ISO_DATE)
     val thisMonth = now().format(DateTimeFormatter.ISO_DATE)
     assertThat(dateField.filter!!.defaultValue).isEqualTo("$lastMonth - $thisMonth")
+
+    val reasonField = lastMonthVariant.specification?.fields?.find { it.name == "reason" }
+    assertThat(reasonField).isNotNull
+    assertThat(reasonField!!.filter).isNotNull
+    assertThat(reasonField.filter!!.type).isEqualTo(FilterType.AutoComplete)
+    assertThat(reasonField.filter!!.staticOptions).isNotNull
+    assertThat(reasonField.filter!!.staticOptions).hasSize(1)
+    assertThat(reasonField.filter!!.staticOptions!![0].name).isEqualTo("Transfer Out to Other Establishment")
+    assertThat(reasonField.filter!!.staticOptions!![0].display).isEqualTo("Transfer Out to Other Establishment")
   }
 
   @Test
@@ -300,7 +309,20 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                         {
                             "defaultsort": false,
                             "display": "Reason",
-                            "filter": null,
+                            "filter": {
+                                "type": "autocomplete",
+                                "dynamicOptions": {
+                                    "minimumLength": 2,
+                                    "returnAsStaticOptions": true
+                                },
+                                "staticOptions": [
+                                {
+                                    "display": "Transfer Out to Other Establishment",
+                                    "name": "Transfer Out to Other Establishment"
+                                }
+                              ],
+                              "defaultValue": null
+                            },
                             "name": "reason",
                             "sortable": true,
                             "type": "string",
@@ -405,7 +427,20 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                         {
                             "defaultsort": false,
                             "display": "Reason",
-                            "filter": null,
+                            "filter": {
+                                "type": "autocomplete",
+                                "dynamicOptions": {
+                                    "minimumLength": 2,
+                                    "returnAsStaticOptions": true
+                                },
+                                "staticOptions": [
+                                {
+                                    "display": "Transfer Out to Other Establishment",
+                                    "name": "Transfer Out to Other Establishment"
+                                }
+                              ],
+                              "defaultValue": null
+                            },
                             "name": "reason",
                             "sortable": true,
                             "type": "string",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -141,7 +141,12 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Single definition is returned as expected`() {
     val result = webTestClient.get()
-      .uri("/definitions/external-movements/last-month")
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/definitions/external-movements/last-month")
+          .queryParam("maxStaticOptions", "15")
+          .build()
+      }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))
       .exchange()
       .expectStatus()
@@ -238,6 +243,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                                   "minimumLength": 2,
                                   "returnAsStaticOptions": false
                               },
+                              "staticOptions": null,
                                "type": "autocomplete"
                             },
                             "name": "name",
@@ -356,6 +362,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                                   "minimumLength": 2,
                                   "returnAsStaticOptions": false
                               },
+                              "staticOptions": null,
                                "type": "autocomplete"
                             },
                             "name": "name",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -739,7 +739,7 @@ class ConfiguredApiServiceTest {
   }
 
   @Test
-  fun `validateAndFetchData should throw an exception when having a prefix with more characters than the minimum length`() {
+  fun `validateAndFetchData should throw an exception when having a prefix with fewer characters than the minimum length`() {
     val reportVariantId = "last-month"
     val selectedPage = 1L
     val pageSize = 10L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -131,7 +131,7 @@ class ReportDefinitionMapperTest {
   fun `Getting report list for user maps full data correctly`() {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(fullProductDefinition, null, emptyList())
+    val result = mapper.map(fullProductDefinition, null, 10, emptyList())
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullProductDefinition.id)
@@ -187,7 +187,7 @@ class ReportDefinitionMapperTest {
     )
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(productDefinition, null, emptyList())
+    val result = mapper.map(productDefinition, null, 10, emptyList())
 
     assertThat(result).isNotNull
     assertThat(result.variants).hasSize(0)
@@ -219,7 +219,7 @@ class ReportDefinitionMapperTest {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
     val exception = assertThrows(IllegalArgumentException::class.java) {
-      mapper.map(productDefinition, null, emptyList())
+      mapper.map(productDefinition, null, 10, emptyList())
     }
     verifyNoInteractions(configuredApiService)
     assertThat(exception).message().isEqualTo("Could not find matching DataSet '9'")
@@ -268,7 +268,7 @@ class ReportDefinitionMapperTest {
     )
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(productDefinition, HTML, emptyList())
+    val result = mapper.map(productDefinition, HTML, 10, emptyList())
 
     assertThat(result).isNotNull
     assertThat(result.variants).hasSize(1)
@@ -291,7 +291,7 @@ class ReportDefinitionMapperTest {
     val defaultValue = createProductDefinitionWithDefaultFilter("today($offset, $magnitude)")
     val expectedDate = getExpectedDate(offset, magnitude)
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
 
@@ -303,7 +303,7 @@ class ReportDefinitionMapperTest {
     val defaultValue = createProductDefinitionWithDefaultFilter("today()")
     val expectedDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
 
@@ -318,7 +318,7 @@ class ReportDefinitionMapperTest {
     val expectedDate3 = getExpectedDate(7, ChronoUnit.DAYS)
     val expectedResult = "$expectedDate1, $expectedDate2, $expectedDate3"
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedResult)
 
@@ -329,7 +329,7 @@ class ReportDefinitionMapperTest {
   fun `Getting single report for user maps full data correctly`() {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(fullSingleReportProductDefinition, emptyList())
+    val result = mapper.map(fullSingleReportProductDefinition, 10, emptyList())
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleReportProductDefinition.id)
@@ -392,7 +392,6 @@ class ReportDefinitionMapperTest {
             wordWrap = WordWrap.None,
             filter = FilterDefinition(
               type = FilterType.AutoComplete,
-              // Minimum length is not really used here as there is no prefix parameter.
               dynamicOptions = DynamicFilterOption(minimumLength = 2, returnAsStaticOptions = true),
             ),
             sortable = true,
@@ -412,11 +411,11 @@ class ReportDefinitionMapperTest {
     whenever(
       configuredApiService.validateAndFetchData(
         fullSingleProductDefinition.id,
-        reportWithDynamicFilter.id, emptyMap(), 1, 10, "13", true, caseLoads, "13",
+        reportWithDynamicFilter.id, emptyMap(), 1, 20, "13", true, caseLoads, "13",
       ),
     ).thenReturn(listOf(mapOf("13" to "static1"), mapOf("13" to "static2")))
 
-    val result = mapper.map(fullSingleProductDefinition, caseLoads)
+    val result = mapper.map(fullSingleProductDefinition, 20, caseLoads)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleProductDefinition.id)
@@ -477,7 +476,6 @@ class ReportDefinitionMapperTest {
             wordWrap = WordWrap.None,
             filter = FilterDefinition(
               type = FilterType.AutoComplete,
-              // Minimum length is not really used here as there is no prefix parameter.
               dynamicOptions = DynamicFilterOption(minimumLength = 2, returnAsStaticOptions = false),
             ),
             sortable = true,
@@ -501,7 +499,7 @@ class ReportDefinitionMapperTest {
       ),
     ).thenReturn(listOf(mapOf("13" to "static1"), mapOf("13" to "static2")))
 
-    val result = mapper.map(fullSingleProductDefinition, caseLoads)
+    val result = mapper.map(fullSingleProductDefinition, 10, caseLoads)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleProductDefinition.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -81,14 +81,14 @@ class ReportDefinitionServiceTest {
       on { getProductDefinitions() } doReturn listOf(minimalDefinition)
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any(), any(), any()) } doReturn expectedResult
+      on { map(any(), any(), any(), any()) } doReturn expectedResult
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML, caseLoads)
+    val actualResult = service.getListForUser(RenderMethod.HTML, 20, caseLoads)
 
     then(repository).should().getProductDefinitions()
-    then(mapper).should().map(minimalDefinition, RenderMethod.HTML, caseLoads)
+    then(mapper).should().map(minimalDefinition, RenderMethod.HTML, 20, caseLoads)
 
     assertThat(actualResult).isNotEmpty
     assertThat(actualResult).hasSize(1)
@@ -112,18 +112,19 @@ class ReportDefinitionServiceTest {
       on { getSingleReportProductDefinition(any(), any()) } doReturn minimalSingleDefinition
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any(), any()) } doReturn expectedResult
+      on { map(any(), any(), any()) } doReturn expectedResult
     }
     val service = ReportDefinitionService(repository, mapper)
 
     val actualResult = service.getDefinition(
       minimalSingleDefinition.id,
       minimalSingleDefinition.report.id,
+      20,
       caseLoads,
     )
 
     then(repository).should().getSingleReportProductDefinition(minimalSingleDefinition.id, minimalSingleDefinition.report.id)
-    then(mapper).should().map(minimalSingleDefinition, caseLoads)
+    then(mapper).should().map(minimalSingleDefinition, 20, caseLoads)
 
     assertThat(actualResult).isNotNull
     assertThat(actualResult).isEqualTo(expectedResult)
@@ -141,11 +142,11 @@ class ReportDefinitionServiceTest {
       on { getProductDefinitions() } doReturn listOf(minimalDefinition)
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any(), any(), any()) } doReturn definitionWithNoVariants
+      on { map(any(), any(), any(), any()) } doReturn definitionWithNoVariants
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML, caseLoads)
+    val actualResult = service.getListForUser(RenderMethod.HTML, 20, caseLoads)
 
     assertThat(actualResult).hasSize(0)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -75,19 +75,20 @@ class ReportDefinitionServiceTest {
         ),
       ),
     )
+    val caseLoads = listOf("caseLoad")
 
     val repository = mock<ProductDefinitionRepository> {
       on { getProductDefinitions() } doReturn listOf(minimalDefinition)
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any(), any()) } doReturn expectedResult
+      on { map(any(), any(), any()) } doReturn expectedResult
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML)
+    val actualResult = service.getListForUser(RenderMethod.HTML, caseLoads)
 
     then(repository).should().getProductDefinitions()
-    then(mapper).should().map(minimalDefinition, RenderMethod.HTML)
+    then(mapper).should().map(minimalDefinition, RenderMethod.HTML, caseLoads)
 
     assertThat(actualResult).isNotEmpty
     assertThat(actualResult).hasSize(1)
@@ -105,19 +106,24 @@ class ReportDefinitionServiceTest {
         resourceName = "3",
       ),
     )
+    val caseLoads = listOf("caseLoad")
 
     val repository = mock<ProductDefinitionRepository> {
       on { getSingleReportProductDefinition(any(), any()) } doReturn minimalSingleDefinition
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any()) } doReturn expectedResult
+      on { map(any(), any()) } doReturn expectedResult
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getDefinition(minimalSingleDefinition.id, minimalSingleDefinition.report.id)
+    val actualResult = service.getDefinition(
+      minimalSingleDefinition.id,
+      minimalSingleDefinition.report.id,
+      caseLoads,
+    )
 
     then(repository).should().getSingleReportProductDefinition(minimalSingleDefinition.id, minimalSingleDefinition.report.id)
-    then(mapper).should().map(minimalSingleDefinition)
+    then(mapper).should().map(minimalSingleDefinition, caseLoads)
 
     assertThat(actualResult).isNotNull
     assertThat(actualResult).isEqualTo(expectedResult)
@@ -130,15 +136,16 @@ class ReportDefinitionServiceTest {
       name = "2",
       variants = emptyList(),
     )
+    val caseLoads = listOf("caseLoad")
     val repository = mock<ProductDefinitionRepository> {
       on { getProductDefinitions() } doReturn listOf(minimalDefinition)
     }
     val mapper = mock<ReportDefinitionMapper> {
-      on { map(any(), any()) } doReturn definitionWithNoVariants
+      on { map(any(), any(), any()) } doReturn definitionWithNoVariants
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML)
+    val actualResult = service.getListForUser(RenderMethod.HTML, caseLoads)
 
     assertThat(actualResult).hasSize(0)
   }

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -145,7 +145,14 @@
         "name" : "$ref:reason",
         "display" : "Reason",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
       } ]
     },
     "destination" : [ ],
@@ -226,7 +233,14 @@
         "name" : "$ref:reason",
         "display" : "Reason",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
       } ]
     },
     "destination" : [ ]

--- a/src/test/resources/productDefinition2.json
+++ b/src/test/resources/productDefinition2.json
@@ -138,7 +138,14 @@
         "name" : "$ref:reason",
         "display" : "Reason",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
       } ]
     },
     "destination" : [ ],
@@ -212,7 +219,14 @@
         "name" : "$ref:reason",
         "display" : "Reason",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
       } ]
     },
     "destination" : [ ]


### PR DESCRIPTION
This is the second PR for DPR2-72 to fulfil the following AC:

> If returnAsStaticOptions is true:
> 
> The unique values for the field are requested when the definition is requested, and included as staticOptions (as with the existing ones).

When the report definition is requested, for each report field which is a dynamic filter and has the flag returnAsStaticOptions set to true, the list of static options is populated in the response and contains all the available distinct values of that field. 
There is no prefix filtering in this case nor any other filters when performing the SQL query, apart from the caseload checks.