### PR TITLE
Refactor product definition repository to reuse get product definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "1.1.3"
+        version = "1.1.4"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import jakarta.validation.ValidationException
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+
+abstract class AbstractProductDefinitionRepository : ProductDefinitionRepository {
+
+  override fun getSingleReportProductDefinition(definitionId: String, reportId: String): SingleReportProductDefinition {
+    val schemaRefPrefix = "\$ref:"
+    val productDefinition = getProductDefinition(definitionId)
+    val reportDefinition = productDefinition.report
+      .filter { it.id == reportId }
+      .ifEmpty { throw ValidationException("Invalid report variant id provided: $reportId") }
+      .first()
+
+    val dataSetId = reportDefinition.dataset.removePrefix(schemaRefPrefix)
+    val dataSet = productDefinition.dataset
+      .filter { it.id == dataSetId }
+      .ifEmpty { throw ValidationException("Invalid dataSetId in report: $dataSetId") }
+      .first()
+
+    return SingleReportProductDefinition(
+      id = definitionId,
+      name = productDefinition.name,
+      description = productDefinition.description,
+      metadata = productDefinition.metadata,
+      datasource = productDefinition.datasource.first(),
+      dataset = dataSet,
+      report = reportDefinition,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
@@ -7,7 +7,6 @@ import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import java.time.LocalDate
 
 class JsonFileProductDefinitionRepository(
@@ -15,11 +14,7 @@ class JsonFileProductDefinitionRepository(
   private val resourceLocations: List<String>,
   private val filterTypeDeserializer: FilterTypeDeserializer,
   private val schemaFieldTypeDeserializer: SchemaFieldTypeDeserializer,
-) : ProductDefinitionRepository {
-
-  companion object {
-    private const val schemaRefPrefix = "\$ref:"
-  }
+) : AbstractProductDefinitionRepository() {
 
   override fun getProductDefinitions(): List<ProductDefinition> {
     val gson: Gson = GsonBuilder()
@@ -34,28 +29,4 @@ class JsonFileProductDefinitionRepository(
     .filter { it.id == definitionId }
     .ifEmpty { throw ValidationException("Invalid report id provided: $definitionId") }
     .first()
-
-  override fun getSingleReportProductDefinition(definitionId: String, reportId: String): SingleReportProductDefinition {
-    val productDefinition = getProductDefinition(definitionId)
-    val reportDefinition = productDefinition.report
-      .filter { it.id == reportId }
-      .ifEmpty { throw ValidationException("Invalid report variant id provided: $reportId") }
-      .first()
-
-    val dataSetId = reportDefinition.dataset.removePrefix(schemaRefPrefix)
-    val dataSet = productDefinition.dataset
-      .filter { it.id == dataSetId }
-      .ifEmpty { throw ValidationException("Invalid dataSetId in report: $dataSetId") }
-      .first()
-
-    return SingleReportProductDefinition(
-      id = definitionId,
-      name = productDefinition.name,
-      description = productDefinition.description,
-      metadata = productDefinition.metadata,
-      datasource = productDefinition.datasource.first(),
-      dataset = dataSet,
-      report = reportDefinition,
-    )
-  }
 }


### PR DESCRIPTION
Introduced AbstractProductDefinitionRepository to provide a default implementation for getSingleReportProductDefinition to reuse the method as it seems a common use case as it is.