### PR TITLE
Dpr2 256 single active caseload to policy engine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "1.1.10"
+        version = "1.2.0"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -68,7 +68,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       pageSize,
       sortColumn,
       sortedAsc,
-      authentication.getCaseLoads(),
+      authentication,
     )
   }
 
@@ -106,7 +106,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       pageSize,
       fieldId,
       sortedAsc,
-      authentication.getCaseLoads(),
+      authentication,
       fieldId,
       prefix,
     ).asSequence()
@@ -132,7 +132,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @PathVariable("reportVariantId") reportVariantId: String,
     authentication: AuthAwareAuthenticationToken,
   ): Count {
-    return configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(filters), authentication.getCaseLoads())
+    return configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(filters), authentication)
   }
 
   private fun filtersOnly(filters: Map<String, String>): Map<String, String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -83,25 +83,26 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-      configuredApiService.validateAndFetchData(
-        reportId,
-        reportVariantId,
-        filtersOnly(filters),
-        selectedPage,
-        pageSize,
-        sortColumn,
-        sortedAsc,
-        authentication,
-      ))
-    }catch (exception: NoDataAvailableException) {
-        val headers = HttpHeaders()
-        headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+          configuredApiService.validateAndFetchData(
+            reportId,
+            reportVariantId,
+            filtersOnly(filters),
+            selectedPage,
+            pageSize,
+            sortColumn,
+            sortedAsc,
+            authentication,
+          ),
+        )
+    } catch (exception: NoDataAvailableException) {
+      val headers = HttpHeaders()
+      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
 
-        ResponseEntity
-          .status(HttpStatus.OK)
-          .headers(headers)
-          .body(emptyList())
-      }
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .headers(headers)
+        .body(emptyList())
+    }
   }
 
   @GetMapping("/reports/{reportId}/{reportVariantId}/{fieldId}")
@@ -202,7 +203,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-     configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(filters), authentication)
+          configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(filters), authentication),
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
@@ -42,7 +42,7 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     maxStaticOptions: Long,
     authentication: AuthAwareAuthenticationToken,
   ): List<ReportDefinition> {
-    return reportDefinitionService.getListForUser(renderMethod, maxStaticOptions, authentication.getCaseLoads())
+    return reportDefinitionService.getListForUser(renderMethod, maxStaticOptions, authentication)
   }
 
   @GetMapping("/definitions/{reportId}/{variantId}")
@@ -72,6 +72,6 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     maxStaticOptions: Long,
     authentication: AuthAwareAuthenticationToken,
   ): SingleVariantReportDefinition {
-    return reportDefinitionService.getDefinition(reportId, variantId, maxStaticOptions, authentication.getCaseLoads())
+    return reportDefinitionService.getDefinition(reportId, variantId, maxStaticOptions, authentication)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
@@ -27,6 +27,7 @@ abstract class AbstractProductDefinitionRepository : ProductDefinitionRepository
       datasource = productDefinition.datasource.first(),
       dataset = dataSet,
       report = reportDefinition,
+      policy = productDefinition.policy,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepository.kt
@@ -7,6 +7,8 @@ import jakarta.validation.ValidationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import java.time.LocalDateTime
 
 class JsonFileProductDefinitionRepository(
@@ -14,6 +16,8 @@ class JsonFileProductDefinitionRepository(
   private val resourceLocations: List<String>,
   private val filterTypeDeserializer: FilterTypeDeserializer,
   private val schemaFieldTypeDeserializer: SchemaFieldTypeDeserializer,
+  private val ruleEffectTypeDeserializer: RuleEffectTypeDeserializer,
+  private val policyTypeDeserializer: PolicyTypeDeserializer,
 ) : AbstractProductDefinitionRepository() {
 
   override fun getProductDefinitions(): List<ProductDefinition> {
@@ -21,6 +25,8 @@ class JsonFileProductDefinitionRepository(
       .registerTypeAdapter(LocalDateTime::class.java, localDateTimeTypeAdaptor)
       .registerTypeAdapter(FilterType::class.java, filterTypeDeserializer)
       .registerTypeAdapter(ParameterType::class.java, schemaFieldTypeDeserializer)
+      .registerTypeAdapter(Effect::class.java, ruleEffectTypeDeserializer)
+      .registerTypeAdapter(PolicyType::class.java, policyTypeDeserializer)
       .create()
     return resourceLocations.map { gson.fromJson(this::class.java.classLoader.getResource(it)?.readText(), object : TypeToken<ProductDefinition>() {}.type) }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/PolicyTypeDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/PolicyTypeDeserializer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
+import java.lang.reflect.Type
+
+class PolicyTypeDeserializer : JsonDeserializer<PolicyType?> {
+  @Throws(JsonParseException::class)
+  override fun deserialize(
+    json: JsonElement,
+    typeOfT: Type?,
+    context: JsonDeserializationContext?,
+  ): PolicyType {
+    val stringValue = json.asString
+    return PolicyType.entries.firstOrNull { enum -> enum.type == stringValue }
+      ?: throw IllegalArgumentException("Unknown ParameterType $stringValue!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
@@ -20,6 +20,8 @@ class ProductDefinitionRepositoryAutoConfig(
       definitionResourceLocations,
       FilterTypeDeserializer(),
       SchemaFieldTypeDeserializer(),
+      RuleEffectTypeDeserializer(),
+      PolicyTypeDeserializer(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RuleEffectTypeDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RuleEffectTypeDeserializer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import java.lang.reflect.Type
+
+class RuleEffectTypeDeserializer : JsonDeserializer<Effect?> {
+  @Throws(JsonParseException::class)
+  override fun deserialize(
+    json: JsonElement,
+    typeOfT: Type?,
+    context: JsonDeserializationContext?,
+  ): Effect {
+    val stringValue = json.asString
+    return Effect.entries.firstOrNull { enum -> enum.type == stringValue }
+      ?: throw IllegalArgumentException("Unknown ParameterType $stringValue!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Condition.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
-
-class Condition(val match: List<String>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Policy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Policy.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
-
-data class Policy(val id: String, val type: String, val action: List<String>, val rule: List<Rule>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+
 data class ProductDefinition(
   val id: String,
   val name: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
@@ -9,7 +9,6 @@ data class Report(
   val created: LocalDateTime?,
   val version: String,
   val dataset: String,
-  val policy: List<String> = emptyList(),
   val render: RenderMethod,
   val schedule: String? = null,
   val specification: Specification? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Rule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Rule.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
-
-data class Rule(val effect: String, val condition: List<Condition>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+
 data class SingleReportProductDefinition(
   val id: String,
   val name: String,
@@ -8,4 +10,5 @@ data class SingleReportProductDefinition(
   val datasource: Datasource,
   val dataset: Dataset,
   val report: Report,
+  val policy: List<Policy>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -1,8 +1,9 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.ROLE
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.TOKEN
 
 data class Condition(
   val match: List<String>? = null,
@@ -48,13 +49,13 @@ data class Condition(
 
   private fun isNotNull(
     authToken: AuthAwareAuthenticationToken?,
-    it: String,
+    varPlaceholder: String,
   ): Boolean {
     val varMappings = mapOf(
-      PolicyEngine.VariableNames.TOKEN to authToken,
+      TOKEN to authToken,
       ROLE to authToken?.authorities?.map { it.authority },
-      PolicyEngine.VariableNames.CASELOAD to authToken?.getCaseLoads()?.firstOrNull(),
+      CASELOAD to authToken?.getCaseLoads()?.firstOrNull(),
     )
-    return varMappings[it] != null
+    return varMappings[varPlaceholder] != null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -1,12 +1,60 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.ROLE
+
 data class Condition(
   val match: List<String>? = null,
   val exists: List<String>? = null,
 ) {
-//  fun getType(): ConditionType {
-//    match?.let { return ConditionType.MATCH }
-//    exists?.let { return ConditionType.EXISTS }
-//
-//  }
+
+  fun execute(authToken: AuthAwareAuthenticationToken?, interpolateVariables: (String) -> String): Boolean {
+    match?.let { matchList ->
+      return executeMatch(matchList, authToken, interpolateVariables)
+    }
+    exists?.map {
+      return isNotNull(authToken, it)
+    }
+    return false
+  }
+
+  private fun executeMatch(
+    matchList: List<String>,
+    authToken: AuthAwareAuthenticationToken?,
+    interpolateVariables: (String) -> String,
+  ): Boolean {
+    return if (matchList.contains(ROLE)) {
+      isAnyOfTheRolesInTheList(authToken, matchList)
+    } else {
+      isTheInterpolatedVarInTheList(matchList, interpolateVariables)
+    }
+  }
+
+  private fun isAnyOfTheRolesInTheList(
+    authToken: AuthAwareAuthenticationToken?,
+    matchList: List<String>,
+  ): Boolean {
+    val userRoles = authToken?.authorities?.map { it.authority }
+    return userRoles?.any { it in matchList } ?: false
+  }
+
+  private fun isTheInterpolatedVarInTheList(
+    matchList: List<String>,
+    interpolateVariables: (String) -> String,
+  ) = matchList.map {
+    interpolateVariables(it)
+  }.toSet().count() == 1
+
+  private fun isNotNull(
+    authToken: AuthAwareAuthenticationToken?,
+    it: String,
+  ): Boolean {
+    val varMappings = mapOf(
+      PolicyEngine.VariableNames.TOKEN to authToken,
+      ROLE to authToken?.authorities?.map { it.authority },
+      PolicyEngine.VariableNames.CASELOAD to authToken?.getCaseLoads()?.firstOrNull(),
+    )
+    return varMappings[it] != null
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+data class Condition(
+  val match: List<String>? = null,
+  val exists: List<String>? = null,
+) {
+//  fun getType(): ConditionType {
+//    match?.let { return ConditionType.MATCH }
+//    exists?.let { return ConditionType.EXISTS }
+//
+//  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/ConditionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/ConditionType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+enum class ConditionType {
+  MATCH,
+  EXISTS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/ConditionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/ConditionType.kt
@@ -1,6 +1,0 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
-
-enum class ConditionType {
-  MATCH,
-  EXISTS,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Effect.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Effect.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+enum class Effect(val type: String) {
+  PERMIT("permit"),
+  DENY("deny"),
+  ;
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+data class Policy(val id: String, val type: PolicyType, val action: List<String>, val rule: List<Rule>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
@@ -1,3 +1,34 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
-data class Policy(val id: String, val type: PolicyType, val action: List<String>, val rule: List<Rule>)
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_PERMIT
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+
+data class Policy(val id: String, val type: PolicyType, val action: List<String>, val rule: List<Rule>) {
+
+  object PolicyResult {
+    const val POLICY_PERMIT = "TRUE"
+    const val POLICY_DENY = "FALSE"
+  }
+  fun execute(userToken: AuthAwareAuthenticationToken?, transformFun: (String) -> String): String {
+    var effect = Effect.PERMIT
+    for (r in rule) {
+      if (r.execute(userToken, transformFun) != Effect.PERMIT) {
+        effect = Effect.DENY
+      }
+      break
+    }
+    return if (effect == Effect.PERMIT) {
+      apply(transformFun)
+    } else {
+      POLICY_DENY
+    }
+  }
+  fun apply(transformFunction: (String) -> String): String {
+    return if (action.isEmpty()) {
+      POLICY_PERMIT
+    } else {
+      action.joinToString(" AND ", transform = transformFunction)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/PolicyType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/PolicyType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+enum class PolicyType(val type: String) {
+  ROW_LEVEL("row-level"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Rule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Rule.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
+
+data class Rule(val effect: Effect, val condition: List<Condition>) {
+//  fun execute(): Effect? {
+//    val aggregateConditionsResult = condition.all { it.execute() }
+//    return if (aggregateConditionsResult) {
+//      effect
+//    } else {
+//      //what if it is null
+//      null
+//    }
+//  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Rule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Rule.kt
@@ -1,13 +1,18 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+
 data class Rule(val effect: Effect, val condition: List<Condition>) {
-//  fun execute(): Effect? {
-//    val aggregateConditionsResult = condition.all { it.execute() }
-//    return if (aggregateConditionsResult) {
-//      effect
-//    } else {
-//      //what if it is null
-//      null
-//    }
-//  }
+  fun execute(token: AuthAwareAuthenticationToken?, transformFun: (String) -> String): Effect? {
+    return if (areAllConditionsPermitted(token, transformFun)) {
+      effect
+    } else {
+      null
+    }
+  }
+
+  private fun areAllConditionsPermitted(
+    token: AuthAwareAuthenticationToken?,
+    transformFun: (String) -> String,
+  ) = condition.all { it.execute(token, transformFun) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -77,9 +77,6 @@ class ConfiguredApiService(
         ?.let { listOf(validateAndMapFieldIdDynamicFilter(productDefinition, reportFieldId, prefix)) }
     } ?: emptyList()
 
-  private fun getCaseloadFields(dataSet: Dataset) =
-    dataSet.schema.field.filter { it.caseload }.map { it.name }
-
   fun validateAndCount(
     reportId: String,
     reportVariantId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
 
@@ -40,14 +41,15 @@ class ConfiguredApiService(
     pageSize: Long,
     sortColumn: String?,
     sortedAsc: Boolean,
-    userCaseloads: List<String>,
+    userToken: AuthAwareAuthenticationToken,
     reportFieldId: String? = null,
     prefix: String? = null,
   ): List<Map<String, Any>> {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId)
     val validatedSortColumn = validateSortColumnOrGetDefault(productDefinition, sortColumn)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
-
+    // Need to support a list of policies
+    val policyEngine = PolicyEngine(productDefinition.policy.first(), userToken)
     return formatToSchemaFieldsCasing(
       configuredApiRepository
         .executeQuery(
@@ -57,9 +59,8 @@ class ConfiguredApiService(
           pageSize,
           validatedSortColumn,
           sortedAsc,
-          userCaseloads,
-          getCaseloadFields(productDefinition.dataset),
           reportId,
+          policyEngine.execute(),
           reportFieldId,
         ),
       productDefinition.dataset.schema.field,
@@ -83,17 +84,16 @@ class ConfiguredApiService(
     reportId: String,
     reportVariantId: String,
     filters: Map<String, String>,
-    userCaseloads: List<String>,
+    userToken: AuthAwareAuthenticationToken,
   ): Count {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId)
-
+    val policyEngine = PolicyEngine(productDefinition.policy.first(), userToken)
     return Count(
       configuredApiRepository.count(
         validateAndMapFilters(productDefinition, filters),
         productDefinition.dataset.query,
-        userCaseloads,
-        getCaseloadFields(productDefinition.dataset),
         reportId,
+        policyEngine.execute(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -48,7 +48,6 @@ class ConfiguredApiService(
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId)
     val validatedSortColumn = validateSortColumnOrGetDefault(productDefinition, sortColumn)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
-    // Need to support a list of policies
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
     return formatToSchemaFieldsCasing(
       configuredApiRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -49,7 +49,7 @@ class ConfiguredApiService(
     val validatedSortColumn = validateSortColumnOrGetDefault(productDefinition, sortColumn)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
     // Need to support a list of policies
-    val policyEngine = PolicyEngine(productDefinition.policy.first(), userToken)
+    val policyEngine = PolicyEngine(productDefinition.policy, userToken)
     return formatToSchemaFieldsCasing(
       configuredApiRepository
         .executeQuery(
@@ -87,7 +87,7 @@ class ConfiguredApiService(
     userToken: AuthAwareAuthenticationToken,
   ): Count {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId)
-    val policyEngine = PolicyEngine(productDefinition.policy.first(), userToken)
+    val policyEngine = PolicyEngine(productDefinition.policy, userToken)
     return Count(
       configuredApiRepository.count(
         validateAndMapFilters(productDefinition, filters),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -1,101 +1,41 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
 
-// What if I have a list of policies
 class PolicyEngine(
   val policy: List<Policy>,
   val authToken: AuthAwareAuthenticationToken? = null,
 ) {
 
-  private val role = "\${role}"
-  private val token = "\${token}"
-  private val caseload = "\${caseload}"
-
-  val varMappings = mapOf(
-    token to authToken,
-    role to authToken?.authorities?.map { it.authority },
-    caseload to authToken?.getCaseLoads()?.firstOrNull(),
-  )
-
-  fun execute(condition: Condition): Boolean {
-    condition.match?.let { matchList ->
-      if (matchList.contains(role)) {
-        val userRoles = authToken?.authorities?.map { it.authority }
-        return userRoles?.any { it in matchList } ?: false
-      } else {
-        matchList.map {
-          return interpolateVariables(it).toSet().count() == 1
-        }
-      }
-    }
-    condition.exists?.map {
-      return varMappings[it] != null
-    }
-    return false
-  }
-
-  fun execute(rule: Rule): Effect? {
-    val aggregateConditionsResult = rule.condition.all { execute(it) }
-    return if (aggregateConditionsResult) {
-      rule.effect
-    } else {
-      // what if it is null
-      null
-    }
-  }
-
-  private fun apply(policy: Policy): String {
-    if (policy.action.isEmpty()) {
-      return "TRUE"
-    } else {
-      return policy.action.joinToString(" AND ", transform = this::interpolateVariables)
-    }
-  }
-
-  private fun deny(): String {
-    return "FALSE"
+  object VariableNames {
+    const val ROLE = "\${role}"
+    const val TOKEN = "\${token}"
+    const val CASELOAD = "\${caseload}"
   }
 
   fun execute(): String {
-    return if (anyPolicyIsDenied(policy)) {
-      deny()
+    return if (isAnyPolicyDenied(policy)) {
+      POLICY_DENY
     } else {
-      policy.joinToString(" AND ", transform = this::apply)
+      policy.joinToString(" AND ") { it.apply(this::interpolateVariables) }
     }
   }
 
-  private fun anyPolicyIsDenied(policies: List<Policy>) =
-    policies.map { execute(it) }.any { it == "FALSE" }
-
-  private fun execute(policy: Policy): String {
-    var effect = Effect.PERMIT
-    for (rule in policy.rule) {
-      if (execute(rule) != Effect.PERMIT) {
-        effect = Effect.DENY
-      }
-      break
-    }
-    return if (effect == Effect.PERMIT) {
-      apply(policy)
-    } else {
-      deny()
-    }
-  }
+  private fun isAnyPolicyDenied(policies: List<Policy>) =
+    policies.map { it.execute(authToken, ::interpolateVariables) }.any { it == POLICY_DENY }
 
   private fun interpolateVariables(s: String): String {
     var interpolated = s
-    if (s.contains(caseload)) {
-      if (varMappings[caseload] == null) {
-        return deny()
+    if (s.contains(CASELOAD)) {
+      if (authToken?.getCaseLoads() == null) {
+        return POLICY_DENY
       }
       // Note: This is currently for a single active caseload
       // Addition of single quotes could be in DPD instead
-      interpolated = s.replace(caseload, "'${authToken?.getCaseLoads()!!.first()}'")
+      interpolated = s.replace(CASELOAD, "'${authToken.getCaseLoads().first()}'")
     }
     return interpolated
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+
+// What if I have a list of policies
+class PolicyEngine(
+  val policy: Policy,
+  val caseloads: List<String>? = null,
+  val authToken: AuthAwareAuthenticationToken? = null,
+) {
+
+  private val role = "\${role}"
+  private val token = "\${token}"
+  private val caseload = "\${caseload}"
+
+  val varMappings = mapOf(
+    token to authToken,
+    role to authToken?.authorities?.map { it.authority },
+    caseload to caseloads?.firstOrNull(),
+  )
+
+  fun execute(condition: Condition): Boolean {
+    condition.match?.let { matchList ->
+      if (matchList.contains(role)) {
+        val userRoles = authToken?.authorities?.map { it.authority }
+        return userRoles?.any { it in matchList } ?: false
+      } else {
+        matchList.map {
+          return interpolateVariables(it).toSet().count() == 1
+        }
+      }
+    }
+    condition.exists?.map {
+      return varMappings[it] != null
+    }
+    return false
+  }
+
+  fun execute(rule: Rule): Effect? {
+    val aggregateConditionsResult = rule.condition.all { execute(it) }
+    return if (aggregateConditionsResult) {
+      rule.effect
+    } else {
+      // what if it is null
+      null
+    }
+  }
+  private fun apply(): String {
+    if (policy.action.isEmpty()) {
+      return "TRUE"
+    } else {
+      return policy.action.joinToString(" AND ", transform = this::interpolateVariables)
+    }
+  }
+
+  private fun deny(): String {
+    return "FALSE"
+  }
+  fun execute(): String {
+    var effect = Effect.PERMIT
+    for (rule in policy.rule) {
+      if (execute(rule) != Effect.PERMIT) {
+        effect = Effect.DENY
+      }
+      break
+    }
+    return if (effect == Effect.PERMIT) {
+      apply()
+    } else {
+      deny()
+    }
+  }
+
+  fun interpolateVariables(s: String): String {
+    var interpolated = s
+    if (s.contains(caseload)) {
+      if (varMappings[caseload] == null) {
+        return deny()
+      }
+      // Note: This is currently for a single active caseload
+      interpolated = s.replace(caseload, caseloads!!.first())
+    }
+    return interpolated
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAware
 // What if I have a list of policies
 class PolicyEngine(
   val policy: Policy,
-  val caseloads: List<String>? = null,
   val authToken: AuthAwareAuthenticationToken? = null,
 ) {
 
@@ -20,7 +19,7 @@ class PolicyEngine(
   val varMappings = mapOf(
     token to authToken,
     role to authToken?.authorities?.map { it.authority },
-    caseload to caseloads?.firstOrNull(),
+    caseload to authToken?.getCaseLoads()?.firstOrNull(),
   )
 
   fun execute(condition: Condition): Boolean {
@@ -82,7 +81,8 @@ class PolicyEngine(
         return deny()
       }
       // Note: This is currently for a single active caseload
-      interpolated = s.replace(caseload, caseloads!!.first())
+      // Addition of single quotes could be in DPD instead
+      interpolated = s.replace(caseload, "'${authToken?.getCaseLoads()!!.first()}'")
     }
     return interpolated
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -17,7 +17,7 @@ class PolicyEngine(
   }
 
   fun execute(): String {
-    return if (isAnyPolicyDenied(policy)) {
+    return if (policy.isEmpty() || isAnyPolicyDenied(policy)) {
       POLICY_DENY
     } else {
       policy.joinToString(" AND ") { it.apply(this::interpolateVariables) }
@@ -30,7 +30,7 @@ class PolicyEngine(
   private fun interpolateVariables(s: String): String {
     var interpolated = s
     if (s.contains(CASELOAD)) {
-      if (authToken?.getCaseLoads() == null) {
+      if (authToken == null || authToken.getCaseLoads().isEmpty()) {
         return POLICY_DENY
       }
       // Note: This is currently for a single active caseload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionService.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.R
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 
 @Service
 class ReportDefinitionService(
@@ -12,17 +13,17 @@ class ReportDefinitionService(
   val mapper: ReportDefinitionMapper,
 ) {
 
-  fun getListForUser(renderMethod: RenderMethod?, maxStaticOptions: Long, caseLoads: List<String>): List<ReportDefinition> {
+  fun getListForUser(renderMethod: RenderMethod?, maxStaticOptions: Long, userToken: AuthAwareAuthenticationToken): List<ReportDefinition> {
     return productDefinitionRepository.getProductDefinitions()
-      .map { mapper.map(it, renderMethod, maxStaticOptions, caseLoads) }
+      .map { mapper.map(it, renderMethod, maxStaticOptions, userToken) }
       .filter { it.variants.isNotEmpty() }
   }
 
-  fun getDefinition(reportId: String, variantId: String, maxStaticOptions: Long, caseLoads: List<String>): SingleVariantReportDefinition {
+  fun getDefinition(reportId: String, variantId: String, maxStaticOptions: Long, userToken: AuthAwareAuthenticationToken): SingleVariantReportDefinition {
     return mapper.map(
       productDefinitionRepository.getSingleReportProductDefinition(reportId, variantId),
       maxStaticOptions,
-      caseLoads,
+      userToken,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -20,8 +22,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner4
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner5
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisonerDestinationCaseloadDirectionIn
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisonerDestinationCaseloadDirectionOut
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisonerOriginCaseloadDirectionIn
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovements.allExternalMovements
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovements.externalMovement1
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovements.externalMovement2
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllPrisoners.prisoner9846
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllPrisoners.prisoner9847
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllPrisoners.prisoner9848
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine
 import java.time.LocalDateTime
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -58,6 +59,11 @@ class ConfiguredApiRepositoryTest {
     allPrisoners.forEach {
       prisonerRepository.save(it)
     }
+    whenever(
+      policyEngine
+        .execute(),
+    )
+      .thenReturn("(origin_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='out') OR (destination_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='in')")
   }
 
   val query = "SELECT " +
@@ -75,8 +81,7 @@ class ConfiguredApiRepositoryTest {
     "JOIN prisoner_prisoner as prisoners\n" +
     "ON movements.prisoner = prisoners.id"
 
-  private val caseloads = listOf("HEI", "LWSTMC", "NSI", "LCI", "TCI")
-  private val caseloadFields = listOf("origin_code", "destination_code")
+  private val policyEngine = mock<PolicyEngine>()
 
   @Test
   fun `should return 2 external movements for the selected page 2 and pageSize 2 sorted by date in ascending order`() {
@@ -87,9 +92,8 @@ class ConfiguredApiRepositoryTest {
       2,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner3, movementPrisoner4), actual)
     Assertions.assertEquals(2, actual.size)
@@ -104,9 +108,8 @@ class ConfiguredApiRepositoryTest {
       2,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner5), actual)
     Assertions.assertEquals(1, actual.size)
@@ -121,9 +124,8 @@ class ConfiguredApiRepositoryTest {
       5,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner1, movementPrisoner2, movementPrisoner3, movementPrisoner4, movementPrisoner5), actual)
     Assertions.assertEquals(5, actual.size)
@@ -138,9 +140,8 @@ class ConfiguredApiRepositoryTest {
       5,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
@@ -154,9 +155,8 @@ class ConfiguredApiRepositoryTest {
       1,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
@@ -210,9 +210,8 @@ class ConfiguredApiRepositoryTest {
       20,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(5, actual.size)
   }
@@ -226,9 +225,8 @@ class ConfiguredApiRepositoryTest {
       20,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(4, actual.size)
   }
@@ -242,9 +240,8 @@ class ConfiguredApiRepositoryTest {
       20,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(4, actual.size)
   }
@@ -258,9 +255,8 @@ class ConfiguredApiRepositoryTest {
       20,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(1, actual.size)
   }
@@ -274,9 +270,8 @@ class ConfiguredApiRepositoryTest {
       20,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(1, actual.size)
   }
@@ -290,9 +285,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3), actual)
   }
@@ -306,9 +300,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner2, movementPrisoner1), actual)
   }
@@ -322,9 +315,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3, movementPrisoner2), actual)
   }
@@ -338,9 +330,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner3, movementPrisoner2), actual)
   }
@@ -359,9 +350,8 @@ class ConfiguredApiRepositoryTest {
       10,
       NAME,
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
       NAME,
     )
     Assertions.assertEquals(
@@ -388,9 +378,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
@@ -404,9 +393,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
@@ -420,9 +408,8 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
@@ -436,15 +423,19 @@ class ConfiguredApiRepositoryTest {
       10,
       "date",
       false,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should not throw an error when some columns are null`() {
+    whenever(
+      policyEngine
+        .execute(),
+    )
+      .thenReturn("(origin_code IN ('BOLTCC') AND lower(direction)='out') OR (destination_code IN ('BOLTCC') AND lower(direction)='in')")
     val externalMovementNullValues = ExternalMovementEntity(
       6,
       9846,
@@ -482,9 +473,8 @@ class ConfiguredApiRepositoryTest {
         1,
         "date",
         true,
-        listOf("BOLTCC"),
-        caseloadFields,
         EXTERNAL_MOVEMENTS_PRODUCT_ID,
+        policyEngineResult = policyEngine.execute(),
       )
       Assertions.assertEquals(listOf(movementPrisonerNullValues), actual)
       Assertions.assertEquals(1, actual.size)
@@ -497,6 +487,11 @@ class ConfiguredApiRepositoryTest {
   @Test
   fun `should return only the rows whose origin code is in the caseloads list and its direction is "Out" or the destination code is in the caseloads list and its direction is "IN" for external-movements`() {
     try {
+      whenever(
+        policyEngine
+          .execute(),
+      )
+        .thenReturn("(origin_code IN ('LWSTMC') AND lower(direction)='out') OR (destination_code IN ('LWSTMC') AND lower(direction)='in')")
       externalMovementRepository.save(externalMovementOriginCaseloadDirectionIn)
       externalMovementRepository.save(externalMovementDestinationCaseloadDirectionOut)
       externalMovementRepository.save(externalMovementDestinationCaseloadDirectionIn)
@@ -510,9 +505,8 @@ class ConfiguredApiRepositoryTest {
         10,
         "date",
         true,
-        listOf("LWSTMC"),
-        caseloadFields,
         EXTERNAL_MOVEMENTS_PRODUCT_ID,
+        policyEngineResult = policyEngine.execute(),
       )
       Assertions.assertEquals(listOf(movementPrisoner4, movementPrisonerDestinationCaseloadDirectionIn), actual)
       Assertions.assertEquals(2, actual.size)
@@ -527,39 +521,12 @@ class ConfiguredApiRepositoryTest {
   }
 
   @Test
-  fun `should return all the rows whose origin code or destination code is in the caseloads list for all other products apart from external-movements`() {
-    try {
-      externalMovementRepository.save(externalMovementOriginCaseloadDirectionIn)
-      externalMovementRepository.save(externalMovementDestinationCaseloadDirectionOut)
-      externalMovementRepository.save(externalMovementDestinationCaseloadDirectionIn)
-      prisonerRepository.save(prisoner9846)
-      prisonerRepository.save(prisoner9847)
-      prisonerRepository.save(prisoner9848)
-      val actual = configuredApiRepository.executeQuery(
-        query,
-        listOf(Filter("date", "2022-06-01", DATE_RANGE_START), Filter("date", "2024-06-01", DATE_RANGE_END)),
-        1,
-        10,
-        "date",
-        true,
-        listOf("LWSTMC"),
-        caseloadFields,
-        "product2-id",
-      )
-      Assertions.assertEquals(listOf(movementPrisoner4, movementPrisonerOriginCaseloadDirectionIn, movementPrisonerDestinationCaseloadDirectionOut, movementPrisonerDestinationCaseloadDirectionIn), actual)
-      Assertions.assertEquals(4, actual.size)
-    } finally {
-      externalMovementRepository.delete(externalMovementOriginCaseloadDirectionIn)
-      externalMovementRepository.delete(externalMovementDestinationCaseloadDirectionOut)
-      externalMovementRepository.delete(externalMovementDestinationCaseloadDirectionIn)
-      prisonerRepository.delete(prisoner9846)
-      prisonerRepository.delete(prisoner9847)
-      prisonerRepository.delete(prisoner9848)
-    }
-  }
-
-  @Test
-  fun `should return no rows for an empty caseloads list`() {
+  fun `should return no rows for a policy deny`() {
+    whenever(
+      policyEngine
+        .execute(),
+    )
+      .thenReturn("FALSE")
     val actual = configuredApiRepository.executeQuery(
       query,
       emptyList(),
@@ -567,9 +534,29 @@ class ConfiguredApiRepositoryTest {
       5,
       "date",
       true,
-      emptyList(),
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
+    )
+    Assertions.assertEquals(emptyList<Map<String, String>>(), actual)
+    Assertions.assertEquals(0, actual.size)
+  }
+
+  @Test
+  fun `should return no rows for a policy deny even if some filters match`() {
+    whenever(
+      policyEngine
+        .execute(),
+    )
+      .thenReturn("FALSE")
+    val actual = configuredApiRepository.executeQuery(
+      query,
+      listOf(Filter("direction", "in")),
+      1,
+      5,
+      "date",
+      true,
+      EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = policyEngine.execute(),
     )
     Assertions.assertEquals(emptyList<Map<String, String>>(), actual)
     Assertions.assertEquals(0, actual.size)
@@ -577,7 +564,12 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return a count of all rows with no filters`() {
-    val actual = configuredApiRepository.count(emptyList(), query, caseloads, caseloadFields, EXTERNAL_MOVEMENTS_PRODUCT_ID)
+    val actual = configuredApiRepository.count(
+      emptyList(),
+      query,
+      EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
+    )
     Assertions.assertEquals(5L, actual)
   }
 
@@ -586,9 +578,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("direction", "in")),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(4L, actual)
   }
@@ -598,9 +589,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("direction", "out")),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(1L, actual)
   }
@@ -610,9 +600,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2023-05-01", DATE_RANGE_START)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(2, actual)
   }
@@ -622,9 +611,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2023-01-31", DATE_RANGE_END)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(1, actual)
   }
@@ -634,9 +622,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2023-04-30", DATE_RANGE_START), Filter("date", "2023-05-01", DATE_RANGE_END)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(2, actual)
   }
@@ -646,9 +633,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2025-04-30", DATE_RANGE_START)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(0, actual)
   }
@@ -658,9 +644,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2019-04-30", DATE_RANGE_END)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(0, actual)
   }
@@ -670,9 +655,8 @@ class ConfiguredApiRepositoryTest {
     val actual = configuredApiRepository.count(
       listOf(Filter("date", "2023-04-30", DATE_RANGE_START), Filter("date", "2019-05-01", DATE_RANGE_END)),
       query,
-      caseloads,
-      caseloadFields,
       EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngine.execute(),
     )
     Assertions.assertEquals(0, actual)
   }
@@ -691,9 +675,8 @@ class ConfiguredApiRepositoryTest {
             1,
             sortColumn,
             sortedAsc,
-            caseloads,
-            caseloadFields,
             EXTERNAL_MOVEMENTS_PRODUCT_ID,
+            policyEngineResult = policyEngine.execute(),
           )
           Assertions.assertEquals(expected, actual)
           Assertions.assertEquals(1, actual.size)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
@@ -21,13 +21,6 @@ class JsonFileProductDefinitionRepositoryTest {
 
   @Test
   fun `returns the correct product definition`() {
-//    val policy = Policy(
-//      "caseload",
-//      "row-level",
-//      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
-//      listOf(Rule(Effect.PERMIT, emptyList())),
-//    )
-
     val policy = Policy(
       "caseload",
       ROW_LEVEL,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+
+class JsonFileProductDefinitionRepositoryTest {
+
+  val jsonFileProductDefinitionRepository = JsonFileProductDefinitionRepository(
+    IsoLocalDateTimeTypeAdaptor(),
+    listOf("productDefinition.json", "dpd001-court-hospital-movements.json"),
+    FilterTypeDeserializer(),
+    SchemaFieldTypeDeserializer(),
+    RuleEffectTypeDeserializer(),
+    PolicyTypeDeserializer(),
+  )
+
+  @Test
+  fun `returns the correct product definition`() {
+//    val policy = Policy(
+//      "caseload",
+//      "row-level",
+//      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+//      listOf(Rule(Effect.PERMIT, emptyList())),
+//    )
+
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${caseload}"))))),
+    )
+    val productDefinition = jsonFileProductDefinitionRepository.getProductDefinition("dpd001-court-hospital-movements")
+    Assertions.assertThat(productDefinition).isNotNull
+    Assertions.assertThat(productDefinition.id).isEqualTo("dpd001-court-hospital-movements")
+    Assertions.assertThat(productDefinition.policy).isEqualTo(listOf(policy))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import jakarta.validation.ValidationException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PolicyTypeDes
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RuleEffectTypeDeserializer
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.SchemaFieldTypeDeserializer
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 
 class ConfiguredApiServiceTest {
   private val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
@@ -58,14 +60,18 @@ class ConfiguredApiServiceTest {
     mapOf("type" to "trn"),
     mapOf("reason" to "normal transfer"),
   )
-  private val caseloads = listOf("WWI")
-  private val caseloadFields = listOf("origin_code", "destination_code")
-
+  private val authToken = mock<AuthAwareAuthenticationToken>()
   private val reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID
+  private val reportVariantId = "last-month"
+  val policyEngineResult = "(origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
+
+  @BeforeEach
+  fun setup() {
+    whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
+  }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows when both range and non range filters are provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "in"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val selectedPage = 1L
@@ -82,13 +88,12 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult,
       ),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -97,16 +102,14 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(expectedServiceResult, actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows when a dynamic filter is provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf(
       "direction" to "in",
       "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25",
@@ -133,9 +136,8 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult,
         reportFieldId,
       ),
     ).thenReturn(expectedRepositoryResult)
@@ -148,7 +150,7 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
+      authToken,
       reportFieldId,
       prefix,
     )
@@ -160,9 +162,8 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
       reportFieldId,
     )
     assertEquals(expectedServiceResult, actual)
@@ -170,28 +171,25 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `should call the repository with the corresponding arguments and get a count of rows when both range and non range filters are provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "in"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
-    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
+    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, reportId, policyEngineResult)).thenReturn(4)
 
-    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
 
     verify(configuredApiRepository, times(1)).count(
       repositoryFilters,
       dataSet.query,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(Count(4), actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows when only range filters are provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val selectedPage = 1L
@@ -208,13 +206,12 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult,
       ),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -223,37 +220,33 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(expectedServiceResult, actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a count of rows when only range filters are provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
-    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
+    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, reportId, policyEngineResult)).thenReturn(4)
 
-    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
 
     verify(configuredApiRepository, times(1)).count(
       repositoryFilters,
       dataSet.query,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(Count(4), actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows when only non range filters are provided`() {
-    val reportVariantId = "last-month"
     val filtersExcludingRange = mapOf("direction" to "in")
     val repositoryFilters = listOf(Filter("direction", "in"))
 
@@ -271,13 +264,12 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult = policyEngineResult,
       ),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filtersExcludingRange, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -286,37 +278,33 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult = policyEngineResult,
     )
     assertEquals(expectedServiceResult, actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a count of rows when only non range filters are provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in")
     val repositoryFilters = listOf(Filter("direction", "in"))
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
-    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
+    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, reportId, policyEngineResult)).thenReturn(4)
 
-    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
 
     verify(configuredApiRepository, times(1)).count(
       repositoryFilters,
       dataSet.query,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(Count(4), actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a list of rows regardless of the casing of the values of the non range filters`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "In", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "In"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val selectedPage = 1L
@@ -333,13 +321,12 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult = policyEngineResult,
       ),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -348,37 +335,33 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult = policyEngineResult,
     )
     assertEquals(expectedServiceResult, actual)
   }
 
   @Test
   fun `should call the repository with the corresponding arguments and get a count of rows regardless of the casing of the values of the non range filters`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "In", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "In"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
-    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
+    whenever(configuredApiRepository.count(repositoryFilters, dataSet.query, reportId, policyEngineResult)).thenReturn(4)
 
-    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
 
     verify(configuredApiRepository, times(1)).count(
       repositoryFilters,
       dataSet.query,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(Count(4), actual)
   }
 
   @Test
   fun `the service calls the repository without filters if no filters are provided`() {
-    val reportVariantId = "last-month"
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
     val selectedPage = 1L
     val pageSize = 10L
@@ -393,9 +376,8 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult = policyEngineResult,
       ),
     ).thenReturn(
       listOf(
@@ -403,7 +385,7 @@ class ConfiguredApiServiceTest {
       ),
     )
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -412,9 +394,8 @@ class ConfiguredApiServiceTest {
       10,
       "date",
       true,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult = policyEngineResult,
     )
     assertEquals(
       listOf(
@@ -426,21 +407,20 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `the service count method calls the repository without filters if no filters are provided`() {
-    val reportVariantId = "last-month"
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
 
-    whenever(configuredApiRepository.count(emptyList(), dataSet.query, caseloads, caseloadFields, reportId)).thenReturn(4)
+    whenever(configuredApiRepository.count(emptyList(), dataSet.query, reportId, policyEngineResult)).thenReturn(4)
 
-    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, emptyMap(), caseloads)
+    val actual = configuredApiService.validateAndCount(reportId, reportVariantId, emptyMap(), authToken)
 
-    verify(configuredApiRepository, times(1)).count(emptyList(), dataSet.query, caseloads, caseloadFields, reportId)
+    verify(configuredApiRepository, times(1)).count(emptyList(), dataSet.query, reportId, policyEngineResult)
     assertEquals(Count(4), actual)
   }
 
   @Test
   fun `validateAndFetchData should throw an exception for invalid report id`() {
     val reportId = "random report id"
-    val reportVariantId = "last-month"
+
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
@@ -448,11 +428,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_ID_MESSAGE} $reportId", e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -468,14 +447,14 @@ class ConfiguredApiServiceTest {
   @Test
   fun `validateAndCount should throw an exception for invalid report id`() {
     val reportId = "random report id"
-    val reportVariantId = "last-month"
+
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_ID_MESSAGE} $reportId", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
@@ -488,11 +467,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_VARIANT_ID_MESSAGE} $reportVariantId", e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -511,15 +489,14 @@ class ConfiguredApiServiceTest {
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals("${ConfiguredApiService.INVALID_REPORT_VARIANT_ID_MESSAGE} $reportVariantId", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `validateAndFetchData should throw an exception for invalid sort column`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
@@ -527,11 +504,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals("Invalid sortColumn provided: abc", e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -546,7 +522,6 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndFetchData should throw an exception for invalid filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("non existent filter" to "blah")
     val selectedPage = 1L
     val pageSize = 10L
@@ -554,11 +529,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -574,18 +548,16 @@ class ConfiguredApiServiceTest {
   @ParameterizedTest
   @ValueSource(strings = ["origin", "invalid field name"])
   fun `validateAndFetchData should throw an exception for invalid dynamic filter`(fieldId: String) {
-    val reportVariantId = "last-month"
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads, fieldId, "ab")
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, authToken, fieldId, "ab")
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -600,7 +572,6 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndFetchData should throw an exception for a fieldId which is a filter but not a dynamic one`() {
-    val reportVariantId = "last-month"
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -608,11 +579,10 @@ class ConfiguredApiServiceTest {
     val fieldId = "direction"
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, caseloads, fieldId, "ab")
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, emptyMap(), selectedPage, pageSize, sortColumn, sortedAsc, authToken, fieldId, "ab")
     }
     assertEquals(ConfiguredApiService.INVALID_DYNAMIC_FILTER_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -627,19 +597,17 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndCount should throw an exception for invalid filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("non existent filter" to "blah")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `validateAndFetchData should throw an exception when having a valid and an invalid filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("non existent filter" to "blah", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
     val selectedPage = 1L
     val pageSize = 10L
@@ -647,11 +615,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -666,19 +633,17 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndCount should throw an exception when having a valid and an invalid filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("non existent filter" to "blah", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_FILTERS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `validateAndFetchData should throw an exception when having invalid static options for a filter and a valid range filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "randomValue", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
     val selectedPage = 1L
     val pageSize = 10L
@@ -686,11 +651,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -705,19 +669,17 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndCount should throw an exception when having invalid static options for a filter and a valid range filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "randomValue", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `validateAndFetchData should throw an exception when having invalid static options for a filter and no range filters`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "randomValue")
     val selectedPage = 1L
     val pageSize = 10L
@@ -725,11 +687,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -744,7 +705,6 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndFetchData should throw an exception when having a prefix with fewer characters than the minimum length`() {
-    val reportVariantId = "last-month"
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -759,7 +719,7 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
+        authToken,
         "name",
         "A",
       )
@@ -775,25 +735,22 @@ class ConfiguredApiServiceTest {
       any(),
       any(),
       any(),
-      any(),
     )
   }
 
   @Test
   fun `validateAndCount should throw an exception when having invalid static options for a filter and no range filters`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "randomValue")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals(ConfiguredApiService.INVALID_STATIC_OPTIONS_MESSAGE, e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `validateAndFetchData should throw an exception when having an invalid range filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "abc")
     val selectedPage = 1L
     val pageSize = 10L
@@ -801,11 +758,10 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, caseloads)
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc, authToken)
     }
     assertEquals("Invalid value abc for filter date. Cannot be parsed as a date.", e.message)
     verify(configuredApiRepository, times(0)).executeQuery(
-      any(),
       any(),
       any(),
       any(),
@@ -820,19 +776,17 @@ class ConfiguredApiServiceTest {
 
   @Test
   fun `validateAndCount should throw an exception when having an invalid range filter`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "abc")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
-      configuredApiService.validateAndCount(reportId, reportVariantId, filters, caseloads)
+      configuredApiService.validateAndCount(reportId, reportVariantId, filters, authToken)
     }
     assertEquals("Invalid value abc for filter date. Cannot be parsed as a date.", e.message)
-    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any(), any())
+    verify(configuredApiRepository, times(0)).count(any(), any(), any(), any())
   }
 
   @Test
   fun `should call the configuredApiRepository with the default sort column if none is provided`() {
-    val reportVariantId = "last-month"
     val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val repositoryFilters = listOf(Filter("direction", "in"), Filter("date", "2023-04-25", DATE_RANGE_START), Filter("date", "2023-09-10", DATE_RANGE_END))
     val selectedPage = 1L
@@ -849,13 +803,12 @@ class ConfiguredApiServiceTest {
         pageSize,
         sortColumn,
         sortedAsc,
-        caseloads,
-        caseloadFields,
         reportId,
+        policyEngineResult,
       ),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, null, sortedAsc, caseloads)
+    val actual = configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, null, sortedAsc, authToken)
 
     verify(configuredApiRepository, times(1)).executeQuery(
       dataSet.query,
@@ -864,9 +817,8 @@ class ConfiguredApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      caseloads,
-      caseloadFields,
       reportId,
+      policyEngineResult,
     )
     assertEquals(expectedServiceResult, actual)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -22,7 +22,9 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.FilterTypeDeserializer
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IsoLocalDateTimeTypeAdaptor
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.JsonFileProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PolicyTypeDeserializer
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RuleEffectTypeDeserializer
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.SchemaFieldTypeDeserializer
 
 class ConfiguredApiServiceTest {
@@ -31,6 +33,8 @@ class ConfiguredApiServiceTest {
     listOf("productDefinition.json"),
     FilterTypeDeserializer(),
     SchemaFieldTypeDeserializer(),
+    RuleEffectTypeDeserializer(),
+    PolicyTypeDeserializer(),
   )
   private val configuredApiRepository: ConfiguredApiRepository = mock<ConfiguredApiRepository>()
   private val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -1,0 +1,143 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
+
+class PolicyEngineTest {
+  @Test
+  fun `policy engine permits given action for an active caseload`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+      listOf(Rule(Effect.PERMIT, emptyList())),
+    )
+    val caseloads = listOf("ABC")
+    val policyEngine = PolicyEngine(policy, caseloads)
+    val expected = "(origin_code=ABC AND direction='OUT') OR (destination_code=ABC AND direction='IN')"
+    Assertions.assertThat(policyEngine.execute()).isEqualTo(expected)
+  }
+
+  @Test
+  fun `policy engine denies given action for no caseload with no conditions`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+      listOf(Rule(Effect.PERMIT, emptyList())),
+    )
+    val policyEngine = PolicyEngine(policy, emptyList())
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+
+  @Test
+  fun `policy engine denies given action for no caseload with exists conditions`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${caseload}"))))),
+    )
+    val policyEngine = PolicyEngine(policy, emptyList())
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+
+  @Test
+  fun `policy engine permits a policy with a permit rule with no conditions and an action of TRUE`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.PERMIT, emptyList())),
+    )
+    val policyEngine = PolicyEngine(policy, emptyList())
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("TRUE")
+  }
+
+  @Test
+  fun `policy engine returns FALSE for a policy with a permit rule with no conditions and an action of FALSE`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("FALSE"),
+      listOf(Rule(Effect.PERMIT, emptyList())),
+    )
+    val policyEngine = PolicyEngine(policy, emptyList())
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+
+  @Test
+  fun `policy engine returns FALSE for a policy with a deny rule with no conditions and an action of TRUE`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.DENY, emptyList())),
+    )
+    val policyEngine = PolicyEngine(policy, emptyList())
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+
+  @Test
+  fun `policy engine returns TRUE for a policy with a permit rule with a condition that a token exists and an action of TRUE when there is a token`() {
+    val authToken = mock<AuthAwareAuthenticationToken>()
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${token}"))))),
+    )
+    val policyEngine = PolicyEngine(policy, authToken = authToken)
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("TRUE")
+  }
+
+  @Test
+  fun `policy engine returns FALSE for a policy with a permit rule with a condition that a token exists and an action of TRUE when the token is null`() {
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${token}"))))),
+    )
+    val policyEngine = PolicyEngine(policy, authToken = null)
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+
+  @Test
+  fun `policy engine returns TRUE for a policy with a permit rule with a condition of matching a role and an action of TRUE when there is a matching role`() {
+    val userRole = "A_ROLE"
+    val authToken = mock<AuthAwareAuthenticationToken>()
+    whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority(userRole)))
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", userRole))))),
+    )
+    val policyEngine = PolicyEngine(policy, authToken = authToken)
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("TRUE")
+  }
+
+  @Test
+  fun `policy engine returns FALSE for a policy with a permit rule with a condition of matching a role and an action of TRUE when there is no matching role`() {
+    val authToken = mock<AuthAwareAuthenticationToken>()
+    whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("A_ROLE")))
+    val policy = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("TRUE"),
+      listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", "B_ROLE"))))),
+    )
+    val policyEngine = PolicyEngine(policy, authToken = authToken)
+    Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policye
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -138,13 +139,13 @@ class ReportDefinitionMapperTest {
 
   private val configuredApiService: ConfiguredApiService = mock<ConfiguredApiService>()
 
-  private val caseLoads: List<String> = listOf("caseLoad")
+  private val authToken = mock<AuthAwareAuthenticationToken>()
 
   @Test
   fun `Getting report list for user maps full data correctly`() {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(fullProductDefinition, null, 10, emptyList())
+    val result = mapper.map(fullProductDefinition, null, 10, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullProductDefinition.id)
@@ -200,7 +201,7 @@ class ReportDefinitionMapperTest {
     )
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(productDefinition, null, 10, emptyList())
+    val result = mapper.map(productDefinition, null, 10, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.variants).hasSize(0)
@@ -232,7 +233,7 @@ class ReportDefinitionMapperTest {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
     val exception = assertThrows(IllegalArgumentException::class.java) {
-      mapper.map(productDefinition, null, 10, emptyList())
+      mapper.map(productDefinition, null, 10, authToken)
     }
     verifyNoInteractions(configuredApiService)
     assertThat(exception).message().isEqualTo("Could not find matching DataSet '9'")
@@ -281,7 +282,7 @@ class ReportDefinitionMapperTest {
     )
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(productDefinition, HTML, 10, emptyList())
+    val result = mapper.map(productDefinition, HTML, 10, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.variants).hasSize(1)
@@ -304,7 +305,7 @@ class ReportDefinitionMapperTest {
     val defaultValue = createProductDefinitionWithDefaultFilter("today($offset, $magnitude)")
     val expectedDate = getExpectedDate(offset, magnitude)
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, authToken)
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
 
@@ -316,7 +317,7 @@ class ReportDefinitionMapperTest {
     val defaultValue = createProductDefinitionWithDefaultFilter("today()")
     val expectedDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, authToken)
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
 
@@ -331,7 +332,7 @@ class ReportDefinitionMapperTest {
     val expectedDate3 = getExpectedDate(7, ChronoUnit.DAYS)
     val expectedResult = "$expectedDate1, $expectedDate2, $expectedDate3"
 
-    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, emptyList())
+    val result = ReportDefinitionMapper(configuredApiService).map(defaultValue, HTML, 10, authToken)
 
     assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedResult)
 
@@ -342,7 +343,7 @@ class ReportDefinitionMapperTest {
   fun `Getting single report for user maps full data correctly`() {
     val mapper = ReportDefinitionMapper(configuredApiService)
 
-    val result = mapper.map(fullSingleReportProductDefinition, 10, emptyList())
+    val result = mapper.map(fullSingleReportProductDefinition, 10, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleReportProductDefinition.id)
@@ -424,11 +425,11 @@ class ReportDefinitionMapperTest {
     whenever(
       configuredApiService.validateAndFetchData(
         fullSingleProductDefinition.id,
-        reportWithDynamicFilter.id, emptyMap(), 1, 20, "13", true, caseLoads, "13",
+        reportWithDynamicFilter.id, emptyMap(), 1, 20, "13", true, authToken, "13",
       ),
     ).thenReturn(listOf(mapOf("13" to "static1"), mapOf("13" to "static2")))
 
-    val result = mapper.map(fullSingleProductDefinition, 20, caseLoads)
+    val result = mapper.map(fullSingleProductDefinition, 20, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleProductDefinition.id)
@@ -508,11 +509,11 @@ class ReportDefinitionMapperTest {
     whenever(
       configuredApiService.validateAndFetchData(
         fullSingleProductDefinition.id,
-        reportWithDynamicFilter.id, emptyMap(), 1, 10, "13", true, caseLoads, "13",
+        reportWithDynamicFilter.id, emptyMap(), 1, 10, "13", true, authToken, "13",
       ),
     ).thenReturn(listOf(mapOf("13" to "static1"), mapOf("13" to "static2")))
 
-    val result = mapper.map(fullSingleProductDefinition, 10, caseLoads)
+    val result = mapper.map(fullSingleProductDefinition, 10, authToken)
 
     assertThat(result).isNotNull
     assertThat(result.id).isEqualTo(fullSingleProductDefinition.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -27,6 +27,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleR
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.WordWrap
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -61,7 +65,6 @@ class ReportDefinitionMapperTest {
     created = LocalDateTime.MAX,
     version = "24",
     dataset = "\$ref:10",
-    policy = listOf("25"),
     render = RenderMethod.PDF,
     schedule = "26",
     specification = Specification(
@@ -87,7 +90,8 @@ class ReportDefinitionMapperTest {
         ),
       ),
     ),
-    destination = listOf(singletonMap("28", "29")), classification = "someClassification",
+    destination = listOf(singletonMap("28", "29")),
+    classification = "someClassification",
   )
 
   private val fullProductDefinition: ProductDefinition = ProductDefinition(
@@ -107,6 +111,13 @@ class ReportDefinitionMapperTest {
     report = listOf(fullReport),
   )
 
+  private val policy: Policy = Policy(
+    "caseload",
+    ROW_LEVEL,
+    listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+    listOf(Rule(Effect.PERMIT, emptyList())),
+  )
+
   private val fullSingleReportProductDefinition: SingleReportProductDefinition = SingleReportProductDefinition(
     id = "1",
     name = "2",
@@ -119,9 +130,10 @@ class ReportDefinitionMapperTest {
       profile = "8",
       dqri = "9",
     ),
-    dataset = fullDataset,
     datasource = fullDatasource,
+    dataset = fullDataset,
     report = fullReport,
+    policy = listOf(policy),
   )
 
   private val configuredApiService: ConfiguredApiService = mock<ConfiguredApiService>()
@@ -381,7 +393,6 @@ class ReportDefinitionMapperTest {
       created = LocalDateTime.MAX,
       version = "24",
       dataset = "\$ref:10",
-      policy = listOf("25"),
       render = RenderMethod.PDF,
       schedule = "26",
       specification = Specification(
@@ -402,7 +413,8 @@ class ReportDefinitionMapperTest {
           ),
         ),
       ),
-      destination = listOf(singletonMap("28", "29")), classification = "someClassification",
+      destination = listOf(singletonMap("28", "29")),
+      classification = "someClassification",
     )
 
     val fullSingleProductDefinition = fullSingleReportProductDefinition.copy(report = reportWithDynamicFilter)
@@ -465,7 +477,6 @@ class ReportDefinitionMapperTest {
       created = LocalDateTime.MAX,
       version = "24",
       dataset = "\$ref:10",
-      policy = listOf("25"),
       render = RenderMethod.PDF,
       schedule = "26",
       specification = Specification(
@@ -486,7 +497,8 @@ class ReportDefinitionMapperTest {
           ),
         ),
       ),
-      destination = listOf(singletonMap("28", "29")), classification = "someClassification",
+      destination = listOf(singletonMap("28", "29")),
+      classification = "someClassification",
     )
 
     val fullSingleProductDefinition = fullSingleReportProductDefinition.copy(report = reportWithDynamicFilter)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policye
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.AuthAwareAuthenticationToken
 import java.time.LocalDateTime
 
 class ReportDefinitionServiceTest {
@@ -87,7 +88,7 @@ class ReportDefinitionServiceTest {
         ),
       ),
     )
-    val caseLoads = listOf("caseLoad")
+    val authToken = mock<AuthAwareAuthenticationToken>()
 
     val repository = mock<ProductDefinitionRepository> {
       on { getProductDefinitions() } doReturn listOf(minimalDefinition)
@@ -97,10 +98,10 @@ class ReportDefinitionServiceTest {
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML, 20, caseLoads)
+    val actualResult = service.getListForUser(RenderMethod.HTML, 20, authToken)
 
     then(repository).should().getProductDefinitions()
-    then(mapper).should().map(minimalDefinition, RenderMethod.HTML, 20, caseLoads)
+    then(mapper).should().map(minimalDefinition, RenderMethod.HTML, 20, authToken)
 
     assertThat(actualResult).isNotEmpty
     assertThat(actualResult).hasSize(1)
@@ -118,7 +119,7 @@ class ReportDefinitionServiceTest {
         resourceName = "3",
       ),
     )
-    val caseLoads = listOf("caseLoad")
+    val authToken = mock<AuthAwareAuthenticationToken>()
 
     val repository = mock<ProductDefinitionRepository> {
       on { getSingleReportProductDefinition(any(), any()) } doReturn minimalSingleDefinition
@@ -132,11 +133,11 @@ class ReportDefinitionServiceTest {
       minimalSingleDefinition.id,
       minimalSingleDefinition.report.id,
       20,
-      caseLoads,
+      authToken,
     )
 
     then(repository).should().getSingleReportProductDefinition(minimalSingleDefinition.id, minimalSingleDefinition.report.id)
-    then(mapper).should().map(minimalSingleDefinition, 20, caseLoads)
+    then(mapper).should().map(minimalSingleDefinition, 20, authToken)
 
     assertThat(actualResult).isNotNull
     assertThat(actualResult).isEqualTo(expectedResult)
@@ -144,6 +145,7 @@ class ReportDefinitionServiceTest {
 
   @Test
   fun `Getting HTML report list with no matches returns no domains`() {
+    val authToken = mock<AuthAwareAuthenticationToken>()
     val definitionWithNoVariants = ReportDefinition(
       id = "1",
       name = "2",
@@ -158,7 +160,7 @@ class ReportDefinitionServiceTest {
     }
     val service = ReportDefinitionService(repository, mapper)
 
-    val actualResult = service.getListForUser(RenderMethod.HTML, 20, caseLoads)
+    val actualResult = service.getListForUser(RenderMethod.HTML, 20, authToken)
 
     assertThat(actualResult).hasSize(0)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -19,6 +19,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.RenderM
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType.ROW_LEVEL
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
 import java.time.LocalDateTime
 
 class ReportDefinitionServiceTest {
@@ -32,6 +36,13 @@ class ReportDefinitionServiceTest {
       version = "5",
     ),
     report = emptyList(),
+  )
+
+  private val policy: Policy = Policy(
+    "caseload",
+    ROW_LEVEL,
+    listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
+    listOf(Rule(Effect.PERMIT, emptyList())),
   )
 
   val minimalSingleDefinition = SingleReportProductDefinition(
@@ -60,6 +71,7 @@ class ReportDefinitionServiceTest {
       version = "31",
       owner = "32",
     ),
+    policy = listOf(policy),
   )
 
   @Test

--- a/src/test/resources/dpd001-court-hospital-movements.json
+++ b/src/test/resources/dpd001-court-hospital-movements.json
@@ -143,7 +143,7 @@
       "rule": [
         {
           "effect": "permit",
-          "condition": []
+          "condition": [{ "exists": ["${caseload}"]}]
         }
       ]
     }

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -56,7 +56,7 @@
     {
       "id": "caseload",
       "type": "row-level",
-      "action": ["(origin_code=${caseload} AND direction='OUT') OR (destination_code=${caseload} AND direction='IN')"],
+      "action": ["(origin_code=${caseload} AND lower(direction)='out') OR (destination_code=${caseload} AND lower(direction)='in')"],
       "rule": [
         {
           "effect": "permit",

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -58,7 +58,7 @@
       "rule": [
         {
           "effect": "permit",
-          "condition": []
+          "condition": [{ "exists": ["${caseload}"] }]
         }
       ]
     }

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -31,15 +31,13 @@
         "type" : "string"
       }, {
         "name" : "origin_code",
-        "type" : "string",
-        "caseload" : true
+        "type" : "string"
       }, {
         "name" : "destination",
         "type" : "string"
       },{
         "name" : "destination_code",
-        "type" : "string",
-        "caseload" : true
+        "type" : "string"
       }, {
         "name" : "direction",
         "type" : "string"


### PR DESCRIPTION
This PR introduces the policy engine which currently fulfils all the acceptance criteria of https://dsdmoj.atlassian.net/browse/DPR2-256.

Notes for consideration:
1. Until now there is a case insensitive comparison in the SQL query for the direction fields (in/out). 
If we want to maintain it the following needs to be changed in the DPD action: `lower(direction) = 'in'` and similar for 'out'. [This is shown here](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/DPR2-256_single_active_caseload_to_policy_engine/src/test/resources/productDefinition.json#L57).
2. Also to have consistency across variable interpolation, the following would be good to be changed in the DPD action:
`origin_code='${caseload}'` and similarly for the destination code they both need quotes.
3. In the DPD it would be good to have the following condition `{ "exists": ["$caseload"] }` to cover the case of returning no data when the user has no caseload which is [done in the example json](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/DPR2-256_single_active_caseload_to_policy_engine/src/test/resources/productDefinition.json#L61). Currently there is a special handling in the action interpolation logic to handle this.
4. For consistency all variables will have to be defined in the same way in the DPDs: `${var}`