### PR TITLE
DPR2-299 access policy implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "2.0.1"
+        version = "2.0.2"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -79,10 +79,10 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @PathVariable("reportId") reportId: String,
     @PathVariable("reportVariantId") reportVariantId: String,
     @Parameter(
-      description = ReportDefinitionController.dataProductDefinitionsPathDescription,
-      example = ReportDefinitionController.dataProductDefinitionsPathExample,
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
     )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.dataProductDefinitionsPathExample)
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): ResponseEntity<List<Map<String, Any>>> {
@@ -156,10 +156,10 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @NotEmpty
     fieldId: String,
     @Parameter(
-      description = ReportDefinitionController.dataProductDefinitionsPathDescription,
-      example = ReportDefinitionController.dataProductDefinitionsPathExample,
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
     )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.dataProductDefinitionsPathExample)
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): ResponseEntity<List<String>> {
@@ -221,10 +221,10 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @PathVariable("reportId") reportId: String,
     @PathVariable("reportVariantId") reportVariantId: String,
     @Parameter(
-      description = ReportDefinitionController.dataProductDefinitionsPathDescription,
-      example = ReportDefinitionController.dataProductDefinitionsPathExample,
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
     )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.dataProductDefinitionsPathExample)
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): ResponseEntity<Count> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ReportDefinitionController.kt
@@ -23,9 +23,9 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefi
 class ReportDefinitionController(val reportDefinitionService: ReportDefinitionService) {
 
   companion object {
-    const val dataProductDefinitionsPathDescription = """This optional parameter sets the path of the directory of the data product definition files your application will use.
+    const val DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION = """This optional parameter sets the path of the directory of the data product definition files your application will use.
       "This query parameter is intended to be used in conjunction with the `dpr.lib.dataProductDefinitions.host` property to retrieve definition files from another application by using a web client."""
-    const val dataProductDefinitionsPathExample = "definitions/prisons/orphanage"
+    const val DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE = "definitions/prisons/orphanage"
   }
 
   @GetMapping("/definitions")
@@ -48,10 +48,10 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     @Min(1)
     maxStaticOptions: Long,
     @Parameter(
-      description = dataProductDefinitionsPathDescription,
-      example = dataProductDefinitionsPathExample,
+      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
     )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = dataProductDefinitionsPathExample)
+    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): List<ReportDefinition> {
@@ -89,10 +89,10 @@ class ReportDefinitionController(val reportDefinitionService: ReportDefinitionSe
     @Min(1)
     maxStaticOptions: Long,
     @Parameter(
-      description = dataProductDefinitionsPathDescription,
-      example = dataProductDefinitionsPathExample,
+      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
     )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = dataProductDefinitionsPathExample)
+    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): SingleVariantReportDefinition {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldType.kt
@@ -7,5 +7,4 @@ enum class FieldType(@JsonValue val type: kotlin.String) {
   Date("date"),
   Long("long"),
   Time("time"),
-  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/RenderMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/RenderMethod.kt
@@ -4,5 +4,4 @@ enum class RenderMethod {
   HTML,
   PDF,
   SVG,
-  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ParameterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ParameterType.kt
@@ -7,5 +7,4 @@ enum class ParameterType(@JsonValue val type: kotlin.String) {
   Date("date"),
   Long("long"),
   Time("time"),
-  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/RenderMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/RenderMethod.kt
@@ -4,5 +4,4 @@ enum class RenderMethod {
   HTML,
   PDF,
   SVG,
-  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Effect.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Effect.kt
@@ -3,5 +3,4 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policy
 enum class Effect(val type: String) {
   PERMIT("permit"),
   DENY("deny"),
-  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Policy.kt
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
+import com.google.gson.annotations.SerializedName
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_PERMIT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 
-data class Policy(val id: String, val type: PolicyType, val action: List<String>, val rule: List<Rule>) {
+data class Policy(val id: String, val type: PolicyType, @SerializedName("action") private val _action: List<String>? = null, val rule: List<Rule>) {
+
+  val action
+    get() = _action ?: emptyList()
 
   object PolicyResult {
     const val POLICY_PERMIT = "TRUE"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/PolicyType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/PolicyType.kt
@@ -2,4 +2,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policy
 
 enum class PolicyType(val type: String) {
   ROW_LEVEL("row-level"),
+  ACCESS("access"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -30,7 +30,7 @@ class ConfiguredApiService(
     const val INVALID_STATIC_OPTIONS_MESSAGE = "Invalid static options provided."
     const val INVALID_DYNAMIC_OPTIONS_MESSAGE = "Invalid dynamic options length provided."
     const val INVALID_DYNAMIC_FILTER_MESSAGE = "Error. This filter is not a dynamic filter."
-    private const val schemaRefPrefix = "\$ref:"
+    private const val SCHEMA_REF_PREFIX = "\$ref:"
   }
 
   fun validateAndFetchData(
@@ -104,7 +104,7 @@ class ConfiguredApiService(
       ?.field
       ?.firstOrNull { it.defaultSort }
       ?.name
-      ?.removePrefix(schemaRefPrefix)
+      ?.removePrefix(SCHEMA_REF_PREFIX)
   }
 
   private fun sortColumnFromQueryOrGetDefault(productDefinition: SingleReportProductDefinition, sortColumn: String?): String? {
@@ -169,7 +169,7 @@ class ConfiguredApiService(
   fun findFilterDefinition(definition: SingleReportProductDefinition, filterName: String): FilterDefinition {
     val field =
       definition.report.specification?.field
-        ?.firstOrNull { it.filter != null && filterName == it.name.removePrefix(schemaRefPrefix) }
+        ?.firstOrNull { it.filter != null && filterName == it.name.removePrefix(SCHEMA_REF_PREFIX) }
 
     return field?.filter ?: throw ValidationException(INVALID_FILTERS_MESSAGE)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ConfiguredApiIntegrationTest.kt
@@ -39,7 +39,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  val CASELOADS_WITH_NONE_ACTIVE: String = """
+  val caseloadsWithNoneActive: String = """
           {
             "username": "TESTUSER1",
             "active": true,
@@ -284,7 +284,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
         WireMock.aResponse()
           .withStatus(HttpStatus.OK.value())
           .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-          .withBody(CASELOADS_WITH_NONE_ACTIVE),
+          .withBody(caseloadsWithNoneActive),
       ),
     )
     stubDefinitionsResponse()
@@ -317,7 +317,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
         WireMock.aResponse()
           .withStatus(HttpStatus.OK.value())
           .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-          .withBody(CASELOADS_WITH_NONE_ACTIVE),
+          .withBody(caseloadsWithNoneActive),
       ),
     )
     stubDefinitionsResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -270,7 +270,7 @@ class PolicyEngineTest {
     val policy = Policy(
       id = "caseload",
       type = ACCESS,
-      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", userRole, "RANDOM-ROLE","GLOBAL-SEARCH"))))),
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", userRole, "RANDOM-ROLE", "GLOBAL-SEARCH"))))),
     )
     val policyEngine = PolicyEngine(listOf(policy), authToken = authToken)
     Assertions.assertThat(policyEngine.execute()).isEqualTo("TRUE")
@@ -283,7 +283,7 @@ class PolicyEngineTest {
     val policy = Policy(
       id = "caseload",
       type = ACCESS,
-      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", "DPR-USER", "RANDOM-ROLE","GLOBAL-SEARCH"))))),
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${role}", "DPR-USER", "RANDOM-ROLE", "GLOBAL-SEARCH"))))),
     )
     val policyEngine = PolicyEngine(listOf(policy), authToken = authToken)
     Assertions.assertThat(policyEngine.execute()).isEqualTo("FALSE")

--- a/src/test/resources/productDefinitionPolicyNoAction.json
+++ b/src/test/resources/productDefinitionPolicyNoAction.json
@@ -1,0 +1,163 @@
+{
+  "id" : "definition-policy-no-action",
+  "name" : "External Movements",
+  "description" : "Reports about prisoner external movements",
+  "metadata" : {
+    "author" : "Adam",
+    "version" : "1.2.3",
+    "owner" : "Eve"
+  },
+  "datasource" : [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }],
+  "dataset" : [ {
+    "id" : "definition-policy-no-action",
+    "name" : "All movements",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "schema" : {
+      "field" : [ {
+        "name" : "prisonNumber",
+        "type" : "string"
+      }, {
+        "name" : "name",
+        "type" : "string"
+      }, {
+        "name" : "date",
+        "type" : "date"
+      }, {
+        "name" : "origin",
+        "type" : "string"
+      }, {
+        "name" : "origin_code",
+        "type" : "string"
+      }, {
+        "name" : "destination",
+        "type" : "string"
+      },{
+        "name" : "destination_code",
+        "type" : "string"
+      }, {
+        "name" : "direction",
+        "type" : "string"
+      }, {
+        "name" : "type",
+        "type" : "string"
+      }, {
+        "name" : "reason",
+        "type" : "string"
+      } ]
+    }
+  } ],
+  "policy": [
+    {
+      "id": "role-based-policy-212312",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "match": [
+                "${role}",
+                "USER-ROLE-1",
+                "USER-ROLE-2",
+                "USER-ROLE-N"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report" : [ {
+    "id" : "last-month",
+    "name" : "Last month",
+    "description" : "All movements in the past month",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:definition-policy-no-action",
+    "policy" : [ ],
+    "render" : "HTML",
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "None",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "daterange",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "None",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "None",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "visible": "report visibility",
+    "formula": "formula placeholder"
+  } ]
+}


### PR DESCRIPTION
This PR implements the new policy type "access".
Main changes include:
- Support "access" type policy. Including being able to parse this from JSON.
- Support policies with missing action.