### PR TITLE
DPR2-404 return HTML type for make_url formula fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "3.0.3"
+        version = "3.0.4"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldType.kt
@@ -7,4 +7,5 @@ enum class FieldType(@JsonValue val type: kotlin.String) {
   Date("date"),
   Long("long"),
   Time("time"),
+  HTML("HTML"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -215,11 +215,6 @@ class ConfiguredApiService(
     }
   }
 
-  private fun formatToSchemaFieldsCasing(resultRows: List<Map<String, Any>>, schemaFields: List<SchemaField>): List<Map<String, Any>> {
-    return resultRows
-      .map { row -> row.entries.associate { e -> transformKey(e.key, schemaFields) to e.value } }
-  }
-
   private fun transformKey(key: String, schemaFields: List<SchemaField>): String {
     return schemaFields.first { it.name.lowercase() == key.lowercase() }.name
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -4,6 +4,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportF
 
 class FormulaEngine(private val reportFields: List<ReportField>) {
 
+  companion object {
+    const val MAKE_URL_FORMULA_PREFIX = "make_url"
+  }
+
   fun applyFormulas(row: Map<String, Any>): Map<String, Any> =
     row.entries.associate { e ->
       e.key to constructValueWithFormulaInterpolationIfNeeded(e, row)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -69,7 +69,7 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
       description = report.description,
       specification = map(report.specification, dataSet.schema.field, productDefinitionId, report.id, userToken, dataProductDefinitionsPath),
       classification = report.classification,
-      printable = report.feature?.any { it.type == FeatureType.PRINT },
+      printable = report.feature?.any { it.type == FeatureType.PRINT } ?: false,
       resourceName = "reports/$productDefinitionId/${report.id}",
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -69,7 +69,7 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
       description = report.description,
       specification = map(report.specification, dataSet.schema.field, productDefinitionId, report.id, userToken, dataProductDefinitionsPath),
       classification = report.classification,
-      printable = report.feature?.filter { f -> f.type.equals(FeatureType.PRINT) }?.size == 1,
+      printable = report.feature?.any { it.type == FeatureType.PRINT },
       resourceName = "reports/$productDefinitionId/${report.id}",
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaF
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEngine.Companion.MAKE_URL_FORMULA_PREFIX
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 import java.time.temporal.ChronoUnit
@@ -109,8 +110,13 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
       filter = field.filter?.let { map(it, productDefinitionId, reportVariantId, schemaField.name, userToken, dataProductDefinitionsPath) },
       sortable = field.sortable,
       defaultsort = field.defaultSort,
-      type = schemaField.type.toString().let(FieldType::valueOf),
+      type = populateType(schemaField, field),
     )
+  }
+
+  private fun populateType(schemaField: SchemaField, reportField: ReportField): FieldType {
+    return reportField.formula?.takeIf { it.startsWith(MAKE_URL_FORMULA_PREFIX) }?.let { FieldType.HTML }
+      ?: schemaField.type.toString().let(FieldType::valueOf)
   }
 
   private fun map(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod.HTML
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
@@ -610,6 +611,70 @@ class ReportDefinitionMapperTest {
     assertThat(field.filter?.staticOptions).isNull()
     assertThat(field.filter?.dynamicOptions).isEqualTo(DynamicFilterOption(2, false))
     assertThat(field.type.toString()).isEqualTo(sourceSchemaField.type.toString())
+    verifyNoInteractions(configuredApiService)
+  }
+
+  @Test
+  fun `getting single report with a field containing a make_url formula maps full data correctly and generates HTML type for that field`() {
+    val reportWithMakeUrlFormula = Report(
+      id = "21",
+      name = "22",
+      description = "23",
+      created = LocalDateTime.MAX,
+      version = "24",
+      dataset = "\$ref:10",
+      render = RenderMethod.PDF,
+      schedule = "26",
+      specification = Specification(
+        template = "27",
+        field = listOf(
+          ReportField(
+            name = "\$ref:13",
+            display = "14",
+            wordWrap = WordWrap.None,
+            sortable = true,
+            defaultSort = true,
+            formula = "make_url('\${profile_host}/prisoner/\${prisoner_number}',\${full_name},TRUE)",
+            visible = true,
+          ),
+        ),
+      ),
+      destination = listOf(singletonMap("28", "29")),
+      classification = "someClassification",
+    )
+
+    val fullSingleProductDefinition = fullSingleReportProductDefinition.copy(report = reportWithMakeUrlFormula)
+
+    val mapper = ReportDefinitionMapper(configuredApiService)
+
+    val result = mapper.map(fullSingleProductDefinition, authToken)
+
+    assertThat(result).isNotNull
+    assertThat(result.id).isEqualTo(fullSingleProductDefinition.id)
+    assertThat(result.name).isEqualTo(fullSingleProductDefinition.name)
+    assertThat(result.description).isEqualTo(fullSingleProductDefinition.description)
+
+    val variant = result.variant
+
+    assertThat(variant.id).isEqualTo(fullSingleProductDefinition.report.id)
+    assertThat(variant.name).isEqualTo(fullSingleProductDefinition.report.name)
+    assertThat(variant.resourceName).isEqualTo("reports/${fullSingleProductDefinition.id}/${fullSingleProductDefinition.report.id}")
+    assertThat(variant.description).isEqualTo(fullSingleProductDefinition.report.description)
+    assertThat(variant.specification).isNotNull
+    assertThat(variant.specification?.template).isEqualTo(fullSingleProductDefinition.report.specification?.template)
+    assertThat(variant.specification?.fields).isNotEmpty
+    assertThat(variant.specification?.fields).hasSize(1)
+
+    val field = variant.specification!!.fields.first()
+    val sourceSchemaField = fullSingleProductDefinition.dataset.schema.field.first()
+    val sourceReportField = fullSingleProductDefinition.report.specification!!.field.first()
+
+    assertThat(field.name).isEqualTo(sourceSchemaField.name)
+    assertThat(field.display).isEqualTo(sourceReportField.display)
+    assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
+    assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
+    assertThat(field.defaultsort).isEqualTo(sourceReportField.defaultSort)
+    assertThat(field.type).isEqualTo(FieldType.HTML)
     verifyNoInteractions(configuredApiService)
   }
 


### PR DESCRIPTION
Changes for the single report definition endpoint to return HTML as the type of fields which have a `make_url` formula.