### PR TITLE
Dpr2 341 fix issue with null row values

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "3.0.4"
+        version = "3.0.5"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -85,7 +85,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
-  ): ResponseEntity<List<Map<String, Any>>> {
+  ): ResponseEntity<List<Map<String, Any?>>> {
     return try {
       ResponseEntity
         .status(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -35,7 +35,7 @@ class ConfiguredApiRepository {
     policyEngineResult: String,
     dynamicFilterFieldId: String? = null,
     dataSourceName: String,
-  ): List<Map<String, Any>> {
+  ): List<Map<String, Any?>> {
     val stopwatch = StopWatch.createStarted()
     val jdbcTemplate = populateJdbcTemplate(dataSourceName)
     val result = jdbcTemplate.queryForList(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -38,7 +38,10 @@ class ConfiguredApiRepository {
   ): List<Map<String, Any?>> {
     val stopwatch = StopWatch.createStarted()
     val jdbcTemplate = populateJdbcTemplate(dataSourceName)
-    val result = jdbcTemplate.queryForList(
+    //The result of the query can contain null values.
+    //This is coming from Java and if the returned type is not specified in Kotlin it will assume it is List<Map<String, Any>>
+    //while in reality it is List<Map<String, Any?>>.
+    val result: List<Map<String, Any?>> = jdbcTemplate.queryForList(
       buildFinalQuery(
         buildReportQuery(query),
         buildPolicyQuery(policyEngineResult),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -45,7 +45,7 @@ class ConfiguredApiService(
     reportFieldId: String? = null,
     prefix: String? = null,
     dataProductDefinitionsPath: String? = null,
-  ): List<Map<String, Any>> {
+  ): List<Map<String, Any?>> {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
@@ -68,7 +68,7 @@ class ConfiguredApiService(
   }
 
   private fun formatColumnNamesToSchemaFieldNamesCasing(
-    row: Map<String, Any>,
+    row: Map<String, Any?>,
     productDefinition: SingleReportProductDefinition,
   ) = row.entries.associate { e -> transformKey(e.key, productDefinition.dataset.schema.field) to e.value }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -8,33 +8,33 @@ class FormulaEngine(private val reportFields: List<ReportField>) {
     const val MAKE_URL_FORMULA_PREFIX = "make_url"
   }
 
-  fun applyFormulas(row: Map<String, Any>): Map<String, Any> =
+  fun applyFormulas(row: Map<String, Any?>): Map<String, Any?> =
     row.entries.associate { e ->
       e.key to constructValueWithFormulaInterpolationIfNeeded(e, row)
     }
 
   private fun constructValueWithFormulaInterpolationIfNeeded(
-    e: Map.Entry<String, Any>,
-    row: Map<String, Any>,
+    e: Map.Entry<String, Any?>,
+    row: Map<String, Any?>,
   ) = (
-    findFormulas(e.key)
+    findFormula(e.key)
       ?.let {
         interpolate(formula = it, row)
       } ?: e.value
     )
 
-  private fun findFormulas(columnName: String) =
+  private fun findFormula(columnName: String) =
     reportFields.firstOrNull { reportField -> reportField.name.removePrefix("\$ref:") == columnName }
       ?.formula?.ifEmpty { null }
 
-  private fun interpolate(formula: String, row: Map<String, Any>): String {
+  private fun interpolate(formula: String, row: Map<String, Any?>): String {
     val sb = StringBuilder(formula)
     row.keys.forEach {
       sb.replace(
         0,
         sb.length,
         sb.toString()
-          .replace("\${$it}", row.getOrDefault(it, "").toString()),
+          .replace("\${$it}", row.getOrElse(it) { "" }.toString()),
       )
     }
     return sb.toString()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -213,7 +213,7 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return data and not error when there is no sort column provided `() {
-    var actual: List<Map<String, Any>> = emptyList()
+    var actual: List<Map<String, Any?>> = emptyList()
     assertDoesNotThrow {
       actual = configuredApiRepository.executeQuery(
         query = query,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ExternalMovementEntity.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ExternalMovementEntity.kt
@@ -17,6 +17,6 @@ data class ExternalMovementEntity(
   val destination: String?,
   val destinationCode: String?,
   val direction: String?,
-  val type: String,
+  val type: String?,
   val reason: String,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
@@ -200,4 +200,30 @@ class FormulaEngineTest {
     val formulaEngine = FormulaEngine(reportFields)
     assertEquals(expectedRow, formulaEngine.applyFormulas(row))
   }
+
+  @Test
+  fun `Formula engine outputs empty String for null fields with formulas`() {
+    val row: Map<String, Any?> = mapOf(
+      NAME to null,
+      DATE to externalMovementOriginCaseloadDirectionIn.time,
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "MNCH",
+    )
+    val reportFields = listOf(
+      ReportField(
+        name = "\$ref:destination_code",
+        display = "Destination Code",
+        visible = true,
+        formula = "\${name}",
+      ),
+    )
+    val expectedRow: Map<String, Any?> = mapOf(
+      NAME to null,
+      DATE to externalMovementOriginCaseloadDirectionIn.time,
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "",
+    )
+    val formulaEngine = FormulaEngine(reportFields)
+    assertEquals(expectedRow, formulaEngine.applyFormulas(row))
+  }
 }

--- a/src/test/resources/productDefinitionWithFormula.json
+++ b/src/test/resources/productDefinitionWithFormula.json
@@ -162,8 +162,7 @@
       } ]
     },
     "destination" : [ ],
-    "visible": "report visibility",
-    "formula": "formula placeholder"
+    "visible": "report visibility"
   }, {
     "id" : "last-week",
     "name" : "Last week",


### PR DESCRIPTION
These changes fix the current NPE due to which a 500 response is returned when formulas are specified and some rows have null values.
The result of the jdbcTemplate query can contain null values.
This is coming from Java and if the returned type is not specified in Kotlin it will assume it is List<Map<String, Any>>
and despite that, it can and in our case does contain null values.
There correct type is List<Map<String, Any?>> and this has now been specified explicitly in the code to avoid confusion and not mask similar issues.
