### PR TITLE
DPR2-413 more changes to visible field parsing based on recent details

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
         group = "uk.gov.justice.service.hmpps"
         name.set(base.archivesName)
         artifactId = base.archivesName.get()
-        version = "3.2.0"
+        version = "3.2.1"
         description.set("A Spring Boot reporting library to be integrated into your project and allow you to produce reports.")
         url.set("https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib")
         licenses {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FieldDefinition.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Visible
-
 data class FieldDefinition(
   val name: String,
   val display: String,
@@ -10,6 +8,6 @@ data class FieldDefinition(
   val sortable: Boolean = true,
   val defaultsort: Boolean = false,
   val type: FieldType,
-  val mandatory: Boolean? = false,
-  val visible: Visible? = Visible.TRUE,
+  val mandatory: Boolean = false,
+  val visible: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
@@ -12,6 +12,5 @@ data class ReportField(
   val defaultSort: Boolean = false,
   // Formula and visible are not used yet. This is pending ticket https://dsdmoj.atlassian.net/browse/DPR2-241
   val formula: String? = null,
-  val visible: Visible?,
-  val mandatory: Boolean? = false,
+  val visible: Visible? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Visible.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Visible.kt
@@ -1,26 +1,14 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
 
 enum class Visible {
-  @SerializedName(Companion.TRUE)
-  @JsonProperty(Companion.TRUE)
+  @SerializedName("true")
   TRUE,
 
-  @SerializedName(Companion.FALSE)
-  @JsonProperty(Companion.FALSE)
+  @SerializedName("false")
   FALSE,
 
-  @SerializedName(Companion.MANDATORY)
-  @JsonProperty(Companion.MANDATORY)
+  @SerializedName("mandatory")
   MANDATORY,
-
-  ;
-
-  companion object {
-    private const val TRUE: String = "true"
-    private const val FALSE: String = "false"
-    private const val MANDATORY: String = "mandatory"
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportF
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Visible
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEngine.Companion.MAKE_URL_FORMULA_PREFIX
 import java.time.LocalDate
@@ -112,9 +113,29 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
       sortable = field.sortable,
       defaultsort = field.defaultSort,
       type = populateType(schemaField, field),
-      mandatory = field.mandatory,
-      visible = field.visible,
+      mandatory = populateMandatory(field.visible),
+      visible = populateVisible(field.visible),
     )
+  }
+
+  private fun populateVisible(visible: Visible?): Boolean {
+    return visible?.let {
+      when (visible) {
+        Visible.TRUE -> true
+        Visible.FALSE -> false
+        Visible.MANDATORY -> true
+      }
+    } ?: true
+  }
+
+  private fun populateMandatory(visible: Visible?): Boolean {
+    return visible?.let {
+      when (visible) {
+        Visible.TRUE -> false
+        Visible.FALSE -> false
+        Visible.MANDATORY -> true
+      }
+    } ?: false
   }
 
   private fun populateType(schemaField: SchemaField, reportField: ReportField): FieldType {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -305,8 +305,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "mandatory": false,
+                    "visible": true
                   },
                   {
                     "name": "name",
@@ -327,8 +327,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "mandatory": false,
+                    "visible": true
                   },
                   {
                     "name": "date",
@@ -338,15 +338,14 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                       "type": "daterange",
                       "staticOptions": null,
                       "dynamicOptions": null,
-                      "defaultValue": "2024-01-22 - 2024-02-22",
                       "min": null,
                       "max": null
                     },
                     "sortable": true,
                     "defaultsort": true,
                     "type": "date",
-                    "mandatory": null,
-                    "visible": null
+                    "mandatory": false,
+                    "visible": true
                   },
                   {
                     "name": "origin",
@@ -356,8 +355,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "mandatory": false,
+                    "visible": true
                   },
                   {
                     "name": "destination",
@@ -367,8 +366,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "visible": true,
+                    "mandatory": false
                   },
                   {
                     "name": "direction",
@@ -394,8 +393,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "mandatory": false,
+                    "visible": true
                   },
                   {
                     "name": "type",
@@ -406,7 +405,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "defaultsort": false,
                     "type": "string",
                     "mandatory": false,
-                    "visible": "false"
+                    "visible": false
                   },
                   {
                     "name": "reason",
@@ -432,8 +431,8 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": true,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": null,
-                    "visible": null
+                    "visible": true,
+                    "mandatory": true
                   }
                 ]
               },

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -120,7 +120,8 @@
         "display" : "To",
         "wordWrap" : "None",
         "sortable" : true,
-        "defaultsort" : false
+        "defaultsort" : false,
+        "visible": "true"
       }, {
         "name" : "$ref:direction",
         "display" : "Direction",
@@ -141,13 +142,13 @@
         "display" : "Type",
         "sortable" : true,
         "defaultsort" : false,
-        "visible": "false",
-        "mandatory": false
+        "visible": "false"
       }, {
         "name" : "$ref:reason",
         "display" : "Reason",
         "sortable" : true,
         "defaultsort" : false,
+        "visible": "mandatory",
         "filter" : {
           "type" : "autocomplete",
           "dynamicoptions":{


### PR DESCRIPTION
Updated the logic of parsing and outputting the "visible" and "mandatory" fields based on the below rules:
```
The DPD no longer needs a "mandatory" column.
The DPD "visible" tristate property maps like:
DPD "true": UI: "visible": true, "mandatory": false
DPD "false": UI: "visible": false, "mandatory": false
DPD "mandatory": UI: "visible": true, "mandatory": true
The UI model should have "visible" as a boolean, like before the DPD change.
```
If the visible field is not present in the DPD I defaulted it to true and the mandatory to false in the resulting UI model.