### PR TITLE
DPR2-517 format_date returns empty string for null date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,6 @@ The JSON schema has been reconciled to the library functionality:
   - `break-words` allows the text to wrap, breaking words if it has to.
 - Removed report-field.type enum values: `null`, `bytes`.
 - Added support for the remaining field types. 
+
+## 3.7.1
+Fixed the issue in which null dates would throw an error when the format_date function was applied to them. 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -42,6 +42,9 @@ class FormulaEngine(private val reportFields: List<ReportField>, private val env
     val (dateFieldPlaceholder, dateFormat) = formula.substring(FORMAT_DATE_FORMULA_PREFIX.length, formula.indexOf(")"))
       .split(",")
     val date = interpolateStandardFormula(dateFieldPlaceholder.trim(), row)
+    if (date.isBlank()) {
+      return ""
+    }
     return LocalDateTime.parse(date).format(DateTimeFormatter.ofPattern(removeQuotes(dateFormat.trim())))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
@@ -394,4 +394,32 @@ class FormulaEngineTest {
     val formulaEngine = FormulaEngine(reportFields)
     assertEquals(expectedRow, formulaEngine.applyFormulas(row))
   }
+
+  @Test
+  fun `Formula engine returns an empty string for a null date and the format_date formula does not error`() {
+    val formatDateFormula = "format_date(\${date}, 'dd/MM/yyyy')"
+    val name = "LastName6, F"
+    val row: Map<String, Any?> = mapOf(
+      NAME to name,
+      DATE to null,
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "MNCH",
+    )
+    val reportFields = listOf(
+      ReportField(
+        name = "\$ref:date",
+        display = "Date",
+        visible = Visible.TRUE,
+        formula = formatDateFormula,
+      ),
+    )
+    val expectedRow: Map<String, Any?> = mapOf(
+      NAME to name,
+      DATE to "",
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "MNCH",
+    )
+    val formulaEngine = FormulaEngine(reportFields)
+    assertEquals(expectedRow, formulaEngine.applyFormulas(row))
+  }
 }


### PR DESCRIPTION
This is addressing issue https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/issues/122.
With these changes the format_date formula returns an empty string for null dates which is consistent with the behaviour of other formulas.