### PR TITLE
DPR2-518 Fixed issue with filtering error on Boolean fields.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
       name: hmpps/java
       tag: "19.0"
     steps:
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - restore_cache:
           keys:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@ The JSON schema has been reconciled to the library functionality:
 
 ## 3.7.1
 Fixed the issue in which null dates would throw an error when the format_date function was applied to them. 
+
+## 3.7.2
+Fixed the issue in which filtering by Boolean fields would throw an error.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
   testImplementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
   testImplementation("io.jsonwebtoken:jjwt:0.12.5")
   testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
+  testImplementation("org.postgresql:postgresql:42.7.1")
+  testImplementation("org.testcontainers:postgresql:1.19.3")
+  testImplementation("org.testcontainers:junit-jupiter:1.19.3")
 }
 
 java {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -141,7 +141,8 @@ class ConfiguredApiRepository {
 
   fun buildPreparedStatementNamedParams(filters: List<Filter>): MapSqlParameterSource {
     val preparedStatementNamedParams = MapSqlParameterSource()
-    filters.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.lowercase()) }
+    filters.filterNot { it.type == FilterType.BOOLEAN }.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.lowercase()) }
+    filters.filter { it.type == FilterType.BOOLEAN }.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.toBoolean()) }
     log.debug("Prepared statement named parameters: {}", preparedStatementNamedParams)
     return preparedStatementNamedParams
   }
@@ -157,6 +158,7 @@ class ConfiguredApiRepository {
       FilterType.RANGE_END -> "$lowerCaseField <= :$key"
       FilterType.DATE_RANGE_END -> "${filter.field} < (CAST(:$key AS timestamp) + INTERVAL '1' day)"
       FilterType.DYNAMIC -> "${filter.field} ILIKE '${filter.value}%'"
+      FilterType.BOOLEAN -> "${filter.field} = :$key"
     }
   }
 
@@ -175,5 +177,6 @@ class ConfiguredApiRepository {
     DATE_RANGE_START(".start"),
     DATE_RANGE_END(".end"),
     DYNAMIC,
+    BOOLEAN,
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTestContainersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTestContainersTest.kt
@@ -1,0 +1,124 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDateTime
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ConfiguredApiRepositoryTestContainersTest {
+
+  @Autowired
+  lateinit var externalMovementRepository: ExternalMovementRepository
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
+  @Autowired
+  lateinit var configuredApiRepository: ConfiguredApiRepository
+
+  companion object {
+    @DynamicPropertySource
+    @JvmStatic
+    fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
+      registry.add("dpr.lib.definition.locations") { "productDefinition.json" }
+      registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl)
+      registry.add("spring.datasource.username", postgreSQLContainer::getUsername)
+      registry.add("spring.datasource.password", postgreSQLContainer::getPassword)
+      registry.add("spring.datasource.driver-class-name", postgreSQLContainer::getDriverClassName)
+      registry.add("spring.jpa.database-platform", "org.hibernate.dialect.PostgreSQLDialect"::toString)
+    }
+
+    @Container
+    private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:latest")
+  }
+
+  private val policyEngineResult = "TRUE"
+  private val dataSourceName = "datamart"
+
+  @BeforeEach
+  fun setup() {
+    ConfiguredApiRepositoryTest.AllMovements.allExternalMovements.forEach {
+      externalMovementRepository.save(it)
+    }
+    ConfiguredApiRepositoryTest.AllPrisoners.allPrisoners.forEach {
+      prisonerRepository.save(it)
+    }
+  }
+
+  @Test
+  fun `should return all the rows that match the boolean filter`() {
+    val externalMovementEntityWithBoolean = ExternalMovementEntity(
+      16,
+      7852,
+      LocalDateTime.of(2023, 5, 20, 0, 0, 0),
+      LocalDateTime.of(2023, 5, 20, 14, 0, 0),
+      "Bolton Crown Court",
+      "BOLTCC",
+      "HMP HEWELL",
+      "HEI",
+      "In",
+      "Transfer",
+      "Transfer In from Other Establishment",
+      isClosed = true,
+    )
+    val prisonerEntity = PrisonerEntity(7852, "G3154UG", "FirstName5", "LastName5", null)
+    try {
+      val query = "SELECT " +
+        "prisoners.number AS prisonNumber," +
+        "CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name," +
+        "movements.time AS date," +
+        "movements.direction," +
+        "movements.type," +
+        "movements.origin," +
+        "movements.origin_code," +
+        "movements.destination," +
+        "movements.destination_code," +
+        "movements.reason," +
+        "movements.is_closed\n" +
+        "FROM domain.movement_movement as movements\n" +
+        "JOIN domain.prisoner_prisoner as prisoners\n" +
+        "ON movements.prisoner = prisoners.id"
+      externalMovementRepository.save(externalMovementEntityWithBoolean)
+      prisonerRepository.save(prisonerEntity)
+      val movementPrisoner = mapOf(
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.PRISON_NUMBER.lowercase() to "G3154UG",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.NAME.lowercase() to "LastName5, F",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.DATE.lowercase() to ConfiguredApiRepositoryTest.AllMovements.externalMovement5.time,
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.DIRECTION.lowercase() to "In",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.TYPE.lowercase() to "Transfer",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.ORIGIN.lowercase() to "Bolton Crown Court",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.ORIGIN_CODE.lowercase() to "BOLTCC",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION.lowercase() to "HMP HEWELL",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION_CODE.lowercase() to "HEI",
+        ConfiguredApiRepositoryTest.AllMovementPrisoners.REASON.lowercase() to "Transfer In from Other Establishment",
+        "is_closed" to true,
+      )
+      val actual = configuredApiRepository.executeQuery(
+        query,
+        listOf(ConfiguredApiRepository.Filter("is_closed", "true", ConfiguredApiRepository.FilterType.BOOLEAN)),
+        1,
+        10,
+        "date",
+        false,
+        ConfiguredApiRepository.EXTERNAL_MOVEMENTS_PRODUCT_ID,
+        policyEngineResult = policyEngineResult,
+        dataSourceName = dataSourceName,
+      )
+      Assertions.assertEquals(listOf(movementPrisoner), actual)
+    } finally {
+      externalMovementRepository.delete(externalMovementEntityWithBoolean)
+      prisonerRepository.delete(prisonerEntity)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ExternalMovementEntity.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ExternalMovementEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
@@ -19,4 +20,6 @@ data class ExternalMovementEntity(
   val direction: String?,
   val type: String?,
   val reason: String,
+  @Column(name = "IS_CLOSED")
+  val isClosed: Boolean? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -228,7 +228,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       assertThat(lastMonthVariant.name).isEqualTo("Last month")
       assertThat(lastMonthVariant.description).isEqualTo("All movements in the past month")
       assertThat(lastMonthVariant.specification).isNotNull
-      assertThat(lastMonthVariant.specification?.fields).hasSize(8)
+      assertThat(lastMonthVariant.specification?.fields).hasSize(9)
       assertThat(lastMonthVariant.printable).isEqualTo(true)
 
       val directionField = lastMonthVariant.specification?.fields?.find { it.name == "direction" }
@@ -433,6 +433,34 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "type": "string",
                     "visible": true,
                     "mandatory": true
+                  },
+                  {
+                    "name": "is_closed",
+                    "display": "Closed",
+                    "wordWrap":null,
+                    "sortable": true,
+                    "defaultsort":false,
+                    "filter": {
+                      "type": "Radio",
+                      "staticOptions": [
+                        {
+                          "name": "false",
+                          "display": "Only open"
+                        },
+                        {
+                          "name": "true",
+                          "display": "Only closed"
+                        }
+                      ],
+                      "dynamicOptions": null,
+                      "defaultValue":"false",
+                      "min": null,
+                      "max": null
+                    },
+                    "type": "boolean",
+                    "mandatory": false,
+                    "visible": true,
+                    "calculated": false
                   }
                 ]
               },

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,8 @@ spring:
     username: sa
     password: sa
     driver-class-name: org.h2.Driver
+    hikari:
+      connection-init-sql: "CREATE SCHEMA IF NOT EXISTS domain"
   security:
     oauth2:
       resourceserver:

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -57,7 +57,11 @@
         "name" : "reason",
         "type" : "string",
         "display" : ""
-      } ]
+      }, {
+        "name" : "is_closed",
+        "type" : "boolean",
+        "display" : ""
+      }]
     }
   } ],
   "policy": [
@@ -167,6 +171,24 @@
             "returnAsStaticOptions": true,
             "maximumOptions": 1
           }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
         }
       } ]
     },


### PR DESCRIPTION
This PR addresses https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/issues/111.
These changes fix the error when trying to filter by Boolean fields.
TestContainers were reintroduced to reproduce the failing scenario in a test as this problem was DB specific since it was occurring only on Redshift and not locally when the in memory H2 DB was used.
Therefore, using TestContainers with Postgres replicated the failure.
As TestContainers increase the build time significantly they were used only for the required test and not across all tests.