### PR TITLE
Reverse CHANGELOG.md versions order

### DIFF
--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -12,9 +12,7 @@ jobs:
   preparation:
     runs-on: ubuntu-latest
 
-    permissions:
-      pull-requests: write
-      contents: write
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -1,5 +1,7 @@
 name: PR preparation
 
+permissions: write-all
+
 on:
   pull_request:
     types:

--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      pull-requests: write
+      pull-requests: write-all
       contents: write
 
     steps:
@@ -43,6 +43,5 @@ jobs:
       - name: PR comment
         uses: thollander/actions-comment-pull-request@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment_tag: coverage
           filePath: message.txt

--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -1,7 +1,5 @@
 name: PR preparation
 
-permissions: write-all
-
 on:
   pull_request:
     types:
@@ -12,7 +10,9 @@ jobs:
   preparation:
     runs-on: ubuntu-latest
 
-    permissions: write-all
+    permissions:
+      pull-requests: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -43,5 +43,6 @@ jobs:
       - name: PR comment
         uses: thollander/actions-comment-pull-request@v2
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment_tag: coverage
           filePath: message.txt

--- a/.github/workflows/pr-raised.yml
+++ b/.github/workflows/pr-raised.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      pull-requests: write-all
+      pull-requests: write
       contents: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,10 @@
 Below you can find the changes included in each release.
 
-## v3.4.0
-Added changelog.
+## 3.7.2
+Fixed the issue in which filtering by Boolean fields would throw an error.
 
-## v3.5.0 
-Support for format_date formula. Please refer to the [integrating-with-library](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/main/integrating-with-library.md) README file for more details.
-
-## v3.5.1
-Make the report variant display field optional as there is already a fallback to the dataset display field. 
-
-## v3.5.2
-Add a 'calculated' property to the controller definition, to show whether a field value is calculated using a formula.
-
-## v3.6.0
-The library is autoconfigured and there is no longer need of a @ComponentScan annotation in the hosting application.
+## 3.7.1
+Fixed the issue in which null dates would throw an error when the `format_date` function was applied to them. 
 
 ## 3.7.0
 The JSON schema has been reconciled to the library functionality:
@@ -26,8 +17,17 @@ The JSON schema has been reconciled to the library functionality:
 - Removed report-field.type enum values: `null`, `bytes`.
 - Added support for the remaining field types. 
 
-## 3.7.1
-Fixed the issue in which null dates would throw an error when the format_date function was applied to them. 
+## v3.6.0
+The library is autoconfigured and there is no longer need of a `@ComponentScan` annotation in the hosting application.
 
-## 3.7.2
-Fixed the issue in which filtering by Boolean fields would throw an error.
+## v3.5.2
+Add a 'calculated' property to the controller definition, to show whether a field value is calculated using a formula.
+
+## v3.5.1
+Make the report variant display field optional as there is already a fallback to the dataset display field. 
+
+## v3.5.0 
+Support for `format_date` formula. Please refer to the [integrating-with-library](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/main/integrating-with-library.md) README file for more details.
+
+## v3.4.0
+Added changelog.


### PR DESCRIPTION
Generally newer versions should be on top of the file.

As time passes and the number of versions grows the information about older versions is less and less important/relevant.