### PR TITLE
Dpr2 729 no filters validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 3.7.8
+Bug fix of the asynchronous query execution which was throwing an error when no filters were provided.
+
 ## 3.7.7
 Report execution status API to get the execution status of queries which were ran asynchronously.  
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -28,7 +28,7 @@ class RedshiftDataApiRepository(
     dynamicFilterFieldId: String? = null,
     dataSourceName: String,
   ): String {
-    val statementRequest: ExecuteStatementRequest = executeStatementRequestBuilder
+    val requestBuilder = executeStatementRequestBuilder
       .sql(
         buildFinalQuery(
           buildReportQuery(query),
@@ -37,8 +37,11 @@ class RedshiftDataApiRepository(
           buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
         ),
       )
-      .parameters(buildQueryParams(filters))
-      .build()
+    if (filters.isNotEmpty()) {
+      requestBuilder
+        .parameters(buildQueryParams(filters))
+    }
+    val statementRequest: ExecuteStatementRequest = requestBuilder.build()
 
     val response: ExecuteStatementResponse = redshiftDataClient.executeStatement(statementRequest)
     log.info("Execution ID: {}", response.id())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -130,7 +130,8 @@ FROM datamart.domain.movement_movement as movements
 JOIN datamart.domain.prisoner_prisoner as prisoners
 ON movements.prisoner = prisoners.id),policy_ AS (SELECT * FROM dataset_ WHERE (origin_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='out') OR (destination_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='in')),filter_ AS (SELECT * FROM policy_ WHERE TRUE)
 SELECT *
-          FROM filter_ ORDER BY date asc;""".trimIndent()
+          FROM filter_ ORDER BY date asc;
+      """.trimIndent()
 
     val mockedBuilderWithSql = ExecuteStatementRequest.builder()
       .clusterIdentifier("ab")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
@@ -10,6 +13,7 @@ import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRespo
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
 import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
+import software.amazon.awssdk.services.redshiftdata.model.ValidationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_DATASOURCE_NAME
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_POLICY_ENGINE_RESULT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_QUERY
@@ -18,13 +22,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Stateme
 
 class RedshiftDataApiRepositoryTest {
 
-  @Test
-  fun `executeQueryAsync should call the redshift data api with the correct query and return the execution id`() {
-    val redshiftDataClient = mock<RedshiftDataClient>()
-    val executeStatementRequestBuilder = mock<ExecuteStatementRequest.Builder>()
-    val executeStatementResponse = mock<ExecuteStatementResponse>()
-    val redshiftDataApiRepository = RedshiftDataApiRepository(redshiftDataClient, executeStatementRequestBuilder)
-
+  companion object {
     val sqlStatement = """WITH dataset_ AS (SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason
 FROM datamart.domain.movement_movement as movements
 JOIN datamart.domain.prisoner_prisoner as prisoners
@@ -32,6 +30,15 @@ ON movements.prisoner = prisoners.id),policy_ AS (SELECT * FROM dataset_ WHERE (
 SELECT *
           FROM filter_ ORDER BY date asc;
     """.trimMargin()
+  }
+
+  @Test
+  fun `executeQueryAsync should call the redshift data api with the correct query and return the execution id`() {
+    val redshiftDataClient = mock<RedshiftDataClient>()
+    val executeStatementRequestBuilder = mock<ExecuteStatementRequest.Builder>()
+    val executeStatementResponse = mock<ExecuteStatementResponse>()
+    val redshiftDataApiRepository = RedshiftDataApiRepository(redshiftDataClient, executeStatementRequestBuilder)
+
     val mockedBuilderWithSql = ExecuteStatementRequest.builder()
       .clusterIdentifier("ab")
       .database("cd")
@@ -109,5 +116,63 @@ SELECT *
     val actual = redshiftDataApiRepository.getStatementStatus(statementId)
 
     assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `executeQueryAsync should call the redshift data api and not error when no filters are provided`() {
+    val redshiftDataClient = mock<RedshiftDataClient>()
+    val executeStatementRequestBuilder = mock<ExecuteStatementRequest.Builder>()
+    val executeStatementResponse = mock<ExecuteStatementResponse>()
+    val redshiftDataApiRepository = RedshiftDataApiRepository(redshiftDataClient, executeStatementRequestBuilder)
+    val finalQuery =
+      """WITH dataset_ AS (SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason
+FROM datamart.domain.movement_movement as movements
+JOIN datamart.domain.prisoner_prisoner as prisoners
+ON movements.prisoner = prisoners.id),policy_ AS (SELECT * FROM dataset_ WHERE (origin_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='out') OR (destination_code IN ('HEI','LWSTMC','NSI','LCI','TCI') AND lower(direction)='in')),filter_ AS (SELECT * FROM policy_ WHERE TRUE)
+SELECT *
+          FROM filter_ ORDER BY date asc;""".trimIndent()
+
+    val mockedBuilderWithSql = ExecuteStatementRequest.builder()
+      .clusterIdentifier("ab")
+      .database("cd")
+      .secretArn("ef")
+      .sql(finalQuery)
+
+    whenever(
+      executeStatementRequestBuilder.sql(
+        finalQuery,
+      ),
+    ).thenReturn(
+      mockedBuilderWithSql,
+    )
+
+    val queryParams = emptyList<SqlParameter>()
+    whenever(
+      executeStatementRequestBuilder.parameters(queryParams),
+    ).thenThrow(ValidationException::class.java)
+
+    whenever(
+      redshiftDataClient.executeStatement(
+        mockedBuilderWithSql.build(),
+      ),
+    ).thenReturn(executeStatementResponse)
+
+    whenever(
+      executeStatementResponse.id(),
+    ).thenReturn("someId")
+
+    val actual = redshiftDataApiRepository.executeQueryAsync(
+      query = REPOSITORY_TEST_QUERY,
+      filters = emptyList(),
+      sortColumn = "date",
+      sortedAsc = true,
+      reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID,
+      policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
+      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
+    )
+
+    verify(executeStatementRequestBuilder, times(0)).parameters(any<List<SqlParameter>>())
+
+    assertEquals("someId", actual)
   }
 }


### PR DESCRIPTION
When there were no filters provided the asynchronous query execution endpoint was throwing an error.
This PR fixes this issue.