### PR TITLE
Dpr2 730 get results endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 3.7.9
+Introduction of the API to get statement result.
+
 ## 3.7.8
 Bug fix of the asynchronous query execution which was throwing an error when no filters were provided.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -219,9 +219,9 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     }
   }
 
-  @GetMapping("/report/statements/{statementId}/result")
+  @GetMapping("/reports/{reportId}/{reportVariantId}/statements/{statementId}/result")
   @Operation(
-    description = "Returns the result of the executed statement.",
+    description = "Returns the resulting rows of the executed statement.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
     responses = [
       ApiResponse(
@@ -235,14 +235,18 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     ],
   )
   fun getQueryExecutionResult(
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
     @PathVariable("statementId") statementId: String,
     authentication: Authentication,
-  ): ResponseEntity<StatementExecutionStatus> {
+  ): ResponseEntity<List<Map<String, Any?>>> {
     return try {
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          configuredApiService.getStatementResult(statementId),
+          configuredApiService.getStatementResult(statementId, reportId, reportVariantId, dataProductDefinitionsPath),
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -3,20 +3,17 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
+import software.amazon.awssdk.services.redshiftdata.model.ColumnMetadata
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
-import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
 import software.amazon.awssdk.services.redshiftdata.model.Field
 import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequest
 import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultResponse
-import software.amazon.awssdk.services.redshiftdata.model.ColumnMetadata
+import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StatementExecutionStatus
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-
-
-
 
 @Service
 class RedshiftDataApiRepository(
@@ -88,7 +85,7 @@ class RedshiftDataApiRepository(
       "varchar" -> field.stringValue()
       "int8" -> field.longValue()
       "timestamp" -> LocalDateTime.parse(field.stringValue(), formatter)
-      //This will need to be extended to support more date types when required in the future.
+      // This will need to be extended to support more date types when required in the future.
       else -> field.stringValue()
     }
     return columnMetadata.name() to value

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -105,8 +105,17 @@ class ConfiguredApiService(
     return redshiftDataApiRepository.getStatementStatus(statementId)
   }
 
-  fun getStatementResult(statementId: String): StatementExecutionStatus {
-    return redshiftDataApiRepository.getStatementStatus(statementId)
+  fun getStatementResult(
+    statementId: String,
+    reportId: String,
+    reportVariantId: String,
+    dataProductDefinitionsPath: String? = null,
+  ): List<Map<String, Any?>> {
+    val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
+    val formulaEngine = FormulaEngine(productDefinition.report.specification?.field ?: emptyList(), env)
+    return redshiftDataApiRepository.getStatementResult(statementId)
+      .map { row -> formatColumnNamesToSchemaFieldNamesCasing(row, productDefinition) }
+      .map(formulaEngine::applyFormulas)
   }
 
   private fun formatColumnNamesToSchemaFieldNamesCasing(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -105,6 +105,10 @@ class ConfiguredApiService(
     return redshiftDataApiRepository.getStatementStatus(statementId)
   }
 
+  fun getStatementResult(statementId: String): StatementExecutionStatus {
+    return redshiftDataApiRepository.getStatementStatus(statementId)
+  }
+
   private fun formatColumnNamesToSchemaFieldNamesCasing(
     row: Map<String, Any?>,
     productDefinition: SingleReportProductDefinition,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -8,14 +8,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
+import software.amazon.awssdk.services.redshiftdata.model.ColumnMetadata
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementResponse
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
-import software.amazon.awssdk.services.redshiftdata.model.ColumnMetadata
 import software.amazon.awssdk.services.redshiftdata.model.Field
-import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultResponse
 import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequest
+import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultResponse
 import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
 import software.amazon.awssdk.services.redshiftdata.model.ValidationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_DATASOURCE_NAME
@@ -210,7 +210,7 @@ SELECT *
       Field.builder().stringValue("STHEMC").build(),
       Field.builder().stringValue("St. Helens Magistrates Court").build(),
       Field.builder().stringValue("Production (Sentence/Civil Custody)").build(),
-      )
+    )
     val movementPrisoner2 = mapOf("id" to "227482.1", "prisoner" to 227482L, "date" to LocalDateTime.of(2010, 12, 8, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 8, 10, 8, 0), "direction" to "IN", "type" to "ADM", "origin_code" to "IMM", "origin" to "Immigration", "destination_code" to "HRI", "destination" to "Haslar Immigration Removal Centre", "reason" to "Detained Immigration Act 71 -Wait Deport")
     val movementPrisoner2Fields = listOf<Field>(
       Field.builder().stringValue("227482.1").build(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -141,7 +141,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/report/status/$queryExecutionId")
+          .path("/report/statements/$queryExecutionId/status")
           .build()
       }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))


### PR DESCRIPTION
These changes create a new endpoint to get the executed statement results.
Note: This does not include pagination at this point.

Documentation References: 
https://docs.aws.amazon.com/cli/latest/reference/redshift-data/get-statement-result.html
https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_GetStatementResult.html
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/redshiftdata/RedshiftDataClient.html#getStatementResult(software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequest)

