### PR TITLE
Dpr2 758 Make use of nextToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Below you can find the changes included in each release.
 
 ## 3.7.10
+Added nextToken query parameter to the getQueryExecutionResult endpoint and 
+changed the response of the endpoint to contain the nextToken if it exists to support
+pagination.
+
+## 3.7.10
 Bug fix of the error thrown when the filters in the request contained dots. 
 
 ## 3.7.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Below you can find the changes included in each release.
 
-## 3.7.10
+## 3.7.11
 Added nextToken query parameter to the getQueryExecutionResult endpoint and 
 changed the response of the endpoint to contain the nextToken if it exists to support
 pagination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Below you can find the changes included in each release.
 Added nextToken query parameter to the getQueryExecutionResult endpoint and 
 changed the response of the endpoint to contain the nextToken if it exists to support
 pagination.
+Added resultSize to the StatementExecutionStatus response.
 
 ## 3.7.10
 Bug fix of the error thrown when the filters in the request contained dots. 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -22,7 +22,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.Configu
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
@@ -240,13 +241,22 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     @PathVariable("statementId") statementId: String,
+    @Parameter(
+      description = "A value that indicates the starting point for the next set of response records in a subsequent request. " +
+        "If a value is returned in a response, you can retrieve the next set of records by providing this returned NextToken value in " +
+        "the next nextToken query parameter and retrying the API call. " +
+        "If the nextToken field is empty, all response records have been retrieved for the request.",
+      example = "aa37926e-e40a-43ce-a553-ec015ecec52e",
+    )
+    @RequestParam("nextToken", required = false)
+    nextToken: String?,
     authentication: Authentication,
-  ): ResponseEntity<List<Map<String, Any?>>> {
+  ): ResponseEntity<StatementResult> {
     return try {
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          configuredApiService.getStatementResult(statementId, reportId, reportVariantId, dataProductDefinitionsPath),
+          configuredApiService.getStatementResult(statementId, reportId, reportVariantId, dataProductDefinitionsPath, nextToken),
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -186,7 +186,9 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       "PICKED - The query has been chosen to be run.\n" +
       "STARTED - The query run has started.\n" +
       "SUBMITTED - The query was submitted, but not yet processed.\n" +
-      "Note: When the status is FAILED the error field of the response will be populated.",
+      "Note: When the status is FAILED the error field of the response will be populated." +
+      "ResultRows is the number of rows returned from the SQL statement. A -1 indicates the value is null." +
+      "ResultSize is the size in bytes of the returned results. A -1 indicates the value is null.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -62,10 +62,11 @@ class RedshiftDataApiRepository(
     val describeStatementResponse = redshiftDataClient.describeStatement(statementRequest)
     return StatementExecutionStatus(
       status = describeStatementResponse.statusAsString(),
-      error = describeStatementResponse.error(),
       duration = describeStatementResponse.duration(),
       queryString = describeStatementResponse.queryString(),
       resultRows = describeStatementResponse.resultRows(),
+      resultSize = describeStatementResponse.resultSize(),
+      error = describeStatementResponse.error(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -6,7 +6,7 @@ data class StatementExecutionStatus(
   val duration: Long,
   val queryString: String,
   val resultRows: Long,
-  //Size of the results in bytes.
+  // Size of the results in bytes.
   val resultSize: Long?,
   val error: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata
 
 data class StatementExecutionStatus(
   val status: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -6,5 +6,7 @@ data class StatementExecutionStatus(
   val duration: Long,
   val queryString: String,
   val resultRows: Long,
+  //Size of the results in bytes.
+  val resultSize: Long?,
   val error: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -6,7 +6,7 @@ data class StatementExecutionStatus(
   val duration: Long,
   val queryString: String,
   val resultRows: Long,
-  // Size of the results in bytes.
+  // The size in bytes of the returned results. A -1 indicates the value is null.
   val resultSize: Long?,
   val error: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementResult.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata
+
+data class StatementResult(
+  val records: List<Map<String, Any?>>,
+  val nextToken: String? = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -222,11 +222,13 @@ SELECT *
     val duration = 278109264L
     val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
     val resultRows = 10L
+    val resultSize = 100L
     val executeStatementResponse = DescribeStatementResponse.builder()
       .status(status)
       .duration(duration)
       .queryString(query)
       .resultRows(resultRows)
+      .resultSize(resultSize)
       .build()
 
     whenever(
@@ -242,6 +244,7 @@ SELECT *
       duration,
       query,
       resultRows,
+      resultSize,
     )
     val actual = redshiftDataApiRepository.getStatementStatus(statementId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -25,7 +25,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_QUERY
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.Companion.EXTERNAL_MOVEMENTS_PRODUCT_ID
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import java.time.LocalDateTime
 
 class RedshiftDataApiRepositoryTest {
@@ -38,6 +39,48 @@ ON movements.prisoner = prisoners.id),policy_ AS (SELECT * FROM dataset_ WHERE (
 SELECT *
           FROM filter_ ORDER BY date asc;
     """.trimMargin()
+
+    val columnMetadata = listOf<ColumnMetadata>(
+      ColumnMetadata.builder().name("id").typeName("varchar").build(),
+      ColumnMetadata.builder().name("prisoner").typeName("int8").build(),
+      ColumnMetadata.builder().name("date").typeName("timestamp").build(),
+      ColumnMetadata.builder().name("time").typeName("timestamp").build(),
+      ColumnMetadata.builder().name("direction").typeName("varchar").build(),
+      ColumnMetadata.builder().name("type").typeName("varchar").build(),
+      ColumnMetadata.builder().name("origin_code").typeName("varchar").build(),
+      ColumnMetadata.builder().name("origin").typeName("varchar").build(),
+      ColumnMetadata.builder().name("destination_code").typeName("varchar").build(),
+      ColumnMetadata.builder().name("destination").typeName("varchar").build(),
+      ColumnMetadata.builder().name("reason").typeName("varchar").build(),
+    )
+    val movementPrisoner1 = mapOf("id" to "171034.12", "prisoner" to 171034L, "date" to LocalDateTime.of(2010, 12, 17, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 17, 7, 12, 0), "direction" to "OUT", "type" to "CRT", "origin_code" to "LFI", "origin" to "LANCASTER FARMS (HMPYOI)", "destination_code" to "STHEMC", "destination" to "St. Helens Magistrates Court", "reason" to "Production (Sentence/Civil Custody)")
+    val movementPrisoner1Fields = listOf<Field>(
+      Field.builder().stringValue("171034.12").build(),
+      Field.builder().longValue(171034).build(),
+      Field.builder().stringValue("2010-12-17 00:00:00").build(),
+      Field.builder().stringValue("2010-12-17 07:12:00").build(),
+      Field.builder().stringValue("OUT").build(),
+      Field.builder().stringValue("CRT").build(),
+      Field.builder().stringValue("LFI").build(),
+      Field.builder().stringValue("LANCASTER FARMS (HMPYOI)").build(),
+      Field.builder().stringValue("STHEMC").build(),
+      Field.builder().stringValue("St. Helens Magistrates Court").build(),
+      Field.builder().stringValue("Production (Sentence/Civil Custody)").build(),
+    )
+    val movementPrisoner2 = mapOf("id" to "227482.1", "prisoner" to 227482L, "date" to LocalDateTime.of(2010, 12, 8, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 8, 10, 8, 0), "direction" to "IN", "type" to "ADM", "origin_code" to "IMM", "origin" to "Immigration", "destination_code" to "HRI", "destination" to "Haslar Immigration Removal Centre", "reason" to "Detained Immigration Act 71 -Wait Deport")
+    val movementPrisoner2Fields = listOf<Field>(
+      Field.builder().stringValue("227482.1").build(),
+      Field.builder().longValue(227482).build(),
+      Field.builder().stringValue("2010-12-08 00:00:00").build(),
+      Field.builder().stringValue("2010-12-08 10:08:00").build(),
+      Field.builder().stringValue("IN").build(),
+      Field.builder().stringValue("ADM").build(),
+      Field.builder().stringValue("IMM").build(),
+      Field.builder().stringValue("Immigration").build(),
+      Field.builder().stringValue("HRI").build(),
+      Field.builder().stringValue("Haslar Immigration Removal Centre").build(),
+      Field.builder().stringValue("Detained Immigration Act 71 -Wait Deport").build(),
+    )
   }
 
   @Test
@@ -266,47 +309,6 @@ SELECT *
 
   @Test
   fun `getStatementResult should call the Redshift Data API and return the existing results`() {
-    val columnMetadata = listOf<ColumnMetadata>(
-      ColumnMetadata.builder().name("id").typeName("varchar").build(),
-      ColumnMetadata.builder().name("prisoner").typeName("int8").build(),
-      ColumnMetadata.builder().name("date").typeName("timestamp").build(),
-      ColumnMetadata.builder().name("time").typeName("timestamp").build(),
-      ColumnMetadata.builder().name("direction").typeName("varchar").build(),
-      ColumnMetadata.builder().name("type").typeName("varchar").build(),
-      ColumnMetadata.builder().name("origin_code").typeName("varchar").build(),
-      ColumnMetadata.builder().name("origin").typeName("varchar").build(),
-      ColumnMetadata.builder().name("destination_code").typeName("varchar").build(),
-      ColumnMetadata.builder().name("destination").typeName("varchar").build(),
-      ColumnMetadata.builder().name("reason").typeName("varchar").build(),
-    )
-    val movementPrisoner1 = mapOf("id" to "171034.12", "prisoner" to 171034L, "date" to LocalDateTime.of(2010, 12, 17, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 17, 7, 12, 0), "direction" to "OUT", "type" to "CRT", "origin_code" to "LFI", "origin" to "LANCASTER FARMS (HMPYOI)", "destination_code" to "STHEMC", "destination" to "St. Helens Magistrates Court", "reason" to "Production (Sentence/Civil Custody)")
-    val movementPrisoner1Fields = listOf<Field>(
-      Field.builder().stringValue("171034.12").build(),
-      Field.builder().longValue(171034).build(),
-      Field.builder().stringValue("2010-12-17 00:00:00").build(),
-      Field.builder().stringValue("2010-12-17 07:12:00").build(),
-      Field.builder().stringValue("OUT").build(),
-      Field.builder().stringValue("CRT").build(),
-      Field.builder().stringValue("LFI").build(),
-      Field.builder().stringValue("LANCASTER FARMS (HMPYOI)").build(),
-      Field.builder().stringValue("STHEMC").build(),
-      Field.builder().stringValue("St. Helens Magistrates Court").build(),
-      Field.builder().stringValue("Production (Sentence/Civil Custody)").build(),
-    )
-    val movementPrisoner2 = mapOf("id" to "227482.1", "prisoner" to 227482L, "date" to LocalDateTime.of(2010, 12, 8, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 8, 10, 8, 0), "direction" to "IN", "type" to "ADM", "origin_code" to "IMM", "origin" to "Immigration", "destination_code" to "HRI", "destination" to "Haslar Immigration Removal Centre", "reason" to "Detained Immigration Act 71 -Wait Deport")
-    val movementPrisoner2Fields = listOf<Field>(
-      Field.builder().stringValue("227482.1").build(),
-      Field.builder().longValue(227482).build(),
-      Field.builder().stringValue("2010-12-08 00:00:00").build(),
-      Field.builder().stringValue("2010-12-08 10:08:00").build(),
-      Field.builder().stringValue("IN").build(),
-      Field.builder().stringValue("ADM").build(),
-      Field.builder().stringValue("IMM").build(),
-      Field.builder().stringValue("Immigration").build(),
-      Field.builder().stringValue("HRI").build(),
-      Field.builder().stringValue("Haslar Immigration Removal Centre").build(),
-      Field.builder().stringValue("Detained Immigration Act 71 -Wait Deport").build(),
-    )
     val redshiftDataClient = mock<RedshiftDataClient>()
     val redshiftDataApiRepository = RedshiftDataApiRepository(redshiftDataClient, mock())
     val statementId = "statementId"
@@ -323,8 +325,36 @@ SELECT *
       ),
     ).thenReturn(resultStatementResponse)
 
-    val expected = listOf<Map<String, Any?>>(movementPrisoner1, movementPrisoner2)
+    val expected = StatementResult(listOf<Map<String, Any?>>(movementPrisoner1, movementPrisoner2))
     val actual = redshiftDataApiRepository.getStatementResult(statementId)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `getStatementResult should call the Redshift Data API with a request containing a nextToken when a nextToken exists`() {
+    val redshiftDataClient = mock<RedshiftDataClient>()
+    val redshiftDataApiRepository = RedshiftDataApiRepository(redshiftDataClient, mock())
+    val statementId = "statementId"
+    val nextTokenRequest = "batch1"
+    val nextTokenResponse = "batch2"
+    val resultStatementResponse = GetStatementResultResponse.builder()
+      .columnMetadata(columnMetadata)
+      .records(listOf(movementPrisoner1Fields, movementPrisoner2Fields))
+      .nextToken(nextTokenResponse)
+      .build()
+
+    whenever(
+      redshiftDataClient.getStatementResult(
+        GetStatementResultRequest.builder()
+          .id(statementId)
+          .nextToken(nextTokenRequest)
+          .build(),
+      ),
+    ).thenReturn(resultStatementResponse)
+
+    val expected = StatementResult(listOf<Map<String, Any?>>(movementPrisoner1, movementPrisoner2), nextTokenResponse)
+    val actual = redshiftDataApiRepository.getStatementResult(statementId, nextTokenRequest)
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -14,7 +14,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.Configu
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
 
@@ -175,17 +176,22 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Calling the getStatementResult endpoint calls the configuredApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
-    val expectedServiceResult = listOf(
-      mapOf(
-        "prisonNumber" to "1",
-        "name" to "FirstName",
-        "date" to "2023-05-20",
-        "origin" to "OriginLocation",
-        "destination" to "DestinationLocation",
-        "direction" to "in",
-        "type" to "trn",
-        "reason" to "normal transfer",
+    val requestNextToken = "requestNextToken"
+    val responseNextToken = "responseNextToken"
+    val expectedServiceResult = StatementResult(
+      listOf(
+        mapOf(
+          "prisonNumber" to "1",
+          "name" to "FirstName",
+          "date" to "2023-05-20",
+          "origin" to "OriginLocation",
+          "destination" to "DestinationLocation",
+          "direction" to "in",
+          "type" to "trn",
+          "reason" to "normal transfer",
+        ),
       ),
+      responseNextToken,
     )
     given(
       configuredApiService.getStatementResult(
@@ -193,6 +199,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq("external-movements"),
         eq("last-month"),
         eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
+        eq(requestNextToken),
       ),
     )
       .willReturn(expectedServiceResult)
@@ -201,6 +208,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/reports/external-movements/last-month/statements/$queryExecutionId/result")
+          .queryParam("nextToken", requestNextToken)
           .build()
       }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -137,11 +137,13 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     val duration = 278109264L
     val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
     val resultRows = 10L
+    val resultSize = 100L
     val statementExecutionStatus = StatementExecutionStatus(
       status,
       duration,
       query,
       resultRows,
+      resultSize,
     )
     given(
       configuredApiService.getStatementStatus(
@@ -167,6 +169,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
           "duration": $duration,
           "queryString": "$query",
           "resultRows": $resultRows,
+          "resultSize": $resultSize,
           "error": null
         }
       """,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -1199,11 +1199,13 @@ class ConfiguredApiServiceTest {
     val duration = 278109264L
     val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
     val resultRows = 10L
+    val resultSize = 100L
     val statementExecutionStatus = StatementExecutionStatus(
       status,
       duration,
       query,
       resultRows,
+      resultSize,
     )
     whenever(
       redshiftDataApiRepository.getStatementStatus(statementId),


### PR DESCRIPTION
These changes include:
- Addition of nextToken request and response parameters to the getStatementResult endpoint to support pagination as described in the [AWS docs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/redshiftdata/RedshiftDataClient.html#getStatementResult(software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequest)).
- Added the resultSize field to the StatementExecutionStatus response.