### PR TITLE
Dpr2 758 Pagination through use of external tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+## 4.0.0
+The asynchronous Redshift endpoint executes the DPD query and the results are stored into an external table.
+The endpoint to retrieve the results queries that table and allows for pagination.
+
 ## 3.7.11
 Added nextToken query parameter to the getQueryExecutionResult endpoint and 
 changed the response of the endpoint to contain the nextToken if it exists to support

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.Configu
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
@@ -117,8 +118,9 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
 
   @GetMapping("/async/reports/{reportId}/{reportVariantId}")
   @Operation(
-    description = "Executes asynchronously the dataset query for the given report and returns the execution ID. " +
-      "This is the asynchronous non-paginated version of the /reports/{reportId}/{reportVariantId} API.",
+    description = "Executes asynchronously the dataset query for the given report and stores the result into an external table." +
+      "The response returned contains the table ID and the execution ID. " +
+      "This is the asynchronous version of the /reports/{reportId}/{reportVariantId} API.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
     responses = [
       ApiResponse(
@@ -149,7 +151,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
-  ): ResponseEntity<String> {
+  ): ResponseEntity<StatementExecutionResponse> {
     return try {
       ResponseEntity
         .status(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -38,7 +38,7 @@ class ConfiguredApiRepository : RepositoryHelper() {
         buildPolicyQuery(policyEngineResult),
         buildFiltersQuery(filters),
         buildFinalStageQueryWithPagination(dynamicFilterFieldId, sortColumn, sortedAsc, pageSize, selectedPage),
-      ),
+      ) + ";",
       buildPreparedStatementNamedParams(filters),
     )
       .map {
@@ -86,7 +86,7 @@ class ConfiguredApiRepository : RepositoryHelper() {
         buildPolicyQuery(policyEngineResult),
         buildFiltersQuery(filters),
         "SELECT COUNT(1) as total FROM $FILTER_",
-      ),
+      ) + ";",
       buildPreparedStatementNamedParams(filters),
     ).first()?.get("total") as Long
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -1,19 +1,11 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
 import org.apache.commons.lang3.time.StopWatch
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationContext
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
-import java.sql.Timestamp
-import javax.sql.DataSource
 
 @Service
 class ConfiguredApiRepository : RepositoryHelper() {
-
-  @Autowired
-  lateinit var context: ApplicationContext
 
   fun executeQuery(
     query: String,
@@ -49,17 +41,6 @@ class ConfiguredApiRepository : RepositoryHelper() {
     return result
   }
 
-  private fun populateJdbcTemplate(dataSourceName: String): NamedParameterJdbcTemplate {
-    val dataSource = if (context.containsBean(dataSourceName)) {
-      context.getBean(dataSourceName, DataSource::class) as DataSource
-    } else {
-      log.warn("No DataSource Bean found with name: {}", dataSourceName)
-      context.getBean(DataSource::class.java) as DataSource
-    }
-
-    return NamedParameterJdbcTemplate(dataSource)
-  }
-
   private fun buildFinalStageQueryWithPagination(
     dynamicFilterFieldId: String?,
     sortColumn: String?,
@@ -89,14 +70,6 @@ class ConfiguredApiRepository : RepositoryHelper() {
       ) + ";",
       buildPreparedStatementNamedParams(filters),
     ).first()?.get("total") as Long
-  }
-
-  private fun transformTimestampToLocalDateTime(it: MutableMap<String, Any>) = it.entries.associate { (k, v) ->
-    if (v is Timestamp) {
-      k to v.toLocalDateTime()
-    } else {
-      k to v
-    }
   }
 
   private fun buildPreparedStatementNamedParams(filters: List<Filter>): MapSqlParameterSource {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
@@ -56,6 +56,12 @@ class ProductDefinitionRepositoryAutoConfig(
     .concurrencyLevel(Runtime.getRuntime().availableProcessors())
     .build()
 
+  @Bean("tableIdToStatementIdCache")
+  fun tableIdToStatementIdCache(): Cache<String, String> = CacheBuilder.newBuilder()
+    .expireAfterWrite(24, TimeUnit.HOURS)
+    .concurrencyLevel(Runtime.getRuntime().availableProcessors())
+    .build()
+
   @Bean
   @ConditionalOnMissingBean(LocalDateTimeTypeAdaptor::class)
   fun localDateTimeTypeAdaptor(): LocalDateTimeTypeAdaptor {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ProductDefinitionRepositoryAutoConfig.kt
@@ -56,12 +56,6 @@ class ProductDefinitionRepositoryAutoConfig(
     .concurrencyLevel(Runtime.getRuntime().availableProcessors())
     .build()
 
-  @Bean("tableIdToStatementIdCache")
-  fun tableIdToStatementIdCache(): Cache<String, String> = CacheBuilder.newBuilder()
-    .expireAfterWrite(24, TimeUnit.HOURS)
-    .concurrencyLevel(Runtime.getRuntime().availableProcessors())
-    .build()
-
   @Bean
   @ConditionalOnMissingBean(LocalDateTimeTypeAdaptor::class)
   fun localDateTimeTypeAdaptor(): LocalDateTimeTypeAdaptor {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
-import com.google.common.cache.Cache
 import org.apache.commons.lang3.time.StopWatch
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -25,7 +24,6 @@ import java.time.format.DateTimeFormatter
 class RedshiftDataApiRepository(
   val redshiftDataClient: RedshiftDataClient,
   val executeStatementRequestBuilder: ExecuteStatementRequest.Builder,
-  val tableIdToStatementIdCache: Cache<String, String>,
   val tableIdGenerator: TableIdGenerator,
   @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
   private val s3location: String = "dpr-working-development/reports",
@@ -71,7 +69,6 @@ class RedshiftDataApiRepository(
     val statementRequest: ExecuteStatementRequest = requestBuilder.build()
 
     val response: ExecuteStatementResponse = redshiftDataClient.executeStatement(statementRequest)
-    tableIdToStatementIdCache.put(tableId, response.id())
     log.debug("Execution ID: {}", response.id())
     log.debug("External table ID: {}", tableId)
     return StatementExecutionResponse(tableId, response.id())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
@@ -21,7 +21,7 @@ abstract class RepositoryHelper {
     filtersQuery: String,
     selectFromFinalStageQuery: String,
   ): String {
-    val query = listOf(reportQuery, policiesQuery, filtersQuery).joinToString(",") + "\n$selectFromFinalStageQuery;"
+    val query = listOf(reportQuery, policiesQuery, filtersQuery).joinToString(",") + "\n$selectFromFinalStageQuery"
     log.debug("Database query: $query")
     return query
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata
+
+data class StatementExecutionResponse(
+  val tableId: String,
+  val executionId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Paramet
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
@@ -84,7 +85,7 @@ class ConfiguredApiService(
     reportFieldId: String? = null,
     prefix: String? = null,
     dataProductDefinitionsPath: String? = null,
-  ): String {
+  ): StatementExecutionResponse {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaF
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
@@ -107,18 +106,19 @@ class ConfiguredApiService(
   }
 
   fun getStatementResult(
-    statementId: String,
+    tableId: String,
     reportId: String,
     reportVariantId: String,
     dataProductDefinitionsPath: String? = null,
-    nextToken: String? = null,
-  ): StatementResult {
+    selectedPage: Long,
+    pageSize: Long,
+  ): List<Map<String, Any?>> {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val formulaEngine = FormulaEngine(productDefinition.report.specification?.field ?: emptyList(), env)
-    val statementResult = redshiftDataApiRepository.getStatementResult(statementId, nextToken)
-    return StatementResult(
-      formatColumnsAndApplyFormulas(statementResult.records, productDefinition, formulaEngine),
-      statementResult.nextToken,
+    return formatColumnsAndApplyFormulas(
+      redshiftDataApiRepository.getPaginatedExternalTableResult(tableId, selectedPage, pageSize),
+      productDefinition,
+      formulaEngine,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGenerator.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class TableIdGenerator {
+
+  fun generateNewExternalTableId(): String {
+    return "_" + UUID.randomUUID().toString().replace("-", "_")
+  }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionS
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RedshiftDataApiRepository
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DigitalPrisonReportingExceptionHandler
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
-import com.google.common.cache.Cache
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -52,8 +51,6 @@ class RedshiftDataApiRepositoryTest {
     val movementPrisoner2 = mapOf("id" to "227482.1", "prisoner" to 227482L, "date" to LocalDateTime.of(2010, 12, 8, 0, 0, 0), "time" to LocalDateTime.of(2010, 12, 8, 10, 8, 0), "direction" to "IN", "type" to "ADM", "origin_code" to "IMM", "origin" to "Immigration", "destination_code" to "HRI", "destination" to "Haslar Immigration Removal Centre", "reason" to "Detained Immigration Act 71 -Wait Deport")
   }
 
-  private val tableIdToStatementIdCache: Cache<String, String> = mock()
-
   @Test
   fun `executeQueryAsync should call the redshift data api with the correct query and return the execution id`() {
     val redshiftDataClient = mock<RedshiftDataClient>()
@@ -65,7 +62,6 @@ class RedshiftDataApiRepositoryTest {
     val redshiftDataApiRepository = RedshiftDataApiRepository(
       redshiftDataClient,
       executeStatementRequestBuilder,
-      tableIdToStatementIdCache,
       tableIdGenerator,
     )
 
@@ -150,7 +146,6 @@ SELECT *
     val redshiftDataApiRepository = RedshiftDataApiRepository(
       redshiftDataClient,
       executeStatementRequestBuilder,
-      tableIdToStatementIdCache,
       tableIdGenerator,
     )
 
@@ -226,7 +221,6 @@ SELECT *
     val redshiftDataApiRepository = RedshiftDataApiRepository(
       redshiftDataClient,
       mock(),
-      tableIdToStatementIdCache,
       tableIdGenerator,
     )
     val statementId = "statementId"
@@ -272,7 +266,6 @@ SELECT *
     val redshiftDataApiRepository = RedshiftDataApiRepository(
       redshiftDataClient,
       executeStatementRequestBuilder,
-      tableIdToStatementIdCache,
       tableIdGenerator,
     )
     val tableId = "_a6227417_bdac_40bb_bc81_49c750daacd7"
@@ -351,7 +344,6 @@ SELECT *
     val redshiftDataApiRepository = RedshiftDataApiRepository(
       redshiftDataClient,
       mock(),
-      tableIdToStatementIdCache,
       tableIdGenerator,
     )
     val selectedPage = 1L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportD
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
 
@@ -187,10 +186,10 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Calling the getStatementResult endpoint calls the configuredApiService with the correct arguments`() {
-    val queryExecutionId = "queryExecutionId"
-    val requestNextToken = "requestNextToken"
-    val responseNextToken = "responseNextToken"
-    val expectedServiceResult = StatementResult(
+    val tableId = "tableId"
+    val selectedPage = 2L
+    val pageSize = 20L
+    val expectedServiceResult =
       listOf(
         mapOf(
           "prisonNumber" to "1",
@@ -202,16 +201,16 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
           "type" to "trn",
           "reason" to "normal transfer",
         ),
-      ),
-      responseNextToken,
-    )
+      )
+
     given(
       configuredApiService.getStatementResult(
-        eq(queryExecutionId),
+        eq(tableId),
         eq("external-movements"),
         eq("last-month"),
         eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
-        eq(requestNextToken),
+        eq(selectedPage),
+        eq(pageSize),
       ),
     )
       .willReturn(expectedServiceResult)
@@ -219,8 +218,9 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/reports/external-movements/last-month/statements/$queryExecutionId/result")
-          .queryParam("nextToken", requestNextToken)
+          .path("/reports/external-movements/last-month/tables/$tableId/result")
+          .queryParam("selectedPage", 2L)
+          .queryParam("pageSize", 20L)
           .build()
       }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.Configu
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
@@ -30,6 +31,8 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Calling the async execute statement endpoint calls the configuredApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
+    val tableId = "tableId"
+    val statementExecutionResponse = StatementExecutionResponse(tableId, queryExecutionId)
     val filtersPrefix = "filters."
     val dateStartFilter = "date$RANGE_FILTER_START_SUFFIX"
     val dateEndFilter = "date$RANGE_FILTER_END_SUFFIX"
@@ -48,7 +51,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq("definitions/prisons/orphanage"),
       ),
     )
-      .willReturn(queryExecutionId)
+      .willReturn(statementExecutionResponse)
 
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -64,8 +67,14 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isOk()
-      .expectBody(String::class.java)
-      .isEqualTo(queryExecutionId)
+      .expectBody()
+      .json(
+        """{
+          "tableId": "$tableId",
+          "executionId": "$queryExecutionId"
+        }
+      """,
+      )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policye
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_PERMIT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Rule
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
@@ -1165,7 +1166,9 @@ class ConfiguredApiServiceTest {
     val sortedAsc = true
     val dataSet = productDefinitionRepository.getProductDefinitions().first().dataset.first()
     val dataSourceName = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId).datasource.name
-    val executionID = UUID.randomUUID().toString()
+    val executionId = UUID.randomUUID().toString()
+    val tableId = executionId.replace("-", "_")
+    val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     whenever(
       redshiftDataApiRepository.executeQueryAsync(
         query = dataSet.query,
@@ -1176,7 +1179,7 @@ class ConfiguredApiServiceTest {
         policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
       ),
-    ).thenReturn(executionID)
+    ).thenReturn(statementExecutionResponse)
 
     val actual = configuredApiService.validateAndExecuteStatementAsync(reportId, reportVariantId, filters, sortColumn, sortedAsc, authToken)
 
@@ -1189,7 +1192,7 @@ class ConfiguredApiServiceTest {
       policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
     )
-    assertEquals(executionID, actual)
+    assertEquals(statementExecutionResponse, actual)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGeneratorTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 
 class TableIdGeneratorTest {
   @Test
-  fun `generateExternalTableId generates a table UUID starting with an underscore and contains underscores instead of hyphens`() {
+  fun `generateExternalTableId generates a table UUID starting with an underscore and containing underscores instead of hyphens`() {
     val tableIdGenerator = TableIdGenerator()
     val tableId = tableIdGenerator.generateNewExternalTableId()
     assertThat(tableId).startsWith("_")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGeneratorTest.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TableIdGeneratorTest {
+  @Test
+  fun `generateExternalTableId generates a table UUID starting with an underscore and contains underscores instead of hyphens`() {
+    val tableIdGenerator = TableIdGenerator()
+    val tableId = tableIdGenerator.generateNewExternalTableId()
+    assertThat(tableId).startsWith("_")
+    assertThat(tableId).doesNotContain("-")
+    assertThat(tableId).hasSize(37)
+  }
+}


### PR DESCRIPTION
This PR changes the functionality of the endpoint for asynchronous query execution.
The result of the query is now stored in an external table and the endpoint returns the table ID and the statement execution ID.
The results endpoint now accepts a table ID path parameter and a pageSize and selectedPage query parameters which allow for pagination.
It also runs a synchronous query using the JDBCTemplate.