### PR TITLE
Dpr2 790 async athena reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Below you can find the changes included in each release.
 
+## 4.2.0
+Added functionality to call the Athena API to start the query execution and retrieve the execution status for nomis and bodmis reports based on the datasource name.
+Existing datamart reports will run against the Redshift Data API.
+Filters are not supported yet for nomis and bodmis reports as part of this release.\
+The `/report/statements/{statementId}/status` endpoint has changed to
+`/reports/{reportId}/{reportVariantId}/statements/{statementId}/status`
+
 ## 4.1.0
 Added count endpoint for the created external tables.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Below you can find the changes included in each release.
 
 ## 4.2.0
+New AthenaAPIRepository which queries Athena.\
 Added functionality to call the Athena API to start the query execution and retrieve the execution status for nomis and bodmis reports based on the datasource name.
 Existing datamart reports will run against the Redshift Data API.
 Filters are not supported yet for nomis and bodmis reports as part of this release.\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Below you can find the changes included in each release.
 
 ## 4.2.0
 New AthenaAPIRepository which queries Athena.\
+Datasource supports two new optional fields: database and catalog.\
 Added functionality to call the Athena API to start the query execution and retrieve the execution status for nomis and bodmis reports based on the datasource name.
 Existing datamart reports will run against the Redshift Data API.
 Filters are not supported yet for nomis and bodmis reports as part of this release.\

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation("com.google.guava:guava:33.2.0-jre")
   // https://mvnrepository.com/artifact/software.amazon.awssdk/redshiftdata
   implementation("software.amazon.awssdk:redshiftdata:2.25.44")
+  implementation("software.amazon.awssdk:athena:2.25.61")
 
   // Swagger
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.athena.AthenaClient
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.RedshiftDataRequest
@@ -21,6 +22,15 @@ class RedshiftDataApiConfig(
   fun redshiftDataClient(): RedshiftDataClient {
     return RedshiftDataClient.builder()
       .region(Region.EU_WEST_2)
+      .build()
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(AthenaClient::class)
+  fun athenaClient(): AthenaClient {
+    val region = Region.EU_WEST_2
+    return AthenaClient.builder()
+      .region(region)
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -189,7 +189,10 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       "SUBMITTED - The query was submitted, but not yet processed.\n" +
       "Note: When the status is FAILED the error field of the response will be populated." +
       "ResultRows is the number of rows returned from the SQL statement. A -1 indicates the value is null." +
-      "ResultSize is the size in bytes of the returned results. A -1 indicates the value is null.",
+      "ResultSize is the size in bytes of the returned results. A -1 indicates the value is null.\n" +
+      "For Athena: \n" +
+      "Athena automatically retries your queries in cases of certain transient errors. " +
+      "As a result, you may see the query state transition from STARTED or FAILED to SUBMITTED.\n",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/ConfiguredApiController.kt
@@ -176,7 +176,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     }
   }
 
-  @GetMapping("/report/statements/{statementId}/status")
+  @GetMapping("/reports/{reportId}/{reportVariantId}/statements/{statementId}/status")
   @Operation(
     description = "Returns the status of the statement execution based on the statement ID provided." +
       "The following status values can be returned: \n" +
@@ -206,14 +206,22 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     ],
   )
   fun getQueryExecutionStatus(
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
     @PathVariable("statementId") statementId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
     authentication: Authentication,
   ): ResponseEntity<StatementExecutionStatus> {
     return try {
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          configuredApiService.getStatementStatus(statementId),
+          configuredApiService.getStatementStatus(statementId, reportId, reportVariantId, dataProductDefinitionsPath),
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.apache.commons.lang3.time.StopWatch
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+
+abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  abstract fun executeQueryAsync(
+    query: String,
+    filters: List<ConfiguredApiRepository.Filter>,
+    sortColumn: String?,
+    sortedAsc: Boolean,
+    policyEngineResult: String,
+    dynamicFilterFieldId: String? = null,
+    database: String? = null,
+    catalog: String? = null,
+  ): StatementExecutionResponse
+
+  abstract fun getStatementStatus(statementId: String): StatementExecutionStatus
+
+  fun getPaginatedExternalTableResult(
+    tableId: String,
+    selectedPage: Long,
+    pageSize: Long,
+    jdbcTemplate: NamedParameterJdbcTemplate = populateJdbcTemplate(),
+  ): List<Map<String, Any?>> {
+    val stopwatch = StopWatch.createStarted()
+    val result = jdbcTemplate
+      .queryForList(
+        "SELECT * FROM reports.$tableId limit $pageSize OFFSET ($selectedPage - 1) * $pageSize;",
+        MapSqlParameterSource(),
+      )
+      .map {
+        transformTimestampToLocalDateTime(it)
+      }
+    stopwatch.stop()
+    log.debug("Query Execution time in ms: {}", stopwatch.time)
+    return result
+  }
+
+  fun count(tableId: String, jdbcTemplate: NamedParameterJdbcTemplate = populateJdbcTemplate()): Long {
+    return jdbcTemplate.queryForList(
+      "SELECT COUNT(1) as total FROM reports.$tableId;",
+      MapSqlParameterSource(),
+    ).first()?.get("total") as Long
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.athena.AthenaClient
+import software.amazon.awssdk.services.athena.model.AthenaError
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext
+import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
+import software.amazon.awssdk.services.athena.model.ResultConfiguration
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
+
+@Service
+class AthenaApiRepository(
+  val athenaClient: AthenaClient,
+  val tableIdGenerator: TableIdGenerator,
+  @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
+  private val s3location: String = "dpr-working-development/reports",
+) : RepositoryHelper() {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun executeQueryAsync(
+    query: String,
+    filters: List<ConfiguredApiRepository.Filter>,
+    sortColumn: String?,
+    sortedAsc: Boolean,
+    policyEngineResult: String,
+    dataCatalog: String,
+    database: String,
+    dynamicFilterFieldId: String? = null,
+  ): StatementExecutionResponse {
+    val tableId = tableIdGenerator.generateNewExternalTableId()
+    val queryExecutionContext = QueryExecutionContext.builder()
+      .database(database) // "DIGITAL_PRISON_REPORTING"
+      .catalog(dataCatalog) // "nomis"
+      .build()
+
+    val finalQuery = """
+          CREATE TABLE AwsDataCatalog.reports.$tableId 
+          WITH (
+            format = 'PARQUET'
+          ) 
+          AS (
+          SELECT * FROM TABLE(system.query(query =>
+           '${
+      buildFinalQuery(
+        buildReportQuery(query),
+        buildPolicyQuery(policyEngineResult),
+        // The filters part will be replaced with the variables CTE
+        "$FILTER_ AS (SELECT * FROM $POLICY_ WHERE TRUE)",
+        buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
+      ).replace("'", "''")
+    }'
+           )) 
+          );
+    """.trimIndent()
+    val resultConfiguration = ResultConfiguration.builder()
+      .outputLocation("s3://$s3location/$tableId/")
+      .build()
+    val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+      .queryString(finalQuery)
+      .queryExecutionContext(queryExecutionContext)
+      .resultConfiguration(resultConfiguration)
+      .build()
+    val queryExecutionId = athenaClient
+      .startQueryExecution(startQueryExecutionRequest).queryExecutionId()
+    return StatementExecutionResponse(tableId, queryExecutionId)
+  }
+
+  fun getStatementStatus(statementId: String): StatementExecutionStatus {
+    val getQueryExecutionRequest = GetQueryExecutionRequest.builder()
+      .queryExecutionId(statementId)
+      .build()
+
+    val getQueryExecutionResponse = athenaClient.getQueryExecution(getQueryExecutionRequest)
+    val status = getQueryExecutionResponse.queryExecution().status()
+    val stateChangeReason = status.stateChangeReason()
+    val error: AthenaError? = status.athenaError()
+    return StatementExecutionStatus(
+      status = mapAthenaStateToRedshiftState(status.state().toString()),
+      duration = calculateDuration(status),
+      queryString = getQueryExecutionResponse.queryExecution().query(),
+      resultRows = 0,
+      resultSize = 0,
+      error = error?.errorMessage(),
+      errorCategory = error?.errorCategory(),
+      stateChangeReason = stateChangeReason,
+    )
+  }
+
+  private fun mapAthenaStateToRedshiftState(queryState: String): String {
+    val athenaToRedshiftStateMappings = mapOf(
+      "QUEUED" to "SUBMITTED",
+      "RUNNING" to "STARTED",
+      "SUCCEEDED" to "FINISHED",
+      "CANCELLED" to "ABORTED",
+    )
+    return athenaToRedshiftStateMappings.getOrDefault(queryState, queryState)
+  }
+
+  private fun calculateDuration(status: QueryExecutionStatus): Long {
+    return status.completionDateTime()?.let { completion ->
+      status.submissionDateTime()?.let { submission ->
+        completion.minusMillis(submission.toEpochMilli()).toEpochMilli() * 1000000
+      } ?: 0
+    } ?: 0
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -20,26 +20,26 @@ class AthenaApiRepository(
   val tableIdGenerator: TableIdGenerator,
   @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
   private val s3location: String = "dpr-working-development/reports",
-) : RepositoryHelper() {
+) : AthenaAndRedshiftCommonRepository() {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun executeQueryAsync(
+  override fun executeQueryAsync(
     query: String,
     filters: List<ConfiguredApiRepository.Filter>,
     sortColumn: String?,
     sortedAsc: Boolean,
     policyEngineResult: String,
-    dataCatalog: String,
-    database: String,
-    dynamicFilterFieldId: String? = null,
+    dynamicFilterFieldId: String?,
+    database: String?,
+    catalog: String?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val queryExecutionContext = QueryExecutionContext.builder()
       .database(database) // "DIGITAL_PRISON_REPORTING"
-      .catalog(dataCatalog) // "nomis"
+      .catalog(catalog) // "nomis"
       .build()
 
     val finalQuery = """
@@ -74,7 +74,7 @@ class AthenaApiRepository(
     return StatementExecutionResponse(tableId, queryExecutionId)
   }
 
-  fun getStatementStatus(statementId: String): StatementExecutionStatus {
+  override fun getStatementStatus(statementId: String): StatementExecutionStatus {
     val getQueryExecutionRequest = GetQueryExecutionRequest.builder()
       .queryExecutionId(statementId)
       .build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Datasource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Datasource.kt
@@ -3,4 +3,6 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 data class Datasource(
   val id: String,
   val name: String,
+  val database: String? = null,
+  val catalog: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -1,12 +1,40 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class StatementExecutionStatus(
+  @Schema(
+    examples = ["FINISHED", "SUBMITTED", "STARTED", "PICKED", "FAILED", "ALL", "ABORTED"],
+    description = "The status of the statement execution.",
+  )
   val status: String,
-  // The amount of time in nanoseconds that the statement ran.
+  @Schema(
+    example = "10562762848",
+    description = "The amount of time in nanoseconds that the statement ran.",
+  )
   val duration: Long,
   val queryString: String,
+  @Schema(
+    example = "10",
+    description = "The number of rows returned from the query.",
+  )
   val resultRows: Long,
-  // The size in bytes of the returned results. A -1 indicates the value is null.
+  @Schema(
+    example = "0",
+    description = "The size in bytes of the returned results. A -1 indicates the value is null.",
+  )
   val resultSize: Long?,
+  @Schema(description = "Contains a short description of the error that occurred.")
   val error: String? = null,
+  @Schema(
+    examples = ["1", "2", "3"],
+    description = "Specific to Athena queries. An integer value that specifies the category of a query failure error. " +
+      "The following list shows the category for each integer value.\n" +
+      "1 - System\n" +
+      "2 - User\n" +
+      "3 - Other",
+  )
+  val errorCategory: Int? = null,
+  @Schema(description = "Specific to Athena queries. Further detail about the status of the query.")
+  val stateChangeReason: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -111,8 +111,9 @@ class ConfiguredApiService(
       )
   }
 
-  fun getStatementStatus(statementId: String): StatementExecutionStatus {
-    return redshiftDataApiRepository.getStatementStatus(statementId)
+  fun getStatementStatus(statementId: String, reportId: String, reportVariantId: String, dataProductDefinitionsPath: String? = null): StatementExecutionStatus {
+    val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
+    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name, redshiftDataApiRepository).getStatementStatus(statementId)
   }
 
   fun getStatementResult(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AthenaAndRedshiftCommonRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AthenaApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RedshiftDataApiRepository
@@ -28,6 +30,7 @@ class ConfiguredApiService(
   val productDefinitionRepository: ProductDefinitionRepository,
   val configuredApiRepository: ConfiguredApiRepository,
   val redshiftDataApiRepository: RedshiftDataApiRepository,
+  val athenaApiRepository: AthenaApiRepository,
   @Value("\${URL_ENV_SUFFIX:#{null}}") val env: String? = null,
 ) {
 
@@ -40,6 +43,13 @@ class ConfiguredApiService(
     const val INVALID_DYNAMIC_FILTER_MESSAGE = "Error. This filter is not a dynamic filter."
     private const val SCHEMA_REF_PREFIX = "\$ref:"
   }
+
+  private val datasourceNameToRepo: Map<String, AthenaAndRedshiftCommonRepository>
+    get() = mapOf(
+      "datamart" to redshiftDataApiRepository,
+      "nomis" to athenaApiRepository,
+      "bodmis" to athenaApiRepository,
+    )
 
   fun validateAndFetchData(
     reportId: String,
@@ -88,16 +98,16 @@ class ConfiguredApiService(
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
-    return redshiftDataApiRepository
+    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name, redshiftDataApiRepository)
       .executeQueryAsync(
         query = productDefinition.dataset.query,
         filters = validateAndMapFilters(productDefinition, filters) + dynamicFilter,
         sortColumn = sortColumnFromQueryOrGetDefault(productDefinition, sortColumn),
         sortedAsc = sortedAsc,
-        reportId = reportId,
         policyEngineResult = policyEngine.execute(),
         dynamicFilterFieldId = reportFieldId,
-        dataSourceName = productDefinition.datasource.name,
+        database = productDefinition.datasource.database,
+        catalog = productDefinition.datasource.catalog,
       )
   }
 

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,5 +13,6 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionS
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RedshiftDataApiRepository
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AthenaApiRepository
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DigitalPrisonReportingExceptionHandler
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -1,0 +1,170 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.athena.AthenaClient
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse
+import software.amazon.awssdk.services.athena.model.QueryExecution
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext
+import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
+import software.amazon.awssdk.services.athena.model.ResultConfiguration
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class AthenaApiRepositoryTest {
+
+  companion object {
+    val dpdQuery = "SELECT column_a,column_b FROM schema_a.table_a"
+  }
+  fun sqlStatement(tableId: String) =
+    """          CREATE TABLE AwsDataCatalog.reports.$tableId 
+          WITH (
+            format = 'PARQUET'
+          ) 
+          AS (
+          SELECT * FROM TABLE(system.query(query =>
+           'WITH dataset_ AS ($dpdQuery),policy_ AS (SELECT * FROM dataset_ WHERE TRUE),filter_ AS (SELECT * FROM policy_ WHERE TRUE)
+SELECT *
+          FROM filter_ ORDER BY column_a asc'
+           )) 
+          );
+    """.trimIndent()
+
+  @Test
+  fun `executeQueryAsync should call the athena data api with the correct query and return the execution id and table id`() {
+    val athenaClient = mock<AthenaClient>()
+    val startQueryExecutionResponse = mock<StartQueryExecutionResponse>()
+    val tableIdGenerator = mock<TableIdGenerator>()
+    val tableId = "_a6227417_bdac_40bb_bc81_49c750daacd7"
+    val executionId = "someId"
+    val testDb = "testdb"
+    val testCatalog = "testcatalog"
+    val athenaApiRepository = AthenaApiRepository(
+      athenaClient,
+      tableIdGenerator,
+    )
+    val queryExecutionContext = QueryExecutionContext.builder()
+      .database(testDb)
+      .catalog(testCatalog)
+      .build()
+    val resultConfiguration = ResultConfiguration.builder()
+      .outputLocation("s3://dpr-working-development/reports/$tableId/")
+      .build()
+    val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+      .queryString(sqlStatement(tableId))
+      .queryExecutionContext(queryExecutionContext)
+      .resultConfiguration(resultConfiguration)
+      .build()
+    whenever(
+      tableIdGenerator.generateNewExternalTableId(),
+    ).thenReturn(
+      tableId,
+    )
+
+    whenever(
+      athenaClient.startQueryExecution(
+        startQueryExecutionRequest,
+      ),
+    ).thenReturn(startQueryExecutionResponse)
+
+    whenever(
+      startQueryExecutionResponse.queryExecutionId(),
+    ).thenReturn(executionId)
+
+    val actual = athenaApiRepository.executeQueryAsync(
+      query = dpdQuery,
+      filters = emptyList(),
+      sortColumn = "column_a",
+      sortedAsc = true,
+      policyEngineResult = "TRUE",
+      database = testDb,
+      dataCatalog = testCatalog,
+    )
+
+    assertEquals(StatementExecutionResponse(tableId, executionId), actual)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "QUEUED, SUBMITTED",
+    "RUNNING, STARTED",
+    "SUCCEEDED, FINISHED",
+    "CANCELLED, ABORTED",
+  )
+  fun `getStatementStatus should call the getQueryExecution athena api with the correct statement ID and return the StatementExecutionStatus mapped correctly`(athenaStatus: String, redshiftStatus: String) {
+    val athenaClient = mock<AthenaClient>()
+    val tableIdGenerator = mock<TableIdGenerator>()
+    val athenaApiRepository = AthenaApiRepository(
+      athenaClient,
+      tableIdGenerator,
+    )
+    val query = sqlStatement(tableId = "tableId")
+    val statementId = "statementId"
+    val getQueryExecutionRequest = GetQueryExecutionRequest.builder()
+      .queryExecutionId(statementId)
+      .build()
+    val completionTime = Instant.now()
+    val submissionTime = completionTime.minus(Duration.of(10, ChronoUnit.MINUTES))
+//    val getQueryExecutionResponse = mock<GetQueryExecutionResponse>()
+    val getQueryExecutionResponse = GetQueryExecutionResponse.builder()
+      .queryExecution(
+        QueryExecution.builder()
+          .query(query)
+          .status(
+            QueryExecutionStatus.builder().state(
+              athenaStatus,
+            )
+              .submissionDateTime(submissionTime)
+              .completionDateTime(completionTime)
+              .build(),
+          ).build(),
+      ).build()
+    whenever(
+      athenaClient.getQueryExecution(
+        getQueryExecutionRequest,
+      ),
+    ).thenReturn(getQueryExecutionResponse)
+//    val queryExecution = mock<QueryExecution>()
+//    whenever(
+//      getQueryExecutionResponse.queryExecution(),
+//    ).thenReturn(queryExecution)
+//    val queryExecutionStatus = mock<QueryExecutionStatus>()
+//    whenever(
+//      queryExecution.query(),
+//    ).thenReturn(query)
+//    whenever(
+//      queryExecution.status(),
+//    ).thenReturn(queryExecutionStatus)
+//    whenever(
+//      queryExecutionStatus.state(),
+//    ).thenReturn(QueryExecutionState.SUCCEEDED)
+//    whenever(
+//      queryExecutionStatus.completionDateTime(),
+//    ).thenReturn(completionTime)
+//    whenever(
+//      queryExecutionStatus.submissionDateTime(),
+//    ).thenReturn(submissionTime)
+    val tenMinutesInNanoseconds = 600000000000
+    val expected = StatementExecutionStatus(
+      redshiftStatus,
+      tenMinutesInNanoseconds,
+      query,
+      0L,
+      0L,
+    )
+    val actual = athenaApiRepository.getStatementStatus(statementId)
+
+    assertEquals(expected, actual)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -116,7 +116,6 @@ SELECT *
       .build()
     val completionTime = Instant.now()
     val submissionTime = completionTime.minus(Duration.of(10, ChronoUnit.MINUTES))
-//    val getQueryExecutionResponse = mock<GetQueryExecutionResponse>()
     val getQueryExecutionResponse = GetQueryExecutionResponse.builder()
       .queryExecution(
         QueryExecution.builder()
@@ -135,26 +134,6 @@ SELECT *
         getQueryExecutionRequest,
       ),
     ).thenReturn(getQueryExecutionResponse)
-//    val queryExecution = mock<QueryExecution>()
-//    whenever(
-//      getQueryExecutionResponse.queryExecution(),
-//    ).thenReturn(queryExecution)
-//    val queryExecutionStatus = mock<QueryExecutionStatus>()
-//    whenever(
-//      queryExecution.query(),
-//    ).thenReturn(query)
-//    whenever(
-//      queryExecution.status(),
-//    ).thenReturn(queryExecutionStatus)
-//    whenever(
-//      queryExecutionStatus.state(),
-//    ).thenReturn(QueryExecutionState.SUCCEEDED)
-//    whenever(
-//      queryExecutionStatus.completionDateTime(),
-//    ).thenReturn(completionTime)
-//    whenever(
-//      queryExecutionStatus.submissionDateTime(),
-//    ).thenReturn(submissionTime)
     val tenMinutesInNanoseconds = 600000000000
     val expected = StatementExecutionStatus(
       redshiftStatus,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -89,7 +89,7 @@ SELECT *
       sortedAsc = true,
       policyEngineResult = "TRUE",
       database = testDb,
-      dataCatalog = testCatalog,
+      catalog = testCatalog,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -52,7 +52,7 @@ class RedshiftDataApiRepositoryTest {
   }
 
   @Test
-  fun `executeQueryAsync should call the redshift data api with the correct query and return the execution id`() {
+  fun `executeQueryAsync should call the redshift data api with the correct query and return the execution id and table id`() {
     val redshiftDataClient = mock<RedshiftDataClient>()
     val executeStatementRequestBuilder = mock<ExecuteStatementRequest.Builder>()
     val executeStatementResponse = mock<ExecuteStatementResponse>()
@@ -227,8 +227,8 @@ SELECT *
     val status = "FINISHED"
     val duration = 278109264L
     val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
-    val resultRows = 10L
-    val resultSize = 100L
+    val resultRows = 0L
+    val resultSize = 0L
     val executeStatementResponse = DescribeStatementResponse.builder()
       .status(status)
       .duration(duration)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -19,10 +19,8 @@ import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
 import software.amazon.awssdk.services.redshiftdata.model.ValidationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_DATASOURCE_NAME
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_POLICY_ENGINE_RESULT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.Companion.REPOSITORY_TEST_QUERY
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.Companion.EXTERNAL_MOVEMENTS_PRODUCT_ID
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -108,9 +106,7 @@ class RedshiftDataApiRepositoryTest {
       filters = listOf(ConfiguredApiRepository.Filter("direction", "out")),
       sortColumn = "date",
       sortedAsc = true,
-      reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
-      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -206,9 +202,7 @@ SELECT *
       ),
       sortColumn = "date",
       sortedAsc = true,
-      reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
-      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -325,9 +319,7 @@ SELECT *
       filters = emptyList(),
       sortColumn = "date",
       sortedAsc = true,
-      reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
-      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
     )
 
     verify(executeStatementRequestBuilder, times(0)).parameters(any<List<SqlParameter>>())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -142,6 +142,8 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Calling the report status endpoint calls the getStatementStatus of the ConfiguredApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
+    val reportId = "external-movements"
+    val reportVariantId = "last-month"
     val status = "FINISHED"
     val duration = 278109264L
     val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
@@ -157,6 +159,9 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     given(
       configuredApiService.getStatementStatus(
         eq(queryExecutionId),
+        eq(reportId),
+        eq(reportVariantId),
+        eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
       ),
     )
       .willReturn(statementExecutionStatus)
@@ -164,7 +169,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/report/statements/$queryExecutionId/status")
+          .path("/reports/$reportId/$reportVariantId/statements/$queryExecutionId/status")
           .build()
       }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -1245,7 +1245,8 @@ class ConfiguredApiServiceTest {
   }
 
   @Test
-  fun `should call the repository with the statement execution ID when getStatementStatus is called`() {
+  fun `should call the RedshiftDataApiRepository for datamart with the statement execution ID when getStatementStatus is called`() {
+    val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository)
     val statementId = "statementId"
     val status = "FINISHED"
     val duration = 278109264L
@@ -1263,8 +1264,40 @@ class ConfiguredApiServiceTest {
       redshiftDataApiRepository.getStatementStatus(statementId),
     ).thenReturn(statementExecutionStatus)
 
-    val actual = configuredApiService.getStatementStatus(statementId)
+    val actual = configuredApiService.getStatementStatus(statementId, "external-movements", "last-month")
     verify(redshiftDataApiRepository, times(1)).getStatementStatus(statementId)
+    verifyNoInteractions(athenaApiRepository)
+    assertEquals(statementExecutionStatus, actual)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["productDefinitionNomis.json", "productDefinitionBodmis.json"])
+  fun `should call the AthenaApiRepository for nomis and bodmis with the statement execution ID when getStatementStatus is called`(definitionFile: String) {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf(definitionFile),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+    )
+    val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository)
+    val statementId = "statementId"
+    val status = "FINISHED"
+    val duration = 278109264L
+    val query = "SELECT * FROM datamart.domain.movement_movement limit 10;"
+    val resultRows = 10L
+    val resultSize = 100L
+    val statementExecutionStatus = StatementExecutionStatus(
+      status,
+      duration,
+      query,
+      resultRows,
+      resultSize,
+    )
+    whenever(
+      athenaApiRepository.getStatementStatus(statementId),
+    ).thenReturn(statementExecutionStatus)
+
+    val actual = configuredApiService.getStatementStatus(statementId, "external-movements", "last-month")
+    verify(athenaApiRepository, times(1)).getStatementStatus(statementId)
+    verifyNoInteractions(redshiftDataApiRepository)
     assertEquals(statementExecutionStatus, actual)
   }
 

--- a/src/test/resources/productDefinitionBodmis.json
+++ b/src/test/resources/productDefinitionBodmis.json
@@ -1,0 +1,285 @@
+{
+  "id" : "external-movements",
+  "name" : "External Movements",
+  "description" : "Reports about prisoner external movements",
+  "metadata" : {
+    "author" : "Adam",
+    "version" : "1.2.3",
+    "owner" : "Eve"
+  },
+  "datasource" : [
+    {
+      "id": "bodmis",
+      "name": "bodmis",
+      "database": "bodmis_db",
+      "catalog": "bodmis"
+    }],
+  "dataset" : [ {
+    "id" : "external-movements",
+    "name" : "All movements",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "schema" : {
+      "field" : [ {
+        "name" : "prisonNumber",
+        "type" : "string",
+        "display" : "Prison Number"
+      }, {
+        "name" : "name",
+        "type" : "string",
+        "display" : "Name"
+      }, {
+        "name" : "date",
+        "type" : "date",
+        "display" : ""
+      }, {
+        "name" : "origin",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "origin_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "destination",
+        "type" : "string",
+        "display" : ""
+      },{
+        "name" : "destination_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "direction",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "type",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "reason",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "is_closed",
+        "type" : "boolean",
+        "display" : ""
+      }]
+    }
+  } ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseload}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report" : [ {
+    "id" : "last-month",
+    "name" : "Last month",
+    "description" : "All movements in the past month",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "formula": "formula placeholder"
+  }, {
+    "id" : "last-week",
+    "name" : "Last week",
+    "description" : "All movements in the past week",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "daterange",
+          "default" : "today(-1,weeks) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
+      } ]
+    },
+    "destination" : [ ]
+  } ]
+}

--- a/src/test/resources/productDefinitionNomis.json
+++ b/src/test/resources/productDefinitionNomis.json
@@ -1,0 +1,285 @@
+{
+  "id" : "external-movements",
+  "name" : "External Movements",
+  "description" : "Reports about prisoner external movements",
+  "metadata" : {
+    "author" : "Adam",
+    "version" : "1.2.3",
+    "owner" : "Eve"
+  },
+  "datasource" : [
+    {
+      "id": "nomis",
+      "name": "nomis",
+      "database": "nomis_db",
+      "catalog": "nomis"
+    }],
+  "dataset" : [ {
+    "id" : "external-movements",
+    "name" : "All movements",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "schema" : {
+      "field" : [ {
+        "name" : "prisonNumber",
+        "type" : "string",
+        "display" : "Prison Number"
+      }, {
+        "name" : "name",
+        "type" : "string",
+        "display" : "Name"
+      }, {
+        "name" : "date",
+        "type" : "date",
+        "display" : ""
+      }, {
+        "name" : "origin",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "origin_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "destination",
+        "type" : "string",
+        "display" : ""
+      },{
+        "name" : "destination_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "direction",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "type",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "reason",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "is_closed",
+        "type" : "boolean",
+        "display" : ""
+      }]
+    }
+  } ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseload}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report" : [ {
+    "id" : "last-month",
+    "name" : "Last month",
+    "description" : "All movements in the past month",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "formula": "formula placeholder"
+  }, {
+    "id" : "last-week",
+    "name" : "Last week",
+    "description" : "All movements in the past week",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "daterange",
+          "default" : "today(-1,weeks) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
+      } ]
+    },
+    "destination" : [ ]
+  } ]
+}


### PR DESCRIPTION
Main changes in this PR:
- New AthenaAPIRepository which queries Athena.
- Datasource supports two new optional fields: database and catalog.
- Added functionality to call the Athena API to start the query execution and retrieve the execution status for nomis and bodmis reports based on the datasource name.

- Existing datamart reports will run against the Redshift Data API.
Filters are not supported yet for nomis and bodmis reports as part of this release.

- The `/report/statements/{statementId}/status` endpoint has changed to
`/reports/{reportId}/{reportVariantId}/statements/{statementId}/status`