### PR TITLE
DPR2-818 request builder is not a bean

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
@@ -1,21 +1,14 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.athena.AthenaClient
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
-import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
-import software.amazon.awssdk.services.redshiftdata.model.RedshiftDataRequest
 
 @Configuration
-class RedshiftDataApiConfig(
-  @Value("\${dpr.lib.redshiftdataapi.database:#{null}}") val redshiftDataApiDb: String? = null,
-  @Value("\${dpr.lib.redshiftdataapi.clusterid:#{null}}") val redshiftDataApiClusterId: String? = null,
-  @Value("\${dpr.lib.redshiftdataapi.secretarn:#{null}}") val redshiftDataApiSecretArn: String? = null,
-) {
+class RedshiftDataApiConfig {
 
   @Bean
   @ConditionalOnMissingBean(RedshiftDataClient::class)
@@ -32,14 +25,5 @@ class RedshiftDataApiConfig(
     return AthenaClient.builder()
       .region(region)
       .build()
-  }
-
-  @Bean
-  @ConditionalOnMissingBean(RedshiftDataRequest.Builder::class)
-  fun executeStatementRequestBuilder(): ExecuteStatementRequest.Builder {
-    return ExecuteStatementRequest.builder()
-      .clusterIdentifier(redshiftDataApiClusterId)
-      .database(redshiftDataApiDb)
-      .secretArn(redshiftDataApiSecretArn)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -15,8 +15,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGen
 @Service
 class RedshiftDataApiRepository(
   val redshiftDataClient: RedshiftDataClient,
-  val executeStatementRequestBuilder: ExecuteStatementRequest.Builder,
   val tableIdGenerator: TableIdGenerator,
+  @Value("\${dpr.lib.redshiftdataapi.database:db}") private val redshiftDataApiDb: String,
+  @Value("\${dpr.lib.redshiftdataapi.clusterid:clusterId}") private val redshiftDataApiClusterId: String,
+  @Value("\${dpr.lib.redshiftdataapi.secretarn:arn}") private val redshiftDataApiSecretArn: String,
   @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
   private val s3location: String = "dpr-working-development/reports",
 ) : AthenaAndRedshiftCommonRepository() {
@@ -50,10 +52,11 @@ class RedshiftDataApiRepository(
     }
           );
     """.trimIndent()
-    val requestBuilder = executeStatementRequestBuilder
-      .sql(
-        generateSql,
-      )
+    val requestBuilder = ExecuteStatementRequest.builder()
+      .clusterIdentifier(redshiftDataApiClusterId)
+      .database(redshiftDataApiDb)
+      .secretArn(redshiftDataApiSecretArn)
+      .sql(generateSql)
     if (filters.isNotEmpty()) {
       requestBuilder
         .parameters(buildQueryParams(filters))


### PR DESCRIPTION
This PR fixes the issue in which when a request was made with filters then all subsequent requests without filters would fail.


Steps to reproduce:

1. Make a request to `https://digital-prison-reporting-mi-dev.hmpps.service.justice.gov.uk/async/reports/dpd000-external-movements/last-week` with a filter e.g. `filters.direction = “out”`

2. Call the status endpoint 
https://digital-prison-reporting-mi-dev.hmpps.service.justice.gov.uk/reports/dpd000-external-movements/last-week/statements/b615d235-8273-456a-920f-fdf8017ae3a2/status

3. The request fails as expected due to DPR2-817.
 
4. Remove the filter from the execution request.

5. Repeat the call to the execution endpoint without any filters this time.

6. The request fails with a 400 error:
"Validation failure: Parameters list contains unused parameters. Unused parameters: [direction] (Service: RedshiftData, Status Code: 400, Request ID: 5883e5f9-b253-4a85-aaea-f918dc258b36)"

7. Now kill the K8s pods.

8. Repeat the execution request without filters.

9. The request succeeds.