### PR TITLE
Dpr2 817 Fix Redshift Error When Passing Filters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/RedshiftDataApiConfig.kt
@@ -1,21 +1,14 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.athena.AthenaClient
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
-import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
-import software.amazon.awssdk.services.redshiftdata.model.RedshiftDataRequest
 
 @Configuration
-class RedshiftDataApiConfig(
-  @Value("\${dpr.lib.redshiftdataapi.database:#{null}}") val redshiftDataApiDb: String? = null,
-  @Value("\${dpr.lib.redshiftdataapi.clusterid:#{null}}") val redshiftDataApiClusterId: String? = null,
-  @Value("\${dpr.lib.redshiftdataapi.secretarn:#{null}}") val redshiftDataApiSecretArn: String? = null,
-) {
+class RedshiftDataApiConfig {
 
   @Bean
   @ConditionalOnMissingBean(RedshiftDataClient::class)
@@ -32,14 +25,5 @@ class RedshiftDataApiConfig(
     return AthenaClient.builder()
       .region(region)
       .build()
-  }
-
-  @Bean
-  @ConditionalOnMissingBean(RedshiftDataRequest.Builder::class)
-  fun executeStatementRequestBuilder(): ExecuteStatementRequest.Builder {
-    return ExecuteStatementRequest.builder()
-      .clusterIdentifier(redshiftDataApiClusterId)
-      .database(redshiftDataApiDb)
-      .secretArn(redshiftDataApiSecretArn)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -38,8 +38,8 @@ class AthenaApiRepository(
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val queryExecutionContext = QueryExecutionContext.builder()
-      .database(database) // "DIGITAL_PRISON_REPORTING"
-      .catalog(catalog) // "nomis"
+      .database(database)
+      .catalog(catalog)
       .build()
 
     val finalQuery = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepository.kt
@@ -74,7 +74,7 @@ class ConfiguredApiRepository : RepositoryHelper() {
 
   private fun buildPreparedStatementNamedParams(filters: List<Filter>): MapSqlParameterSource {
     val preparedStatementNamedParams = MapSqlParameterSource()
-    filters.filterNot { it.type == FilterType.BOOLEAN }.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.lowercase()) }
+    filters.filterNot { it.type == FilterType.DYNAMIC }.filterNot { it.type == FilterType.BOOLEAN }.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.lowercase()) }
     filters.filter { it.type == FilterType.BOOLEAN }.forEach { preparedStatementNamedParams.addValue(it.getKey(), it.value.toBoolean()) }
     log.debug("Prepared statement named parameters: {}", preparedStatementNamedParams)
     return preparedStatementNamedParams

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -15,8 +15,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGen
 @Service
 class RedshiftDataApiRepository(
   val redshiftDataClient: RedshiftDataClient,
-  val executeStatementRequestBuilder: ExecuteStatementRequest.Builder,
   val tableIdGenerator: TableIdGenerator,
+  @Value("\${dpr.lib.redshiftdataapi.database:db}") private val redshiftDataApiDb: String,
+  @Value("\${dpr.lib.redshiftdataapi.clusterid:clusterId}") private val redshiftDataApiClusterId: String,
+  @Value("\${dpr.lib.redshiftdataapi.secretarn:arn}") private val redshiftDataApiSecretArn: String,
   @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
   private val s3location: String = "dpr-working-development/reports",
 ) : AthenaAndRedshiftCommonRepository() {
@@ -50,10 +52,11 @@ class RedshiftDataApiRepository(
     }
           );
     """.trimIndent()
-    val requestBuilder = executeStatementRequestBuilder
-      .sql(
-        generateSql,
-      )
+    val requestBuilder = ExecuteStatementRequest.builder()
+      .clusterIdentifier(redshiftDataApiClusterId)
+      .database(redshiftDataApiDb)
+      .secretArn(redshiftDataApiSecretArn)
+      .sql(generateSql)
     if (filters.isNotEmpty()) {
       requestBuilder
         .parameters(buildQueryParams(filters))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -7,7 +7,6 @@ import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
-import software.amazon.awssdk.services.redshiftdata.model.SqlParameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
@@ -46,22 +45,18 @@ class RedshiftDataApiRepository(
       buildFinalQuery(
         buildReportQuery(query),
         buildPolicyQuery(policyEngineResult),
-        buildFiltersQuery(filters, queryParamKeyTransformer),
+        buildFiltersQuery(filters),
         buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
       )
     }
           );
     """.trimIndent()
-    val requestBuilder = ExecuteStatementRequest.builder()
+    val statementRequest = ExecuteStatementRequest.builder()
       .clusterIdentifier(redshiftDataApiClusterId)
       .database(redshiftDataApiDb)
       .secretArn(redshiftDataApiSecretArn)
       .sql(generateSql)
-    if (filters.isNotEmpty()) {
-      requestBuilder
-        .parameters(buildQueryParams(filters))
-    }
-    val statementRequest: ExecuteStatementRequest = requestBuilder.build()
+      .build()
 
     val response: ExecuteStatementResponse = redshiftDataClient.executeStatement(statementRequest)
     log.debug("Execution ID: {}", response.id())
@@ -83,14 +78,16 @@ class RedshiftDataApiRepository(
       error = describeStatementResponse.error(),
     )
   }
-
-  private fun buildQueryParams(filters: List<ConfiguredApiRepository.Filter>): List<SqlParameter> {
-    val sqlParams: MutableList<SqlParameter> = mutableListOf()
-    filters.filterNot { it.type == FilterType.BOOLEAN }.forEach { sqlParams.add(SqlParameter.builder().name(maybeTransform(it.getKey(), queryParamKeyTransformer)).value(it.value.lowercase()).build()) }
-    filters.filter { it.type == FilterType.BOOLEAN }.forEach { sqlParams.add(SqlParameter.builder().name(maybeTransform(it.getKey(), queryParamKeyTransformer)).value(it.value).build()) }
-    log.debug("SQL parameters: {}", sqlParams)
-    return sqlParams
+  override fun buildCondition(filter: ConfiguredApiRepository.Filter): String {
+    val lowerCaseField = "lower(${filter.field})"
+    return when (filter.type) {
+      FilterType.STANDARD -> "$lowerCaseField = '${filter.value.lowercase()}'"
+      FilterType.RANGE_START -> "$lowerCaseField >= ${filter.value.lowercase()}"
+      FilterType.DATE_RANGE_START -> "${filter.field} >= CAST('${filter.value}' AS timestamp)"
+      FilterType.RANGE_END -> "$lowerCaseField <= ${filter.value.lowercase()}"
+      FilterType.DATE_RANGE_END -> "${filter.field} < (CAST('${filter.value}' AS timestamp) + INTERVAL '1' day)"
+      FilterType.DYNAMIC -> "${filter.field} ILIKE '${filter.value}%'"
+      FilterType.BOOLEAN -> "${filter.field} = ${filter.value.toBoolean()}"
+    }
   }
-
-  private val queryParamKeyTransformer: (s: String) -> String = { s -> s.replace(".", "_") }
 }


### PR DESCRIPTION
These changes fix the issue due to which the Redshift async query was failing when the parameters' values were passed using the requestBuilder.parameters method from the Redshift Data Api.
Redshift Data API does not allow this inside CREATE EXTERNAL TABLE commands and throws this error:
`"ERROR: there is no parameter $1"`
The values are now replaced directly into the query string of the filter_ CTE.
Since this is isolated in the filter_ CTE it is not a concern for SQL injection.