### PR TITLE
DPR2-790 case insensitive datasource name comparisson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.2.3
+Case-insensitive comparison of Datasource name to determine whether to use the Athena or Redshift API.
+
 ## 4.2.2
 Fixes the issue in which the Redshift async query was failing when the parameters' values were passed using the ExecuteStatementRequest.Builder.parameters method of the Redshift Data Api.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiService.kt
@@ -98,7 +98,7 @@ class ConfiguredApiService(
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId, prefix, productDefinition)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
-    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name, redshiftDataApiRepository)
+    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name.lowercase(), redshiftDataApiRepository)
       .executeQueryAsync(
         query = productDefinition.dataset.query,
         filters = validateAndMapFilters(productDefinition, filters) + dynamicFilter,
@@ -113,7 +113,7 @@ class ConfiguredApiService(
 
   fun getStatementStatus(statementId: String, reportId: String, reportVariantId: String, dataProductDefinitionsPath: String? = null): StatementExecutionStatus {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
-    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name, redshiftDataApiRepository).getStatementStatus(statementId)
+    return datasourceNameToRepo.getOrDefault(productDefinition.datasource.name.lowercase(), redshiftDataApiRepository).getStatementStatus(statementId)
   }
 
   fun getStatementResult(

--- a/src/test/resources/productDefinitionNomis.json
+++ b/src/test/resources/productDefinitionNomis.json
@@ -10,7 +10,7 @@
   "datasource" : [
     {
       "id": "nomis",
-      "name": "nomis",
+      "name": "NOMIS",
       "database": "nomis_db",
       "catalog": "nomis"
     }],


### PR DESCRIPTION
Make datasource name comparisson case insensitive for the async APIs in order to decided weather to call Redshift or Athena.