### PR TITLE
DPR2-796 refactoring

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
@@ -4,5 +4,4 @@ data class DynamicFilterOption(
   val minimumLength: Int? = null,
   val returnAsStaticOptions: Boolean,
   val maximumOptions: Long? = null,
-  val dataset: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DynamicFilterOption.kt
@@ -4,4 +4,5 @@ data class DynamicFilterOption(
   val minimumLength: Int? = null,
   val returnAsStaticOptions: Boolean,
   val maximumOptions: Long? = null,
+  val dataset: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -40,27 +40,6 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
       variant = map(report = definition.report, dataSet = definition.dataset, productDefinitionId = definition.id, userToken = userToken, dataProductDefinitionsPath = dataProductDefinitionsPath),
     )
   }
-//  fun map(
-//    productDefinition: ProductDefinition,
-//    renderMethod: RenderMethod?,
-//    userToken: DprAuthAwareAuthenticationToken?,
-//    dataProductDefinitionsPath: String? = null,
-//  ): ReportDefinition = ReportDefinition(
-//    id = productDefinition.id,
-//    name = productDefinition.name,
-//    description = productDefinition.description,
-//    variants = productDefinition.report
-//      .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
-//      .map { map(productDefinition.id, it, productDefinition.dataset, userToken, dataProductDefinitionsPath) },
-//  )
-
-  private fun map(productDefinitionId: String, report: Report, datasets: List<Dataset>, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): VariantDefinition {
-    val dataSetRef = report.dataset.removePrefix("\$ref:")
-    val dataSet = datasets.find { it.id == dataSetRef }
-      ?: throw IllegalArgumentException("Could not find matching DataSet '$dataSetRef'")
-
-    return map(report, dataSet, productDefinitionId, userToken, dataProductDefinitionsPath)
-  }
 
   private fun map(
     report: Report,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -6,8 +6,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.F
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.VariantDefinition
@@ -15,7 +13,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.W
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FeatureType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
@@ -35,20 +32,27 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
 
   val todayRegex: Regex = Regex("today\\(\\)")
   val dateRegex: Regex = Regex("today\\((-?\\d+), ?([a-z]+)\\)", RegexOption.IGNORE_CASE)
-
-  fun map(
-    productDefinition: ProductDefinition,
-    renderMethod: RenderMethod?,
-    userToken: DprAuthAwareAuthenticationToken?,
-    dataProductDefinitionsPath: String? = null,
-  ): ReportDefinition = ReportDefinition(
-    id = productDefinition.id,
-    name = productDefinition.name,
-    description = productDefinition.description,
-    variants = productDefinition.report
-      .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
-      .map { map(productDefinition.id, it, productDefinition.dataset, userToken, dataProductDefinitionsPath) },
-  )
+  fun map(definition: SingleReportProductDefinition, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): SingleVariantReportDefinition {
+    return SingleVariantReportDefinition(
+      id = definition.id,
+      name = definition.name,
+      description = definition.description,
+      variant = map(report = definition.report, dataSet = definition.dataset, productDefinitionId = definition.id, userToken = userToken, dataProductDefinitionsPath = dataProductDefinitionsPath),
+    )
+  }
+//  fun map(
+//    productDefinition: ProductDefinition,
+//    renderMethod: RenderMethod?,
+//    userToken: DprAuthAwareAuthenticationToken?,
+//    dataProductDefinitionsPath: String? = null,
+//  ): ReportDefinition = ReportDefinition(
+//    id = productDefinition.id,
+//    name = productDefinition.name,
+//    description = productDefinition.description,
+//    variants = productDefinition.report
+//      .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
+//      .map { map(productDefinition.id, it, productDefinition.dataset, userToken, dataProductDefinitionsPath) },
+//  )
 
   private fun map(productDefinitionId: String, report: Report, datasets: List<Dataset>, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): VariantDefinition {
     val dataSetRef = report.dataset.removePrefix("\$ref:")
@@ -229,13 +233,4 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
     name = definition.name,
     display = definition.display,
   )
-
-  fun map(definition: SingleReportProductDefinition, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): SingleVariantReportDefinition {
-    return SingleVariantReportDefinition(
-      id = definition.id,
-      name = definition.name,
-      description = definition.description,
-      variant = map(report = definition.report, dataSet = definition.dataset, productDefinitionId = definition.id, userToken = userToken, dataProductDefinitionsPath = dataProductDefinitionsPath),
-    )
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
-import org.assertj.core.api.Assertions
+import jakarta.validation.ValidationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
@@ -27,8 +29,23 @@ class JsonFileProductDefinitionRepositoryTest {
     val productDefinition = jsonFileProductDefinitionRepository.getProductDefinition(
       "dpd001-court-hospital-movements",
     )
-    Assertions.assertThat(productDefinition).isNotNull
-    Assertions.assertThat(productDefinition.id).isEqualTo("dpd001-court-hospital-movements")
-    Assertions.assertThat(productDefinition.policy).isEqualTo(listOf(policy))
+    assertThat(productDefinition).isNotNull
+    assertThat(productDefinition.id).isEqualTo("dpd001-court-hospital-movements")
+    assertThat(productDefinition.policy).isEqualTo(listOf(policy))
+  }
+
+  @Test
+  fun `getSingleReportProductDefinition fails when there is no matching dataset`() {
+    val jsonFileProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("nonMatchingDatasetProductDefinition.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+    )
+    val exception = assertThrows(ValidationException::class.java) {
+      jsonFileProductDefinitionRepository.getSingleReportProductDefinition(
+        "dpd001-court-hospital-movements",
+        "report003-hospital-movement",
+      )
+    }
+    assertThat(exception).message().isEqualTo("Invalid dataSetId in report: non-matching-dataset")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinitionSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest
@@ -167,7 +166,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isOk
-      .expectBodyList<ReportDefinition>()
+      .expectBodyList<ReportDefinitionSummary>()
       .returnResult()
 
     assertThat(result.responseBody).isNotNull

--- a/src/test/resources/nonMatchingDatasetProductDefinition.json
+++ b/src/test/resources/nonMatchingDatasetProductDefinition.json
@@ -1,0 +1,394 @@
+{
+  "id": "dpd001-court-hospital-movements",
+  "name": "Court And Hospital Movement DPD",
+  "description": "DPD contains report variants for courts Movements Description",
+  "metadata": {
+    "author": "Zahoor Hussain",
+    "owner": "Michael Clarke",
+    "version": "1.0.5"
+  },
+  "datasource": [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }
+  ],
+  "dataset": [
+    {
+      "id": "court-dataset",
+      "name": "court-dataset",
+      "datasource": "datamart",
+      "query": "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id Where type='CRT'",
+      "schema": {
+        "field": [
+          {
+            "name": "prisonNumber",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "date",
+            "type": "date",
+            "display": ""
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "origin",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "destination",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "direction",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "reason",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "origin_code",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "destination_code",
+            "type": "string",
+            "display": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "hospital-dataset",
+      "name": "hospital-dataset",
+      "datasource": "datamart",
+      "query": "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id Where type='CRT'",
+      "schema": {
+        "field": [
+          {
+            "name": "prisonNumber",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "date",
+            "type": "date",
+            "display": ""
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "origin",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "destination",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "direction",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "reason",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "origin_code",
+            "type": "string",
+            "display": ""
+          },
+          {
+            "name": "destination_code",
+            "type": "string",
+            "display": ""
+          }
+        ]
+      }
+    }
+  ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseload}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report": [
+    {
+      "id": "report003-hospital-movement",
+      "name": "report003-hospital-movement",
+      "description": "report003-hospital-movement",
+      "classification": "list",
+      "version": "v1.0",
+      "render": "HTML",
+      "dataset": "$ref:non-matching-dataset",
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:name",
+            "display": "Full Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:date",
+            "display": "Date",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:origin",
+            "display": "From",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:destination",
+            "display": "To",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:direction",
+            "display": "Direction",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "Radio",
+              "staticoptions": [
+                {
+                  "name": "In",
+                  "display": "IN"
+                },
+                {
+                  "name": "Out",
+                  "display": "OUT"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:reason",
+            "display": "Reason",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          }
+        ]
+      }
+    },
+    {
+      "id": "report002-hospital-movement",
+      "name": "report002-hospital-movement",
+      "description": "report002-hospital-movement",
+      "classification": "list",
+      "version": "v1.0",
+      "render": "HTML",
+      "dataset": "$ref:hospital-dataset",
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:name",
+            "display": "Full Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:date",
+            "display": "Date",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:origin",
+            "display": "From",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:destination",
+            "display": "To",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:direction",
+            "display": "Direction",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "Radio",
+              "staticoptions": [
+                {
+                  "name": "In",
+                  "display": "IN"
+                },
+                {
+                  "name": "Out",
+                  "display": "OUT"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:reason",
+            "display": "Reason",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          }
+        ]
+      }
+    },
+    {
+      "id": "report001-court-movement",
+      "name": "report001-court-movement",
+      "description": "court movement",
+      "classification": "list",
+      "version": "v1.0",
+      "render": "HTML",
+      "dataset": "$ref:court-dataset",
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:date",
+            "display": "Date",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:origin",
+            "display": "From",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:destination",
+            "display": "To",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:direction",
+            "display": "Direction",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "filter": {
+              "type": "Radio",
+              "staticoptions": [
+                {
+                  "name": "In",
+                  "display": "IN"
+                },
+                {
+                  "name": "Out",
+                  "display": "OUT"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:reason",
+            "display": "Reason",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:name",
+            "display": "Full Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is just some refactoring and does not include actual changes for DPR2-796. 
The main change is the removal of the [map function](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt#L39) which was not used.
This was needed to be done at some point and since the changes for DPR2-796 will touch this area, I created the PR to do this incrementally.