### PR TITLE
DPR2-796 simplify date formula interpolation code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -40,15 +40,12 @@ class FormulaEngine(private val reportFields: List<ReportField>, private val env
   }
 
   private fun interpolateFormatDateFormula(formula: String, row: Map<String, Any?>): String {
-    val (dateFieldPlaceholder, dateFormat) = formula.substring(FORMAT_DATE_FORMULA_PREFIX.length, formula.indexOf(")"))
-      .split(",")
-    val date = interpolateStandardFormula(dateFieldPlaceholder.trim(), row)
-    if (date.isBlank()) {
-      return ""
-    }
-    return when {
-      (date.length == 10) -> LocalDate.parse(date).format(DateTimeFormatter.ofPattern(removeQuotes(dateFormat.trim())))
-      (date.length == 16) -> LocalDateTime.parse(date).format(DateTimeFormatter.ofPattern(removeQuotes(dateFormat.trim())))
+    val datePlaceholder = formula.substring(FORMAT_DATE_FORMULA_PREFIX.length, formula.indexOf(")"))
+      .split(",")[1]
+    val date = row["date"] ?: return ""
+    return when (date) {
+      is LocalDate -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePlaceholder.trim())))
+      is LocalDateTime -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePlaceholder.trim())))
       else -> throw IllegalArgumentException("Could not parse date: $date")
     }
   }


### PR DESCRIPTION
Previously the code to format the date was reusing the interpolateStandardFormula which works but it is unnecessary as in this case the only placeholder in the format_date formula is ${date}. 
So the code can be simplified and in this case instead of converting to string, keep the date type to use this in order to decide how to parse and format the date object.