### PR TITLE
DPR2-820 convert parameters to filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.6.0
+Support parameters in the DPD dataset and return them as filters in the report definition response.
+
 ## 4.5.3
 Fix issue with dynamic filter options based on validated filter values. 
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterDefinition.kt
@@ -10,7 +10,7 @@ data class FilterDefinition(
   val staticOptions: List<FilterOption>? = null,
   @SerializedName("dynamicoptions")
   val dynamicOptions: DynamicFilterOption? = null,
-  val defaultValue: String?,
+  val defaultValue: String? = null,
   val min: String? = null,
   val max: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -8,4 +8,5 @@ enum class FilterType(@JsonValue val type: String) {
   DateRange("daterange"),
   AutoComplete("autocomplete"),
   Text("text"),
+  Date("date"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
@@ -15,7 +15,7 @@ abstract class AbstractProductDefinitionRepository : ProductDefinitionRepository
     reportId: String,
     dataProductDefinitionsPath: String?,
   ): SingleReportProductDefinition {
-    val productDefinition = getProductDefinition(definitionId, dataProductDefinitionsPath)
+    val productDefinition: ProductDefinition = getProductDefinition(definitionId, dataProductDefinitionsPath)
     val reportDefinition = productDefinition.report
       .filter { it.id == reportId }
       .ifEmpty { throw ValidationException("Invalid report variant id provided: $reportId") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
@@ -5,4 +5,5 @@ data class Dataset(
   val name: String,
   val query: String,
   val schema: Schema,
+  val parameters: List<Parameter>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -6,4 +6,5 @@ enum class FilterType {
   DateRange,
   AutoComplete,
   Text,
+  Date,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Parameter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Parameter.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class Parameter(
+  val index: Int,
+  val name: String,
+  val reportFieldType: ParameterType,
+  val filterType: FilterType,
+  val display: String,
+  val mandatory: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -102,7 +102,7 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
         reportVariantId,
         userToken,
         dataProductDefinitionsPath,
-        filterDatasets
+        filterDatasets,
       ) + maybeConvertToReportFieldsFromParameters(parameters),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -92,22 +92,41 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
     if (specification == null) {
       return null
     }
-    val reportFieldsFromParameters: List<FieldDefinition> = parameters?.map { convert(it) } ?: emptyList()
-    val fields: List<FieldDefinition> = specification.field.map {
-      map(
-        field = it,
-        schemaFields = schemaFields,
-        productDefinitionId = productDefinitionId,
-        reportVariantId = reportVariantId,
-        userToken = userToken,
-        dataProductDefinitionsPath = dataProductDefinitionsPath,
-        filterDatasets = filterDatasets,
-      )
-    }
     return Specification(
       template = specification.template,
       sections = specification.section?.map { it.removePrefix(SCHEMA_REF_PREFIX) } ?: emptyList(),
-      fields = fields + reportFieldsFromParameters,
+      fields = mapToReportFieldDefinitions(
+        specification,
+        schemaFields,
+        productDefinitionId,
+        reportVariantId,
+        userToken,
+        dataProductDefinitionsPath,
+        filterDatasets
+      ) + maybeConvertToReportFieldsFromParameters(parameters),
+    )
+  }
+
+  private fun maybeConvertToReportFieldsFromParameters(parameters: List<Parameter>?) =
+    parameters?.map { convert(it) } ?: emptyList()
+
+  private fun mapToReportFieldDefinitions(
+    specification: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification,
+    schemaFields: List<SchemaField>,
+    productDefinitionId: String,
+    reportVariantId: String,
+    userToken: DprAuthAwareAuthenticationToken?,
+    dataProductDefinitionsPath: String?,
+    filterDatasets: List<Dataset>?,
+  ) = specification.field.map {
+    map(
+      field = it,
+      schemaFields = schemaFields,
+      productDefinitionId = productDefinitionId,
+      reportVariantId = reportVariantId,
+      userToken = userToken,
+      dataProductDefinitionsPath = dataProductDefinitionsPath,
+      filterDatasets = filterDatasets,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -103,11 +103,11 @@ class ReportDefinitionMapper(val configuredApiService: ConfiguredApiService) {
         userToken,
         dataProductDefinitionsPath,
         filterDatasets,
-      ) + maybeConvertToReportFieldsFromParameters(parameters),
+      ) + maybeConvertToReportFields(parameters),
     )
   }
 
-  private fun maybeConvertToReportFieldsFromParameters(parameters: List<Parameter>?) =
+  private fun maybeConvertToReportFields(parameters: List<Parameter>?) =
     parameters?.map { convert(it) } ?: emptyList()
 
   private fun mapToReportFieldDefinitions(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -592,4 +592,279 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       prisonerRepository.delete(ConfiguredApiRepositoryTest.AllPrisoners.prisoner9848)
     }
   }
+
+  class ReportDefinitionParametersListTest : IntegrationTestBase() {
+
+    companion object {
+      @JvmStatic
+      @DynamicPropertySource
+      fun registerProperties(registry: DynamicPropertyRegistry) {
+        registry.add("dpr.lib.definition.locations") { "productDefinitionWithParameters.json" }
+      }
+    }
+
+    @Test
+    fun `Single Definition with parameters is returned with the parameters converted to filters`() {
+      try {
+        prisonerRepository.save(ConfiguredApiRepositoryTest.AllPrisoners.prisoner9848)
+        externalMovementRepository.save(ConfiguredApiRepositoryTest.AllMovements.externalMovementDestinationCaseloadDirectionIn)
+
+        webTestClient.get()
+          .uri { uriBuilder: UriBuilder ->
+            uriBuilder
+              .path("/definitions/external-movements-with-parameters/last-month")
+              .build()
+          }
+          .headers(setAuthorisation(roles = listOf(authorisedRole)))
+          .exchange()
+          .expectStatus()
+          .isOk
+          .expectBody()
+          .json(
+            """
+          {
+            "id": "external-movements-with-parameters",
+            "name": "External Movements",
+            "description": "Reports about prisoner external movements",
+            "variant": {
+              "id": "last-month",
+              "name": "Last month",
+              "resourceName": "reports/external-movements-with-parameters/last-month",
+              "description": "All movements in the past month",
+              "specification": {
+                "template": "list-section",
+                "sections": [ "direction" ],
+                "fields": [
+                  {
+                    "name": "prisonNumber",
+                    "display": "Prison Number",
+                    "wordWrap": null,
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": false,
+                    "visible": true,
+                    "filter": {
+                      "type": "Radio",
+                      "staticOptions": [
+                        {
+                          "name": "DD105GF",
+                          "display": "LastName6, F"
+                        },
+                        {
+                          "name": "G2504UV",
+                          "display": "LastName1, F"
+                        },
+                        {
+                          "name": "G2927UV",
+                          "display": "LastName1, F"
+                        },
+                        {
+                          "name": "G3154UG",
+                          "display": "LastName5, F"
+                        },
+                        {
+                          "name": "G3411VR",
+                          "display": "LastName5, F"
+                        },
+                        {
+                          "name": "G3418VR",
+                          "display": "LastName3, F"
+                        }
+                      ],
+                      "dynamicOptions": {
+                        "minimumLength": 2,
+                        "returnAsStaticOptions": true
+                      },
+                      "defaultValue": null,
+                      "min": null,
+                      "max": null
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "display": "Name",
+                    "wordWrap": "none",
+                    "filter": {
+                      "type": "autocomplete",
+                      "staticOptions": null,
+                      "dynamicOptions": {
+                        "minimumLength": 2,
+                        "returnAsStaticOptions": false,
+                        "maximumOptions": null
+                      },
+                      "defaultValue": null,
+                      "min": null,
+                      "max": null
+                    },
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": false,
+                    "visible": true
+                  },
+                  {
+                    "name": "date",
+                    "display": "Date",
+                    "wordWrap": null,
+                    "filter": {
+                      "type": "daterange",
+                      "staticOptions": null,
+                      "dynamicOptions": null,
+                      "mandatory": false,
+                      "min": null,
+                      "max": null
+                    },
+                    "sortable": true,
+                    "defaultsort": true,
+                    "type": "date",
+                    "mandatory": false,
+                    "visible": true
+                  },
+                  {
+                    "name": "origin",
+                    "display": "From",
+                    "wordWrap": "none",
+                    "filter": {
+                      "type": "text"
+                    },
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": false,
+                    "visible": true
+                  },
+                  {
+                    "name": "destination",
+                    "display": "To",
+                    "wordWrap": "none",
+                    "filter": null,
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "visible": true,
+                    "mandatory": false
+                  },
+                  {
+                    "name": "direction",
+                    "display": "Direction",
+                    "wordWrap": "break-words",
+                    "filter": {
+                      "type": "Radio",
+                      "staticOptions": [
+                        {
+                          "name": "in",
+                          "display": "In"
+                        },
+                        {
+                          "name": "out",
+                          "display": "Out"
+                        }
+                      ],
+                      "dynamicOptions": null,
+                      "defaultValue": null,
+                      "min": null,
+                      "max": null
+                    },
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": false,
+                    "visible": true
+                  },
+                  {
+                    "name": "type",
+                    "display": "Type",
+                    "wordWrap": "normal",
+                    "filter": null,
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": false,
+                    "visible": false
+                  },
+                  {
+                    "name": "reason",
+                    "display": "Reason",
+                    "wordWrap": null,
+                    "filter": {
+                      "type": "autocomplete",
+                      "staticOptions": [
+                        {
+                          "name": "Transfer In from Other Establishment",
+                          "display": "Transfer In from Other Establishment"
+                        }
+                      ],
+                      "dynamicOptions": {
+                        "minimumLength": 2,
+                        "returnAsStaticOptions": true,
+                        "maximumOptions": 1
+                      },
+                      "defaultValue": null,
+                      "min": null,
+                      "max": null
+                    },
+                    "sortable": true,
+                    "defaultsort": false,
+                    "type": "string",
+                    "visible": true,
+                    "mandatory": true
+                  },
+                  {
+                    "name": "is_closed",
+                    "display": "Closed",
+                    "wordWrap":null,
+                    "sortable": true,
+                    "defaultsort":false,
+                    "filter": {
+                      "type": "Radio",
+                      "staticOptions": [
+                        {
+                          "name": "false",
+                          "display": "Only open"
+                        },
+                        {
+                          "name": "true",
+                          "display": "Only closed"
+                        }
+                      ],
+                      "dynamicOptions": null,
+                      "defaultValue":"false",
+                      "min": null,
+                      "max": null
+                    },
+                    "type": "boolean",
+                    "mandatory": false,
+                    "visible": true,
+                    "calculated": false
+                  },
+                  {
+                    "name": "prisoner_number",
+                    "display": "Enter NOMS Number",
+                    "filter": {
+                      "type": "text",
+                      "mandatory": true
+                    },
+                    "sortable": false,
+                    "defaultsort": false,
+                    "type": "string",
+                    "mandatory": true,
+                    "visible": true,
+                    "calculated": false
+                  } 
+                ]
+              },
+              "classification": "report classification",
+              "printable": true
+            }
+          }
+
+            """.trimIndent(),
+          )
+      } finally {
+        externalMovementRepository.delete(ConfiguredApiRepositoryTest.AllMovements.externalMovementDestinationCaseloadDirectionIn)
+        prisonerRepository.delete(ConfiguredApiRepositoryTest.AllPrisoners.prisoner9848)
+      }
+    }
+  }
 }

--- a/src/test/resources/productDefinitionWithParameters.json
+++ b/src/test/resources/productDefinitionWithParameters.json
@@ -1,0 +1,450 @@
+{
+  "id" : "external-movements-with-parameters",
+  "name" : "External Movements",
+  "description" : "Reports about prisoner external movements",
+  "metadata" : {
+    "author" : "Adam",
+    "version" : "1.2.3",
+    "owner" : "Eve"
+  },
+  "datasource" : [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }],
+  "dataset" : [ {
+    "id" : "external-movements",
+    "name" : "All movements",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "parameters": [
+      {
+        "index": 0,
+        "name": "prisoner_number",
+        "filterType": "text",
+        "reportFieldType": "string",
+        "display": "Enter NOMS Number",
+        "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
+        "mandatory": "true"
+      }
+    ],
+    "schema" : {
+      "field" : [ {
+        "name" : "prisonNumber",
+        "type" : "string",
+        "display" : "Prison Number"
+      }, {
+        "name" : "name",
+        "type" : "string",
+        "display" : "Name"
+      }, {
+        "name" : "date",
+        "type" : "date",
+        "display" : ""
+      }, {
+        "name" : "origin",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "origin_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "destination",
+        "type" : "string",
+        "display" : ""
+      },{
+        "name" : "destination_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "direction",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "type",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "reason",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "is_closed",
+        "type" : "boolean",
+        "display" : ""
+      }]
+    }
+  },
+    {
+      "id": "prisoner-dataset",
+      "name": "prisoner dataset",
+      "datasource": "datamart",
+      "query": "SELECT prisoners.number AS prisonNumber, CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name FROM datamart.domain.prisoner_prisoner as prisoners",
+      "schema": {
+        "field": [
+          {
+            "name": "prisonNumber",
+            "type": "string",
+            "display": "Prisoner Number"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "display": "Prisoner Name"
+          }]
+      }
+    }
+  ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseload}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report" : [ {
+    "id" : "last-month",
+    "name" : "Last month",
+    "description" : "All movements in the past month",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list-section",
+      "section": [ "$ref:direction" ],
+      "field" : [
+        {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "Radio",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "dataset": "$ref:prisoner-dataset",
+            "name": "$ref:prisonNumber",
+            "display": "$ref:name"
+          }
+        }
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "mandatory": false,
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "filter" : {
+          "type" : "text"
+        },
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "formula": "formula placeholder"
+  }, {
+    "id" : "last-week",
+    "name" : "Last week",
+    "description" : "All movements in the past week",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "daterange",
+          "default" : "today(-1,weeks) - today()",
+          "mandatory": false
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
+      } ]
+    },
+    "destination" : [ ]
+  }, {
+    "id" : "last-year",
+    "name" : "Last year",
+    "description" : "All movements in the past year",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "mandatory": true,
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "filter" : {
+          "type" : "text",
+          "mandatory": true,
+          "pattern": "[A-Z]{3,3}"
+        },
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "formula": "formula placeholder"
+  } ]
+}


### PR DESCRIPTION
These changes:
- Support a list of parameters in the DPD Dataset.
- Convert the list of parameters to a list of report field with attached filters.
- The schema of the parameter object is assumed to be the following:
```
   {
        "index": 0,
        "name": "prisoner_number",
        "filterType": "text",
        "reportFieldType": "string",
        "display": "Enter NOMS Number",
        "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
        "mandatory": "true"
      }
```
filterTypes currently supported on the Back End:
"Radio", "Select", "daterange", "autocomplete", "text", "date"

reportFieldTypes currently supported on the Back End:
"boolean", "date", "datetime", "double", "float", "int", "long", "string", "time", "timestamp"