### PR TITLE
[DPR2-778] Changes for Report Summary/Aggregate templates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: daily
       time: "03:00"
       timezone: Europe/London
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
           - major
           - feature
           - bug
+          - alpha
 
 jobs:
   publish-package:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+## 4.8.0
+
+Support for Report Summary/Aggregate templates.
+
 ## 4.7.0
 Filters converted from parameters are validated based on whether they have matching parameter names.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -7,8 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -19,10 +17,10 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_PREFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ResponseHeader
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -31,91 +29,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAw
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
 import java.util.Collections.singletonList
 
-const val NO_DATA_WARNING_HEADER_NAME = "x-no-data-warning"
-
 @Validated
 @RestController
-@Tag(name = "Configured Data API")
-class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
-  object FiltersPrefix {
-    const val FILTERS_PREFIX = "filters."
-    const val RANGE_FILTER_START_SUFFIX = ".start"
-    const val RANGE_FILTER_END_SUFFIX = ".end"
-    const val FILTERS_QUERY_DESCRIPTION = """The filter query parameters have to start with the prefix "$FILTERS_PREFIX" followed by the name of the filter.
-      |For range filters, like date for instance, these need to be followed by a $RANGE_FILTER_START_SUFFIX or $RANGE_FILTER_END_SUFFIX suffix accordingly.
-    """
-    const val FILTERS_QUERY_EXAMPLE = """{
-        "filters.date$RANGE_FILTER_START_SUFFIX": "2023-04-25",
-        "filters.date$RANGE_FILTER_END_SUFFIX": "2023-05-30"
-        }"""
-  }
-
-  @GetMapping("/reports/{reportId}/{reportVariantId}")
-  @Operation(
-    description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
-    security = [ SecurityRequirement(name = "bearer-jwt") ],
-    responses = [
-      ApiResponse(
-        headers = [
-          Header(
-            name = NO_DATA_WARNING_HEADER_NAME,
-            description = "Provides additional information about why no data has been returned.",
-          ),
-        ],
-      ),
-    ],
-  )
-  fun configuredApiDataset(
-    @RequestParam(defaultValue = "1")
-    @Min(1)
-    selectedPage: Long,
-    @RequestParam(defaultValue = "10")
-    @Min(1)
-    pageSize: Long,
-    @RequestParam sortColumn: String?,
-    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
-    @Parameter(
-      description = FILTERS_QUERY_DESCRIPTION,
-      example = FILTERS_QUERY_EXAMPLE,
-    )
-    @RequestParam
-    filters: Map<String, String>,
-    @PathVariable("reportId") reportId: String,
-    @PathVariable("reportVariantId") reportVariantId: String,
-    @Parameter(
-      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
-      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
-    )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
-    dataProductDefinitionsPath: String? = null,
-    authentication: Authentication,
-  ): ResponseEntity<List<Map<String, Any?>>> {
-    return try {
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .body(
-          configuredApiService.validateAndFetchData(
-            reportId = reportId,
-            reportVariantId = reportVariantId,
-            filters = filtersOnly(filters),
-            selectedPage = selectedPage,
-            pageSize = pageSize,
-            sortColumn = sortColumn,
-            sortedAsc = sortedAsc,
-            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
-            dataProductDefinitionsPath = dataProductDefinitionsPath,
-          ),
-        )
-    } catch (exception: NoDataAvailableException) {
-      val headers = HttpHeaders()
-      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
-
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .headers(headers)
-        .body(emptyList())
-    }
-  }
+@Tag(name = "Data API - Asynchronous")
+class DataApiAsyncController(val configuredApiService: ConfiguredApiService, val filterHelper: FilterHelper) {
 
   @GetMapping("/async/reports/{reportId}/{reportVariantId}")
   @Operation(
@@ -127,7 +44,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       ApiResponse(
         headers = [
           Header(
-            name = NO_DATA_WARNING_HEADER_NAME,
+            name = ResponseHeader.NO_DATA_WARNING_HEADER_NAME,
             description = "Provides additional information about why no data has been returned.",
           ),
         ],
@@ -160,7 +77,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
           configuredApiService.validateAndExecuteStatementAsync(
             reportId = reportId,
             reportVariantId = reportVariantId,
-            filters = filtersOnly(filters),
+            filters = filterHelper.filtersOnly(filters),
             sortColumn = sortColumn,
             sortedAsc = sortedAsc,
             userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
@@ -169,7 +86,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()
-      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+      headers[ResponseHeader.NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
 
       ResponseEntity
         .status(HttpStatus.OK)
@@ -248,7 +165,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       ApiResponse(
         headers = [
           Header(
-            name = NO_DATA_WARNING_HEADER_NAME,
+            name = ResponseHeader.NO_DATA_WARNING_HEADER_NAME,
             description = "Provides additional information about why no data has been returned.",
           ),
         ],
@@ -267,7 +184,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()
-      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+      headers[ResponseHeader.NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
 
       ResponseEntity
         .status(HttpStatus.OK)
@@ -279,7 +196,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
   @GetMapping("/reports/{reportId}/{reportVariantId}/tables/{tableId}/result")
   @Operation(
     description = "Returns the resulting rows of the executed statement in a paginated " +
-      "fashion which has been have been stored in a dedicated table.",
+      "fashion which has been stored in a dedicated table.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
   )
   fun getQueryExecutionResult(
@@ -310,148 +227,30 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
       )
   }
 
-  @GetMapping("/reports/{reportId}/{reportVariantId}/{fieldId}")
+  @GetMapping("/reports/{reportId}/{reportVariantId}/tables/{tableId}/result/summary/{summaryId}")
   @Operation(
-    description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
-    security = [SecurityRequirement(name = "bearer-jwt")],
-    responses = [
-      ApiResponse(
-        headers = [
-          Header(
-            name = NO_DATA_WARNING_HEADER_NAME,
-            description = "Provides additional information about why no data has been returned.",
-          ),
-        ],
-      ),
-    ],
-  )
-  fun configuredApiDynamicFilter(
-    @RequestParam(defaultValue = "10")
-    @Min(1)
-    pageSize: Long,
-    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
-    @Parameter(
-      description = FILTERS_QUERY_DESCRIPTION,
-      example = FILTERS_QUERY_EXAMPLE,
-    )
-    @RequestParam
-    filters: Map<String, String>,
-    @Parameter(
-      description = "The value to match the start of the fieldId",
-      example = "Lond",
-    )
-    @RequestParam
-    prefix: String,
-    @PathVariable("reportId") reportId: String,
-    @PathVariable("reportVariantId") reportVariantId: String,
-    @Parameter(
-      description = "The name of the schema field which will be used as a dynamic filter.",
-      example = "name",
-    )
-    @PathVariable("fieldId")
-    @NotNull
-    @NotEmpty
-    fieldId: String,
-    @Parameter(
-      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
-      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
-    )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
-    dataProductDefinitionsPath: String? = null,
-    authentication: Authentication,
-  ): ResponseEntity<List<String>> {
-    return try {
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .body(
-          configuredApiService.validateAndFetchData(
-            reportId = reportId,
-            reportVariantId = reportVariantId,
-            filters = filtersOnly(filters),
-            selectedPage = 1,
-            pageSize = pageSize,
-            sortColumn = fieldId,
-            sortedAsc = sortedAsc,
-            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
-            reportFieldId = setOf(fieldId),
-            prefix = prefix,
-            dataProductDefinitionsPath = dataProductDefinitionsPath,
-          ).asSequence()
-            .flatMap {
-              it.asSequence()
-            }.groupBy({ it.key }, { it.value })
-            .values.flatten().map { it.toString() },
-        )
-    } catch (exception: NoDataAvailableException) {
-      val headers = HttpHeaders()
-      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
-
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .headers(headers)
-        .body(emptyList())
-    }
-  }
-
-  @GetMapping("/reports/{reportId}/{reportVariantId}/count")
-  @Operation(
-    description = "Returns the number of records for the given report ID and report variant ID filtered by the filters provided in the query.",
+    description = "Returns a summary of a request, which has been stored in a dedicated table.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
-    responses = [
-      ApiResponse(
-        headers = [
-          Header(
-            name = NO_DATA_WARNING_HEADER_NAME,
-            description = "Provides additional information about why no data has been returned.",
-          ),
-        ],
-      ),
-    ],
   )
-  fun configuredApiCount(
-    @Parameter(
-      description = FILTERS_QUERY_DESCRIPTION,
-      example = FILTERS_QUERY_EXAMPLE,
-    )
-    @RequestParam
-    filters: Map<String, String>,
+  fun getSummaryQueryExecutionResult(
     @PathVariable("reportId") reportId: String,
     @PathVariable("reportVariantId") reportVariantId: String,
-    @Parameter(
-      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
-      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
-    )
     @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
     dataProductDefinitionsPath: String? = null,
+    @PathVariable("tableId") tableId: String,
+    @PathVariable("summaryId") summaryId: String,
     authentication: Authentication,
-  ): ResponseEntity<Count> {
-    return try {
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .body(
-          configuredApiService.validateAndCount(
-            reportId = reportId,
-            reportVariantId = reportVariantId,
-            filters = filtersOnly(filters),
-            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
-            dataProductDefinitionsPath = dataProductDefinitionsPath,
-          ),
-        )
-    } catch (exception: NoDataAvailableException) {
-      val headers = HttpHeaders()
-      headers[NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
-
-      ResponseEntity
-        .status(HttpStatus.OK)
-        .headers(headers)
-        .body(Count(0))
-    }
-  }
-
-  private fun filtersOnly(filters: Map<String, String>): Map<String, String> {
-    return filters.entries
-      .filter { it.key.startsWith(FILTERS_PREFIX) }
-      .filter { it.value.isNotBlank() }
-      .associate { (k, v) -> k.removePrefix(FILTERS_PREFIX) to v }
+  ): ResponseEntity<List<Map<String, Any?>>> {
+    return ResponseEntity
+      .status(HttpStatus.OK)
+      .body(
+        configuredApiService.getSummaryResult(
+          tableId,
+          summaryId,
+          reportId,
+          reportVariantId,
+          dataProductDefinitionsPath,
+        ),
+      )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
@@ -1,0 +1,251 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ResponseHeader
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
+import java.util.Collections.singletonList
+
+@Validated
+@RestController
+@Tag(name = "Data API - Synchronous")
+class DataApiSyncController(val configuredApiService: ConfiguredApiService, val filterHelper: FilterHelper) {
+  object FiltersPrefix {
+    const val FILTERS_PREFIX = "filters."
+    const val RANGE_FILTER_START_SUFFIX = ".start"
+    const val RANGE_FILTER_END_SUFFIX = ".end"
+    const val FILTERS_QUERY_DESCRIPTION = """The filter query parameters have to start with the prefix "$FILTERS_PREFIX" followed by the name of the filter.
+      |For range filters, like date for instance, these need to be followed by a $RANGE_FILTER_START_SUFFIX or $RANGE_FILTER_END_SUFFIX suffix accordingly.
+    """
+    const val FILTERS_QUERY_EXAMPLE = """{
+        "filters.date$RANGE_FILTER_START_SUFFIX": "2023-04-25",
+        "filters.date$RANGE_FILTER_END_SUFFIX": "2023-05-30"
+        }"""
+  }
+
+  @GetMapping("/reports/{reportId}/{reportVariantId}")
+  @Operation(
+    description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
+    security = [ SecurityRequirement(name = "bearer-jwt") ],
+    responses = [
+      ApiResponse(
+        headers = [
+          Header(
+            name = ResponseHeader.NO_DATA_WARNING_HEADER_NAME,
+            description = "Provides additional information about why no data has been returned.",
+          ),
+        ],
+      ),
+    ],
+  )
+  fun configuredApiDataset(
+    @RequestParam(defaultValue = "1")
+    @Min(1)
+    selectedPage: Long,
+    @RequestParam(defaultValue = "10")
+    @Min(1)
+    pageSize: Long,
+    @RequestParam sortColumn: String?,
+    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): ResponseEntity<List<Map<String, Any?>>> {
+    return try {
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .body(
+          configuredApiService.validateAndFetchData(
+            reportId = reportId,
+            reportVariantId = reportVariantId,
+            filters = filterHelper.filtersOnly(filters),
+            selectedPage = selectedPage,
+            pageSize = pageSize,
+            sortColumn = sortColumn,
+            sortedAsc = sortedAsc,
+            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+            dataProductDefinitionsPath = dataProductDefinitionsPath,
+          ),
+        )
+    } catch (exception: NoDataAvailableException) {
+      val headers = HttpHeaders()
+      headers[ResponseHeader.NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .headers(headers)
+        .body(emptyList())
+    }
+  }
+
+  @GetMapping("/reports/{reportId}/{reportVariantId}/{fieldId}")
+  @Operation(
+    description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+    responses = [
+      ApiResponse(
+        headers = [
+          Header(
+            name = ResponseHeader.NO_DATA_WARNING_HEADER_NAME,
+            description = "Provides additional information about why no data has been returned.",
+          ),
+        ],
+      ),
+    ],
+  )
+  fun configuredApiDynamicFilter(
+    @RequestParam(defaultValue = "10")
+    @Min(1)
+    pageSize: Long,
+    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @Parameter(
+      description = "The value to match the start of the fieldId",
+      example = "Lond",
+    )
+    @RequestParam
+    prefix: String,
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @Parameter(
+      description = "The name of the schema field which will be used as a dynamic filter.",
+      example = "name",
+    )
+    @PathVariable("fieldId")
+    @NotNull
+    @NotEmpty
+    fieldId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): ResponseEntity<List<String>> {
+    return try {
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .body(
+          configuredApiService.validateAndFetchData(
+            reportId = reportId,
+            reportVariantId = reportVariantId,
+            filters = filterHelper.filtersOnly(filters),
+            selectedPage = 1,
+            pageSize = pageSize,
+            sortColumn = fieldId,
+            sortedAsc = sortedAsc,
+            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+            reportFieldId = setOf(fieldId),
+            prefix = prefix,
+            dataProductDefinitionsPath = dataProductDefinitionsPath,
+          ).asSequence()
+            .flatMap {
+              it.asSequence()
+            }.groupBy({ it.key }, { it.value })
+            .values.flatten().map { it.toString() },
+        )
+    } catch (exception: NoDataAvailableException) {
+      val headers = HttpHeaders()
+      headers[ResponseHeader.NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .headers(headers)
+        .body(emptyList())
+    }
+  }
+
+  @GetMapping("/reports/{reportId}/{reportVariantId}/count")
+  @Operation(
+    description = "Returns the number of records for the given report ID and report variant ID filtered by the filters provided in the query.",
+    security = [ SecurityRequirement(name = "bearer-jwt") ],
+    responses = [
+      ApiResponse(
+        headers = [
+          Header(
+            name = ResponseHeader.NO_DATA_WARNING_HEADER_NAME,
+            description = "Provides additional information about why no data has been returned.",
+          ),
+        ],
+      ),
+    ],
+  )
+  fun configuredApiCount(
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): ResponseEntity<Count> {
+    return try {
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .body(
+          configuredApiService.validateAndCount(
+            reportId = reportId,
+            reportVariantId = reportVariantId,
+            filters = filterHelper.filtersOnly(filters),
+            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+            dataProductDefinitionsPath = dataProductDefinitionsPath,
+          ),
+        )
+    } catch (exception: NoDataAvailableException) {
+      val headers = HttpHeaders()
+      headers[ResponseHeader.NO_DATA_WARNING_HEADER_NAME] = singletonList(exception.reason)
+
+      ResponseEntity
+        .status(HttpStatus.OK)
+        .headers(headers)
+        .body(Count(0))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/FilterHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/FilterHelper.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller
+
+import org.springframework.stereotype.Component
+
+@Component
+class FilterHelper {
+  fun filtersOnly(filters: Map<String, String>): Map<String, String> {
+    return filters.entries
+      .filter { it.key.startsWith(DataApiSyncController.FiltersPrefix.FILTERS_PREFIX) }
+      .filter { it.value.isNotBlank() }
+      .associate { (k, v) -> k.removePrefix(DataApiSyncController.FiltersPrefix.FILTERS_PREFIX) to v }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ReportSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ReportSummary.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+data class ReportSummary(
+  val id: String,
+  val template: SummaryTemplate,
+  val fields: List<SummaryField> = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ResponseHeader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ResponseHeader.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+class ResponseHeader {
+  companion object {
+    const val NO_DATA_WARNING_HEADER_NAME: String = "x-no-data-warning"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Specification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Specification.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
 data class Specification(
-  val template: String,
+  val template: Template,
   val fields: List<FieldDefinition>,
   val sections: List<String> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/SummaryField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/SummaryField.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+data class SummaryField(
+  val name: String,
+  val display: String?,
+  val type: FieldType?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/SummaryTemplate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/SummaryTemplate.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class SummaryTemplate(@JsonValue val template: String) {
+  TableHeader("table-header"),
+  TableFooter("table-footer"),
+  SectionFooter("section-footer"),
+  PageHeader("page-header"),
+  PageFooter("page-footer"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Template.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Template.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class Template(@JsonValue val template: String) {
+  List("list"),
+  ListSection("list-section"),
+  ListAggregate("list-aggregate"),
+  ListTab("list-tab"),
+  CrossTab("crosstab"),
+  ListSummary("summary"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/VariantDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/VariantDefinition.kt
@@ -8,4 +8,5 @@ data class VariantDefinition(
   val specification: Specification? = null,
   val classification: String? = null,
   val printable: Boolean? = true,
+  val summaries: List<ReportSummary>? = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AbstractProductDefinitionRepository.kt
@@ -1,10 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
 import jakarta.validation.ValidationException
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService.Companion.SCHEMA_REF_PREFIX
 
@@ -34,7 +31,7 @@ abstract class AbstractProductDefinitionRepository : ProductDefinitionRepository
       metadata = productDefinition.metadata,
       datasource = productDefinition.datasource.first(),
       reportDataset = dataSet,
-      filterDatasets = findDatasetsForDynamicOptionFilters(reportDefinition, productDefinition.dataset),
+      allDatasets = productDefinition.dataset,
       report = reportDefinition,
       policy = productDefinition.policy,
     )
@@ -44,17 +41,4 @@ abstract class AbstractProductDefinitionRepository : ProductDefinitionRepository
     .filter { it.id == definitionId }
     .ifEmpty { throw ValidationException("Invalid report id provided: $definitionId") }
     .first()
-
-  private fun findDatasetsForDynamicOptionFilters(
-    reportDefinition: Report,
-    productDefinitionDatasets: List<Dataset>,
-  ) = reportDefinition.specification?.field
-    ?.map { field: ReportField ->
-      field.filter?.dynamicOptions?.dataset?.removePrefix(SCHEMA_REF_PREFIX)
-    }?.flatMap { datasetIdForFilterWithoutPrefix ->
-      productDefinitionDatasets
-        .filter { productDefinitionDataset: Dataset ->
-          datasetIdForFilterWithoutPrefix == productDefinitionDataset.id
-        }
-    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -4,25 +4,28 @@ import org.apache.commons.lang3.time.StopWatch
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
 
-abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
+abstract class AthenaAndRedshiftCommonRepository(
+  private val tableIdGenerator: TableIdGenerator,
+  private val datasetHelper: DatasetHelper,
+) : RepositoryHelper() {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   abstract fun executeQueryAsync(
-    query: String,
+    productDefinition: SingleReportProductDefinition,
     filters: List<ConfiguredApiRepository.Filter>,
     sortColumn: String?,
     sortedAsc: Boolean,
     policyEngineResult: String,
     dynamicFilterFieldId: Set<String>? = null,
-    database: String? = null,
-    catalog: String? = null,
     prompts: Map<String, String>? = null,
   ): StatementExecutionResponse
 
@@ -48,6 +51,24 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     return result
   }
 
+  fun getFullExternalTableResult(
+    tableId: String,
+    jdbcTemplate: NamedParameterJdbcTemplate = populateJdbcTemplate(),
+  ): List<Map<String, Any?>> {
+    val stopwatch = StopWatch.createStarted()
+    val result = jdbcTemplate
+      .queryForList(
+        "SELECT * FROM reports.$tableId;",
+        MapSqlParameterSource(),
+      )
+      .map {
+        transformTimestampToLocalDateTime(it)
+      }
+    stopwatch.stop()
+    log.debug("Query Execution time in ms: {}", stopwatch.time)
+    return result
+  }
+
   abstract fun cancelStatementExecution(statementId: String): StatementCancellationResponse
 
   fun count(tableId: String, jdbcTemplate: NamedParameterJdbcTemplate = populateJdbcTemplate()): Long {
@@ -56,4 +77,19 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
       MapSqlParameterSource(),
     ).first()?.get("total") as Long
   }
+
+  protected fun buildSummaryQueries(productDefinition: SingleReportProductDefinition, tableId: String): String? {
+    return productDefinition.report.summary?.joinToString(" ") {
+      val summaryTableId = tableIdGenerator.getTableSummaryId(tableId, it.id)
+      val query = datasetHelper.findDataset(productDefinition.allDatasets, it.dataset).query
+      val substitutedQuery = query.replace(TABLE_TOKEN_NAME, "reports.$tableId")
+
+      buildSummaryQuery(
+        substitutedQuery,
+        summaryTableId,
+      )
+    }
+  }
+
+  protected abstract fun buildSummaryQuery(query: String, summaryTableId: String): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/DatasetHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/DatasetHelper.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
+
+import jakarta.validation.ValidationException
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ConfiguredApiService
+
+@Component
+class DatasetHelper {
+  fun findDataset(allDatasets: List<Dataset>, id: String): Dataset =
+    allDatasets.find { it.id == id.removePrefix(ConfiguredApiService.SCHEMA_REF_PREFIX) }
+      ?: throw ValidationException("Invalid dataSetId: $id")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -50,7 +50,7 @@ class RedshiftDataApiRepository(
           );
           ${buildSummaryQueries(productDefinition, tableId)}
     """.trimIndent()
-    log.info(generateSql)
+
     val statementRequest = ExecuteStatementRequest.builder()
       .clusterIdentifier(redshiftDataApiClusterId)
       .database(redshiftDataApiDb)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient
@@ -8,6 +7,7 @@ import software.amazon.awssdk.services.redshiftdata.model.CancelStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -17,25 +17,20 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGen
 class RedshiftDataApiRepository(
   val redshiftDataClient: RedshiftDataClient,
   val tableIdGenerator: TableIdGenerator,
+  datasetHelper: DatasetHelper,
   @Value("\${dpr.lib.redshiftdataapi.database:db}") private val redshiftDataApiDb: String,
   @Value("\${dpr.lib.redshiftdataapi.clusterid:clusterId}") private val redshiftDataApiClusterId: String,
   @Value("\${dpr.lib.redshiftdataapi.secretarn:arn}") private val redshiftDataApiSecretArn: String,
   @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
   private val s3location: String = "dpr-working-development/reports",
-) : AthenaAndRedshiftCommonRepository() {
-
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
+) : AthenaAndRedshiftCommonRepository(tableIdGenerator, datasetHelper) {
   override fun executeQueryAsync(
-    query: String,
+    productDefinition: SingleReportProductDefinition,
     filters: List<ConfiguredApiRepository.Filter>,
     sortColumn: String?,
     sortedAsc: Boolean,
     policyEngineResult: String,
     dynamicFilterFieldId: Set<String>?,
-    database: String?,
-    catalog: String?,
     prompts: Map<String, String>?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
@@ -46,14 +41,16 @@ class RedshiftDataApiRepository(
           AS ( 
           ${
       buildFinalQuery(
-        buildReportQuery(query),
+        buildReportQuery(productDefinition.reportDataset.query),
         buildPolicyQuery(policyEngineResult),
         buildFiltersQuery(filters),
         buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
       )
     }
           );
+          ${buildSummaryQueries(productDefinition, tableId)}
     """.trimIndent()
+    log.info(generateSql)
     val statementRequest = ExecuteStatementRequest.builder()
       .clusterIdentifier(redshiftDataApiClusterId)
       .database(redshiftDataApiDb)
@@ -75,7 +72,6 @@ class RedshiftDataApiRepository(
     return StatementExecutionStatus(
       status = describeStatementResponse.statusAsString(),
       duration = describeStatementResponse.duration(),
-      queryString = describeStatementResponse.queryString(),
       resultRows = describeStatementResponse.resultRows(),
       resultSize = describeStatementResponse.resultSize(),
       error = describeStatementResponse.error(),
@@ -101,5 +97,14 @@ class RedshiftDataApiRepository(
       FilterType.DYNAMIC -> "${filter.field} ILIKE '${filter.value}%'"
       FilterType.BOOLEAN -> "${filter.field} = ${filter.value.toBoolean()}"
     }
+  }
+
+  override fun buildSummaryQuery(query: String, summaryTableId: String): String {
+    return """
+          CREATE EXTERNAL TABLE reports.$summaryTableId 
+          STORED AS parquet 
+          LOCATION 's3://$s3location/$summaryTableId/' 
+          AS ($query);
+    """
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult
 import java.sql.Timestamp
 import javax.sql.DataSource
@@ -22,6 +22,8 @@ abstract class RepositoryHelper {
     const val DATASET_ = """dataset_"""
     const val POLICY_ = """policy_"""
     const val FILTER_ = """filter_"""
+
+    const val TABLE_TOKEN_NAME = "\${tableId}"
   }
 
   @Autowired

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
@@ -15,4 +15,5 @@ data class Report(
   val destination: List<Map<String, String>> = emptyList(),
   val classification: String? = null,
   val feature: List<Feature>? = emptyList(),
+  val summary: List<ReportSummary>? = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportSummary.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class ReportSummary(
+  val id: String,
+  val dataset: String,
+  val template: SummaryTemplate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleReportProductDefinition.kt
@@ -11,5 +11,5 @@ data class SingleReportProductDefinition(
   val reportDataset: Dataset,
   val report: Report,
   val policy: List<Policy>,
-  val filterDatasets: List<Dataset>? = null,
+  val allDatasets: List<Dataset>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Specification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Specification.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
 data class Specification(
-  val template: String,
+  val template: Template,
   val field: List<ReportField>,
   val section: List<String>?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SummaryTemplate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SummaryTemplate.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+import com.google.gson.annotations.SerializedName
+
+enum class SummaryTemplate {
+  @SerializedName("table-header")
+  TableHeader,
+
+  @SerializedName("table-footer")
+  TableFooter,
+
+  @SerializedName("section-footer")
+  SectionFooter,
+
+  @SerializedName("page-header")
+  PageHeader,
+
+  @SerializedName("page-footer")
+  PageFooter,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Template.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Template.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+import com.google.gson.annotations.SerializedName
+
+enum class Template {
+  @SerializedName("list")
+  List,
+
+  @SerializedName("list-section")
+  ListSection,
+
+  @SerializedName("list-aggregate")
+  ListAggregate,
+
+  @SerializedName("list-tab")
+  ListTab,
+
+  @SerializedName("crosstab")
+  CrossTab,
+
+  @SerializedName("summary")
+  ListSummary,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -13,7 +13,6 @@ data class StatementExecutionStatus(
     description = "The amount of time in nanoseconds that the statement ran.",
   )
   val duration: Long,
-  val queryString: String,
   @Schema(
     example = "10",
     description = "The number of rows returned from the query.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/TableIdGenerator.kt
@@ -9,4 +9,7 @@ class TableIdGenerator {
   fun generateNewExternalTableId(): String {
     return "_" + UUID.randomUUID().toString().replace("-", "_")
   }
+
+  fun getTableSummaryId(tableId: String, summaryId: String): String =
+    "${tableId}_${summaryId.replace('-', '_')}"
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,9 +1,12 @@
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.TokenConverterAutoConfig
-uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.FilterHelper
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiAsyncController
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DprOpenApiConfiguration
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.RedshiftDataApiConfig
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.DatasetHelper
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepositoryAutoConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.CaseloadProviderAutoConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ResourceServerConfiguration

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/JsonFileProductDefinitionRepositoryTest.kt
@@ -5,10 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Condition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Effect
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
@@ -51,34 +47,5 @@ class JsonFileProductDefinitionRepositoryTest {
       )
     }
     assertThat(exception).message().isEqualTo("Invalid dataSetId in report: non-matching-dataset")
-  }
-
-  @Test
-  fun `getSingleReportProductDefinition returns the correct product definition which includes also the filterDatasets when they exist`() {
-    val jsonFileProductDefinitionRepository = JsonFileProductDefinitionRepository(
-      listOf("productDefinition.json"),
-      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
-    )
-    val productDefinition = jsonFileProductDefinitionRepository
-      .getSingleReportProductDefinition("external-movements", "last-month")
-
-    assertThat(productDefinition).isNotNull
-    assertThat(productDefinition.id).isEqualTo("external-movements")
-    assertThat(productDefinition.filterDatasets)
-      .isEqualTo(
-        listOf(
-          Dataset(
-            "prisoner-dataset",
-            "prisoner dataset",
-            "SELECT prisoners.number AS prisonNumber, CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name FROM datamart.domain.prisoner_prisoner as prisoners",
-            Schema(
-              listOf(
-                SchemaField("prisonNumber", ParameterType.String, "Prisoner Number"),
-                SchemaField("name", ParameterType.String, "Prisoner Name"),
-              ),
-            ),
-          ),
-        ),
-      )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
@@ -17,10 +17,10 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.StatusAssertions
 import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.FILTERS_PREFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.NO_DATA_WARNING_HEADER_NAME
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.FILTERS_PREFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ResponseHeader
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION_CODE
@@ -37,7 +37,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ExternalMovem
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.WARNING_NO_ACTIVE_CASELOAD
 import java.time.LocalDateTime
 
-class ConfiguredApiIntegrationTest : IntegrationTestBase() {
+class DataApiIntegrationTest : IntegrationTestBase() {
   companion object {
     fun dateTimeWithSeconds(dateTime: Any?) = """$dateTime:00"""
 
@@ -63,7 +63,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   """.trimIndent()
 
   @Test
-  fun `Configured API returns value from the repository`() {
+  fun `Data API returns value from the repository`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -102,7 +102,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API returns value from the repository when the definitions are retrieved via the web client`() {
+    fun `Data API returns value from the repository when the definitions are retrieved via the web client`() {
       webTestClient.get()
         .uri { uriBuilder: UriBuilder ->
           uriBuilder
@@ -131,7 +131,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API count returns the number of records when the definitions are retrieved via the web client`() {
+    fun `Data API count returns the number of records when the definitions are retrieved via the web client`() {
       webTestClient.get()
         .uri("/reports/external-movements/last-month/count")
         .headers(setAuthorisation(roles = listOf(authorisedRole)))
@@ -143,7 +143,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API calls the definitions service when the cache is disabled`() {
+    fun `Data API calls the definitions service when the cache is disabled`() {
       val expectedJson = """[
         {"prisonNumber": "${movementPrisoner4[PRISON_NUMBER]}", "name": "${movementPrisoner4[NAME]}", "date": "${movementPrisoner4[DATE]}:00", 
         "origin": "${movementPrisoner4[ORIGIN]}", "origin_code": "${movementPrisoner4[ORIGIN_CODE]}", "destination": "${movementPrisoner4[DESTINATION]}", "destination_code": "${movementPrisoner4[DESTINATION_CODE]}", 
@@ -206,7 +206,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API returns value from the cache when it is enabled`() {
+    fun `Data API returns value from the cache when it is enabled`() {
       val expectedJson = """[
         {"prisonNumber": "${movementPrisoner4[PRISON_NUMBER]}", "name": "${movementPrisoner4[NAME]}", "date": "${movementPrisoner4[DATE]}:00", 
         "origin": "${movementPrisoner4[ORIGIN]}", "origin_code": "${movementPrisoner4[ORIGIN_CODE]}", "destination": "${movementPrisoner4[DESTINATION]}", "destination_code": "${movementPrisoner4[DESTINATION_CODE]}", 
@@ -268,7 +268,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API returns value from the repository formatting the fields with formulas correctly`() {
+    fun `Data API returns value from the repository formatting the fields with formulas correctly`() {
       webTestClient.get()
         .uri { uriBuilder: UriBuilder ->
           uriBuilder
@@ -299,7 +299,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `Configured API returns empty String as the value from the repository for a field which has a formula and whose result set value is null`() {
+    fun `Data API returns empty String as the value from the repository for a field which has a formula and whose result set value is null`() {
       externalMovementRepository.delete(externalMovement4)
       val externalMovement4WithNullType = ExternalMovementEntity(
         4,
@@ -346,7 +346,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API count returns the number of records`() {
+  fun `Data API count returns the number of records`() {
     webTestClient.get()
       .uri("/reports/external-movements/last-month/count")
       .headers(setAuthorisation(roles = listOf(authorisedRole)))
@@ -363,7 +363,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     "Out, 1",
     ",    1",
   )
-  fun `Configured API count returns filtered value`(direction: String?, numberOfResults: Int) {
+  fun `Data API count returns filtered value`(direction: String?, numberOfResults: Int) {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -380,7 +380,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API returns value matching the filters provided`() {
+  fun `Data API returns value matching the filters provided`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -406,7 +406,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API returns value matching the dynamic filters provided`() {
+  fun `Data API returns value matching the dynamic filters provided`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -432,7 +432,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API returns value matching the dynamic filters provided, with case insensitivity`() {
+  fun `Data API returns value matching the dynamic filters provided, with case insensitivity`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -458,7 +458,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API call without query params defaults to preset query params`() {
+  fun `Data API call without query params defaults to preset query params`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -489,7 +489,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     "Out, 1",
     ",    1",
   )
-  fun `Configured API returns filtered values`(direction: String?, numberOfResults: Int) {
+  fun `Data API returns filtered values`(direction: String?, numberOfResults: Int) {
     val results = webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -514,7 +514,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API returns empty list and warning header if no active caseloads`() {
+  fun `Data API returns empty list and warning header if no active caseloads`() {
     wireMockServer.resetAll()
     wireMockServer.stubFor(
       WireMock.get("/me/caseloads").willReturn(
@@ -541,13 +541,13 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
       .expectStatus()
       .isOk()
       .expectHeader()
-      .valueEquals(NO_DATA_WARNING_HEADER_NAME, WARNING_NO_ACTIVE_CASELOAD)
+      .valueEquals(ResponseHeader.NO_DATA_WARNING_HEADER_NAME, WARNING_NO_ACTIVE_CASELOAD)
       .expectBody()
       .json("[]")
   }
 
   @Test
-  fun `Configured API count returns zero and warning header if no active caseloads`() {
+  fun `Data API count returns zero and warning header if no active caseloads`() {
     wireMockServer.resetAll()
     wireMockServer.stubFor(
       WireMock.get("/me/caseloads").willReturn(
@@ -566,58 +566,58 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
       .expectStatus()
       .isOk()
       .expectHeader()
-      .valueEquals(NO_DATA_WARNING_HEADER_NAME, WARNING_NO_ACTIVE_CASELOAD)
+      .valueEquals(ResponseHeader.NO_DATA_WARNING_HEADER_NAME, WARNING_NO_ACTIVE_CASELOAD)
       .expectBody()
       .jsonPath("count").isEqualTo("0")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid selectedPage query param`() {
+  fun `Data API returns 400 for invalid selectedPage query param`() {
     requestWithQueryAndAssert400("selectedPage", 0, "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid pageSize query param`() {
+  fun `Data API returns 400 for invalid pageSize query param`() {
     requestWithQueryAndAssert400("pageSize", 0, "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid (wrong type) pageSize query param`() {
+  fun `Data API returns 400 for invalid (wrong type) pageSize query param`() {
     requestWithQueryAndAssert400("pageSize", "a", "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid sortColumn query param`() {
+  fun `Data API returns 400 for invalid sortColumn query param`() {
     requestWithQueryAndAssert400("sortColumn", "nonExistentColumn", "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid sortedAsc query param`() {
+  fun `Data API returns 400 for invalid sortedAsc query param`() {
     requestWithQueryAndAssert400("sortedAsc", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API returns 400 for non-existent filter`() {
+  fun `Data API returns 400 for non-existent filter`() {
     requestWithQueryAndAssert400("${FILTERS_PREFIX}abc", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API count returns 400 for non-existent filter`() {
+  fun `Data API count returns 400 for non-existent filter`() {
     requestWithQueryAndAssert400("${FILTERS_PREFIX}abc", "abc", "/reports/external-movements/last-month/count")
   }
 
   @Test
-  fun `Configured API returns 400 for a report field which is not a filter`() {
+  fun `Data API returns 400 for a report field which is not a filter`() {
     requestWithQueryAndAssert400("${FILTERS_PREFIX}destination", "some name", "/reports/external-movements/last-month")
   }
 
   @Test
-  fun `Configured API count returns 400 for a report field which is not a filter`() {
+  fun `Data API count returns 400 for a report field which is not a filter`() {
     requestWithQueryAndAssert400("${FILTERS_PREFIX}destination", "some name", "/reports/external-movements/last-month/count")
   }
 
   @Test
-  fun `Configured API returns 400 for invalid startDate query param`() {
+  fun `Data API returns 400 for invalid startDate query param`() {
     requestWithQueryAndAssert400("${FILTERS_PREFIX}date$RANGE_FILTER_START_SUFFIX", "abc", "/reports/external-movements/last-month")
   }
 
@@ -627,12 +627,12 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Configured API count returns 400 for invalid startDate query param`() {
+  fun `Data API count returns 400 for invalid startDate query param`() {
     requestWithQueryAndAssert400("filters.startDate", "a", "/reports/external-movements/last-month/count")
   }
 
   @Test
-  fun `Configured API count returns 400 for invalid endDate query param`() {
+  fun `Data API count returns 400 for invalid endDate query param`() {
     requestWithQueryAndAssert400("filters.endDate", "17-12-2050", "/reports/external-movements/last-month/count")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/JwtAuthHelper.kt
@@ -16,12 +16,14 @@ import java.util.UUID
 
 @Component
 class JwtAuthHelper {
-  private val keyPair: KeyPair
+  private val keyPair: KeyPair = createKeyPair()
 
-  init {
-    val gen = KeyPairGenerator.getInstance("RSA")
-    gen.initialize(2048)
-    keyPair = gen.generateKeyPair()
+  companion object {
+    fun createKeyPair(): KeyPair {
+      val gen = KeyPairGenerator.getInstance("RSA")
+      gen.initialize(2048)
+      return gen.generateKeyPair()
+    }
   }
 
   @Bean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -1537,7 +1537,7 @@ class ConfiguredApiServiceTest {
     )
     val productDefinition = productDefinitionRepository.getProductDefinitions().first()
     val singleReportProductDefinition = productDefinitionRepository.getSingleReportProductDefinition(productDefinition.id, productDefinition.report.first().id)
-    val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository)
+    val configuredApiService = ConfiguredApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, datasetHelper)
     val parameterName = "prisoner_number"
     val parameterValue = "somePrisonerNumber"
     val filters = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -21,8 +21,14 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionG
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.Count
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.*
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AthenaApiRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.Filter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.DatasetHelper
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IsoLocalDateTimeTypeAdaptor
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.JsonFileProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RedshiftDataApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.Companion.EXTERNAL_MOVEMENTS_PRODUCT_ID
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.BOOLEAN
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_END

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -48,6 +48,13 @@ class ReportDefinitionServiceTest {
     listOf(Rule(Effect.PERMIT, emptyList())),
   )
 
+  private val dataset = Dataset(
+    id = "10",
+    name = "11",
+    query = "12",
+    schema = Schema(emptyList()),
+  )
+
   private val minimalSingleDefinition = SingleReportProductDefinition(
     id = "1",
     name = "2",
@@ -59,12 +66,7 @@ class ReportDefinitionServiceTest {
       dataset = "\$ref:10",
       render = HTML,
     ),
-    reportDataset = Dataset(
-      id = "10",
-      name = "11",
-      query = "12",
-      schema = Schema(emptyList()),
-    ),
+    reportDataset = dataset,
     datasource = Datasource(
       id = "20",
       name = "21",
@@ -75,6 +77,7 @@ class ReportDefinitionServiceTest {
       owner = "32",
     ),
     policy = listOf(policy),
+    allDatasets = listOf(dataset),
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Template
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Visible
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.WordWrap
 import java.time.LocalDateTime
@@ -54,7 +55,7 @@ class ReportDefinitionSummaryMapperTest {
     render = RenderMethod.PDF,
     schedule = "26",
     specification = Specification(
-      template = "27",
+      template = Template.ListSection,
       section = null,
       field = listOf(
         ReportField(

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -82,6 +82,19 @@
             "display": "Prisoner Name"
           }]
       }
+    },
+    {
+      "id": "summary-dataset",
+      "name": "Summary Dataset",
+      "datasource": "datamart",
+      "query": "SELECT COUNT(*) AS TOTAL FROM ${tableId}",
+      "schema": {
+        "field": [{
+          "name": "total",
+          "type": "int",
+          "display": "Total"
+        }]
+      }
     }
   ],
   "policy": [
@@ -228,7 +241,11 @@
       } ]
     },
     "destination" : [ ],
-    "formula": "formula placeholder"
+    "summary": [{
+      "id": "summaryId",
+      "template": "page-header",
+      "dataset": "$ref:summary-dataset"
+    }]
   }, {
     "id" : "last-week",
     "name" : "Last week",
@@ -432,7 +449,6 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   } ]
 }

--- a/src/test/resources/productDefinitionBodmis.json
+++ b/src/test/resources/productDefinitionBodmis.json
@@ -194,8 +194,7 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   }, {
     "id" : "last-week",
     "name" : "Last week",

--- a/src/test/resources/productDefinitionNomis.json
+++ b/src/test/resources/productDefinitionNomis.json
@@ -194,8 +194,7 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   }, {
     "id" : "last-week",
     "name" : "Last week",

--- a/src/test/resources/productDefinitionPolicyNoAction.json
+++ b/src/test/resources/productDefinitionPolicyNoAction.json
@@ -156,7 +156,6 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   } ]
 }

--- a/src/test/resources/productDefinitionWithParameters.json
+++ b/src/test/resources/productDefinitionWithParameters.json
@@ -241,8 +241,7 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   }, {
     "id" : "last-week",
     "name" : "Last week",
@@ -446,7 +445,6 @@
         }
       } ]
     },
-    "destination" : [ ],
-    "formula": "formula placeholder"
+    "destination" : [ ]
   } ]
 }


### PR DESCRIPTION
- Split the Configured Data API controller into: Sync and Async Data API controllers.
- Added new endpoint for summary requests.
- Added summary data to table query execution.
- Added schema changes for report summaries.
- Added mapping for summary definition information.
- Removed report query from status response.