### PR TITLE
DPR2-980 Filters converted from parameters proper validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.6.1
+Filters converted from parameters are validated based on whether they have matching parameter names.
+
 ## 4.6.0
 Support parameters in the DPD dataset and return them as filters in the report definition response.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -23,6 +23,7 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     dynamicFilterFieldId: Set<String>? = null,
     database: String? = null,
     catalog: String? = null,
+    prompts: Map<String, String>? = null,
   ): StatementExecutionResponse
 
   abstract fun getStatementStatus(statementId: String): StatementExecutionStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -37,6 +37,7 @@ class AthenaApiRepository(
     dynamicFilterFieldId: Set<String>?,
     database: String?,
     catalog: String?,
+    prompts: Map<String, String>?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val queryExecutionContext = QueryExecutionContext.builder()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -36,6 +36,7 @@ class RedshiftDataApiRepository(
     dynamicFilterFieldId: Set<String>?,
     database: String?,
     catalog: String?,
+    prompts: Map<String, String>?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val generateSql = """

--- a/src/test/resources/productDefinitionWithParameters.json
+++ b/src/test/resources/productDefinitionWithParameters.json
@@ -10,7 +10,9 @@
   "datasource" : [
     {
       "id": "datamart",
-      "name": "datamart"
+      "name": "datamart",
+      "database": "datamart",
+      "catalog": "datamart"
     }],
   "dataset" : [ {
     "id" : "external-movements",


### PR DESCRIPTION
Filters converted from parameters are validated based on whether they have matching parameter names.
With these changes the filters that were converted from parameters are extracted from the filters based on whether they have matching parameter names and put into a prompts map since (as part of later changes) they will be used to construct the prompts CTE in the repository for the async calls.