### PR TITLE
Dpr2 939 prompts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.9.0
+Create the prompts_ CTE from the filters which originated from the DPD parameters and embed it into the Athena query.
+
 ## 4.8.0
 
 Support for Report Summary/Aggregate templates.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -31,6 +31,10 @@ abstract class AthenaAndRedshiftCommonRepository(
 
   abstract fun getStatementStatus(statementId: String): StatementExecutionStatus
 
+  abstract fun cancelStatementExecution(statementId: String): StatementCancellationResponse
+
+  protected abstract fun buildSummaryQuery(query: String, summaryTableId: String): String
+
   fun getPaginatedExternalTableResult(
     tableId: String,
     selectedPage: Long,
@@ -69,8 +73,6 @@ abstract class AthenaAndRedshiftCommonRepository(
     return result
   }
 
-  abstract fun cancelStatementExecution(statementId: String): StatementCancellationResponse
-
   fun count(tableId: String, jdbcTemplate: NamedParameterJdbcTemplate = populateJdbcTemplate()): Long {
     return jdbcTemplate.queryForList(
       "SELECT COUNT(1) as total FROM reports.$tableId;",
@@ -90,6 +92,4 @@ abstract class AthenaAndRedshiftCommonRepository(
       )
     }
   }
-
-  protected abstract fun buildSummaryQuery(query: String, summaryTableId: String): String
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ConfiguredApiServiceTest.kt
@@ -1536,7 +1536,7 @@ class ConfiguredApiServiceTest {
   }
 
   @Test
-  fun `validateAndExecuteStatementAsync should not fail validation for filters which were converted from DPD parameters`() {
+  fun `validateAndExecuteStatementAsync should not fail validation for filters which were converted from DPD parameters and convert these filters to prompts`() {
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
       listOf("productDefinitionWithParameters.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),


### PR DESCRIPTION
These changes: 

- Put the filters which originated from the DPD parameters into a prompts_ CTE in the Athena query.
Example prompts_ CTE:
`"WITH $PROMPTS AS (SELECT ''filterValue1'' AS filterName1, ''filterValue2'' AS filterName2 FROM DUAL)"`