### PR TITLE
DPR2-996 use main report query as is if it has dataset_ cte embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.10.0
+If the main dataset query has a dataset_ CTE embedded, then the query is used as is, without recreating the dataset_ CTE in the Athena queries.
+
 ## 4.9.1
 Added debug logs for the async queries.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -104,7 +104,8 @@ class AthenaApiRepository(
     return StatementCancellationResponse(true)
   }
 
-  override fun buildReportQuery(query: String) = """$DATASET_ AS ($query)"""
+  override fun buildReportQuery(query: String) =
+    if (query.contains("$DATASET_ AS", ignoreCase = true)) query else """$DATASET_ AS ($query)"""
 
   private fun buildPromptsQuery(prompts: Map<String, String>?): String {
     if (prompts.isNullOrEmpty()) {


### PR DESCRIPTION
If the main dataset query has a dataset_ CTE embedded, then the query is used as is, without recreating the dataset_ CTE in the Athena queries.