### PR TITLE
DPR2-1003 make use of prefilter_ CTE for Athena queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 4.12.0
+Addition of a prefilter_ CTE to the Athena queries.
+
 ## 4.11.3
 Fix summary table check exception handling.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
@@ -20,12 +20,14 @@ abstract class RepositoryHelper {
     const val FALSE_WHERE_CLAUSE = "0=1"
 
     const val DATASET_ = """dataset_"""
+    const val PREFILTER_ = """prefilter_"""
     const val POLICY_ = """policy_"""
     const val FILTER_ = """filter_"""
     const val PROMPT = """prompt_"""
     const val CONTEXT = """context_"""
 
     const val TABLE_TOKEN_NAME = "\${tableId}"
+    const val DEFAULT_PREFILTER_CTE = "prefilter_ AS (SELECT * FROM dataset_)"
   }
 
   @Autowired
@@ -64,7 +66,8 @@ abstract class RepositoryHelper {
   }
 
   protected open fun buildReportQuery(query: String) = """WITH $DATASET_ AS ($query)"""
-  protected fun buildPolicyQuery(policyEngineResult: String) = """$POLICY_ AS (SELECT * FROM $DATASET_ WHERE ${convertPolicyResultToSql(policyEngineResult)})"""
+  protected fun buildPolicyQuery(policyEngineResult: String, previousCteName: String? = DATASET_) =
+    """$POLICY_ AS (SELECT * FROM $previousCteName WHERE ${convertPolicyResultToSql(policyEngineResult)})"""
   protected fun buildFiltersQuery(filters: List<ConfiguredApiRepository.Filter>) =
     """$FILTER_ AS (SELECT * FROM $POLICY_ WHERE ${buildFiltersWhereClause(filters)})"""
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Report.kt
@@ -16,4 +16,5 @@ data class Report(
   val classification: String? = null,
   val feature: List<Feature>? = emptyList(),
   val summary: List<ReportSummary>? = emptyList(),
+  val filter: ReportFilter? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportFilter.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class ReportFilter(
+  val name: String,
+  val query: String,
+  val id: String? = null,
+  val description: String? = null,
+  val database: String? = null,
+  val version: String? = null,
+)


### PR DESCRIPTION
Adds a new CTE in the Athena queries:
- Before the policy_ CTE and after the dataset_ CTE.
- It is named prefilter_ CTE.
- Takes its value from the report.filter.query field.
- Takes its name from the report.filter.name field.
- If it the report.filter field does not exist the prefilter_ CTE defaults to prefilter_ AS (SELECT * FROM dataset_).
