### PR TITLE
DPR2-1020 fixed format_date formula bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 5.0.2
+Fixed issue with format_date formula when the date columns had names other than 'date'. 
+
 ## 5.0.1
 Renamed prefilter_ CTE to report_ CTE.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -40,12 +40,13 @@ class FormulaEngine(private val reportFields: List<ReportField>, private val env
   }
 
   private fun interpolateFormatDateFormula(formula: String, row: Map<String, Any?>): String {
-    val datePlaceholder = formula.substring(FORMAT_DATE_FORMULA_PREFIX.length, formula.indexOf(")"))
-      .split(",")[1]
-    val date = row["date"] ?: return ""
+    val (dateColumnNamePlaceholder, datePatternPlaceholder) = formula.substring(FORMAT_DATE_FORMULA_PREFIX.length, formula.indexOf(")"))
+      .split(",")
+    val dateColumnName = dateColumnNamePlaceholder.removeSurrounding(prefix = "\${", suffix = "}")
+    val date = row[dateColumnName] ?: return ""
     return when (date) {
-      is LocalDate -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePlaceholder.trim())))
-      is LocalDateTime -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePlaceholder.trim())))
+      is LocalDate -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePatternPlaceholder.trim())))
+      is LocalDateTime -> date.format(DateTimeFormatter.ofPattern(removeQuotes(datePatternPlaceholder.trim())))
       else -> throw IllegalArgumentException("Could not parse date: $date")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
@@ -396,6 +396,38 @@ class FormulaEngineTest {
     assertEquals(expectedRow, formulaEngine.applyFormulas(row))
   }
 
+  @ParameterizedTest
+  @CsvSource(
+    "dd/MM/yyyy, 01/06/2023",
+    "dd/MM/yyyy hh:mm, 01/06/2023 12:00",
+  )
+  fun `Formula engine formats the datetime based on the provided format in the format_date formula regardless of the date column name`(dateFormat: String, expectedDate: String) {
+    val formatDateFormula = "format_date(\${date1}, '$dateFormat')"
+    val name = "LastName6, F"
+    val row: Map<String, Any?> = mapOf(
+      NAME to name,
+      "date1" to externalMovementOriginCaseloadDirectionIn.time,
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "MNCH",
+    )
+    val reportFields = listOf(
+      ReportField(
+        name = "\$ref:date1",
+        display = "Date",
+        visible = Visible.TRUE,
+        formula = formatDateFormula,
+      ),
+    )
+    val expectedRow: Map<String, Any?> = mapOf(
+      NAME to name,
+      "date1" to expectedDate,
+      DESTINATION to "Manchester",
+      DESTINATION_CODE to "MNCH",
+    )
+    val formulaEngine = FormulaEngine(reportFields)
+    assertEquals(expectedRow, formulaEngine.applyFormulas(row))
+  }
+
   @Test
   fun `Formula engine formats the date based on the provided format in the format_date formula`() {
     val formatDateFormula = "format_date(\${date}, 'dd/MM/yyyy')"


### PR DESCRIPTION
These changes fix an issue with the format_date formula due to which the formula was returning an empty string when applied to date columns whose name was other than 'date'.