### PR TITLE
Dpr2 945 athena workgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 5.1.0
+Athena queries use a workgroup.
+
 ## 5.0.3
 Added comment with DPD and report details to the Athena query.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -7,7 +7,6 @@ import software.amazon.awssdk.services.athena.model.AthenaError
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest
 import software.amazon.awssdk.services.athena.model.QueryExecutionContext
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
-import software.amazon.awssdk.services.athena.model.ResultConfiguration
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import software.amazon.awssdk.services.athena.model.StopQueryExecutionRequest
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
@@ -22,8 +21,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGen
 class AthenaApiRepository(
   val athenaClient: AthenaClient,
   val tableIdGenerator: TableIdGenerator,
-  @Value("\${dpr.lib.redshiftdataapi.s3location:#{'dpr-working-development/reports'}}")
-  private val s3location: String = "dpr-working-development/reports",
+  @Value("\${dpr.lib.redshiftdataapi.athenaworkgroup:workgroupArn")
+  private val athenaWorkgroup: String,
 ) : AthenaAndRedshiftCommonRepository() {
 
   override fun executeQueryAsync(
@@ -73,13 +72,10 @@ class AthenaApiRepository(
       .database(datasource.database)
       .catalog(datasource.catalog)
       .build()
-    val resultConfiguration = ResultConfiguration.builder()
-      .outputLocation("s3://$s3location/$tableId/")
-      .build()
     val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
       .queryString(query)
       .queryExecutionContext(queryExecutionContext)
-      .resultConfiguration(resultConfiguration)
+      .workGroup(athenaWorkgroup)
       .build()
     log.debug("Full async query: {}", query)
     val queryExecutionId = athenaClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse
 import software.amazon.awssdk.services.athena.model.QueryExecution
 import software.amazon.awssdk.services.athena.model.QueryExecutionContext
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
-import software.amazon.awssdk.services.athena.model.ResultConfiguration
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse
 import software.amazon.awssdk.services.athena.model.StopQueryExecutionRequest
@@ -51,6 +50,7 @@ class AthenaApiRepositoryTest {
     val executionId = "someId"
     val testDb = "testdb"
     val testCatalog = "testcatalog"
+    val athenaWorkgroup = "athenaWorkgroup"
     val dpdQuery = "SELECT column_a,column_b FROM schema_a.table_a"
     val defaultDatasetCte = "dataset_ AS (SELECT column_a,column_b FROM schema_a.table_a)"
     val emptyPromptsCte = "$PROMPT AS (SELECT '''' FROM DUAL)"
@@ -92,6 +92,7 @@ SELECT *
   private val athenaApiRepository = AthenaApiRepository(
     athenaClient,
     tableIdGenerator,
+    athenaWorkgroup,
   )
   private val startQueryExecutionResponse = mock<StartQueryExecutionResponse>()
   private val dataset = mock<Dataset>()
@@ -250,9 +251,6 @@ SELECT *
       .database(testDb)
       .catalog(testCatalog)
       .build()
-    val resultConfiguration = ResultConfiguration.builder()
-      .outputLocation("s3://dpr-working-development/reports/$tableId/")
-      .build()
     val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
       .queryString(
         sqlStatement(
@@ -264,7 +262,7 @@ SELECT *
         ),
       )
       .queryExecutionContext(queryExecutionContext)
-      .resultConfiguration(resultConfiguration)
+      .workGroup(athenaWorkgroup)
       .build()
     whenever(
       tableIdGenerator.generateNewExternalTableId(),


### PR DESCRIPTION
Change the Athena query configuration to make use of the following workgroup which has been setup:
`dpr-generic-athena-workgroup`
The results of the Athena queries will be stored in:
[s3://dpr-working-development/dpr](https://eu-west-2.console.aws.amazon.com/s3/buckets/dpr-working-development/dpr/)
Providing client configuration in the library for the S3 location will have no effect since the workgroup has been setup to override client configuration.
See below:
https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/digital-prison-reporting/modules/athena_workgroups/variables.tf#L24