### PR TITLE
DPR2-1039 defaulted visible to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 5.1.2
+Defaulted visible to false for the report fields generated from DPD parameters (prompts).
+
 ## 5.1.1
 Fixed wrong Athena workgroup property value.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -154,7 +154,7 @@ class ReportDefinitionMapper(
       defaultsort = false,
       type = convertParameterTypeToFieldType(parameter.reportFieldType),
       mandatory = parameter.mandatory,
-      visible = true,
+      visible = false,
       filter = FilterDefinition(type = FilterType.valueOf(parameter.filterType.toString()), mandatory = parameter.mandatory),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -849,7 +849,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "defaultsort": false,
                     "type": "string",
                     "mandatory": true,
-                    "visible": true,
+                    "visible": false,
                     "calculated": false
                   } 
                 ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -728,6 +728,7 @@ class ReportDefinitionMapperTest {
         type = uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.Text,
         mandatory = true,
       ),
+      visible = false,
     )
     assertThat(result.variant.specification!!.fields.size).isEqualTo(2)
     assertThat(matchingField.size).isEqualTo(1)


### PR DESCRIPTION
Defaulted visible to false for the report fields generated from DPD parameters (prompts).