### PR TITLE
Dpr2 1039 mandatory false to hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 5.1.3
+Defaulted mandatory to false for the report fields generated from DPD parameters (prompts).
+
 ## 5.1.2
 Defaulted visible to false for the report fields generated from DPD parameters (prompts).
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -153,7 +153,7 @@ class ReportDefinitionMapper(
       sortable = false,
       defaultsort = false,
       type = convertParameterTypeToFieldType(parameter.reportFieldType),
-      mandatory = parameter.mandatory,
+      mandatory = false,
       visible = false,
       filter = FilterDefinition(type = FilterType.valueOf(parameter.filterType.toString()), mandatory = parameter.mandatory),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -848,7 +848,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "sortable": false,
                     "defaultsort": false,
                     "type": "string",
-                    "mandatory": true,
+                    "mandatory": false,
                     "visible": false,
                     "calculated": false
                   } 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -720,7 +720,7 @@ class ReportDefinitionMapperTest {
       type = FieldType.String,
       name = parameterName,
       display = parameterDisplay,
-      mandatory = true,
+      mandatory = false,
       defaultsort = false,
       sortable = false,
       calculated = false,


### PR DESCRIPTION
Default mandatory report field to false as it appears defaulting only visible to false does not hide the field from the report.
More info: https://dsdmoj.atlassian.net/browse/DPR2-413