### PR TITLE
Dpr2 1119 Metric Definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 6.1.0
+Added three new APIs to retrieve Dashboard and metric definitions.
+
 ## 6.0.4
 Support for section header summaries.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.core.Authentication
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController.Companion.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController.Companion.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.MetricDefinitionService
+
+@Validated
+@RestController
+@Tag(name = "Metric Definition API")
+class MetricDefinitionController(val metricDefinitionService: MetricDefinitionService) {
+
+  @GetMapping("/definitions/{dataProductDefinitionId}/dashboards/{dashboardId}")
+  @Operation(
+    description = "Gets the metric dashboard definition.",
+    security = [ SecurityRequirement(name = "bearer-jwt") ],
+  )
+  fun dashboardDefinition(
+    @Parameter(
+      description = "The ID of the Data Product Definition.",
+      example = "external-movements",
+    )
+    @PathVariable("dataProductDefinitionId")
+    dataProductDefinitionId: String,
+    @Parameter(
+      description = "The ID of the dashboard.",
+      example = "dashboardId",
+    )
+    @PathVariable("dashboardId")
+    dashboardId: String,
+    @Parameter(
+      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): DashboardDefinition {
+    return metricDefinitionService.getDashboardDefinition(
+      dataProductDefinitionId,
+      dashboardId,
+      dataProductDefinitionsPath,
+    )
+  }
+
+  @GetMapping("/definitions/{dataProductDefinitionId}/metrics/{metricId}")
+  @Operation(
+    description = "Gets the metric definition.",
+    security = [ SecurityRequirement(name = "bearer-jwt") ],
+  )
+  fun metricDefinition(
+    @Parameter(
+      description = "The ID of the Data Product Definition.",
+      example = "external-movements",
+    )
+    @PathVariable("dataProductDefinitionId")
+    dataProductDefinitionId: String,
+    @Parameter(
+      description = "The ID of the metric.",
+      example = "metricId",
+    )
+    @PathVariable("metricId")
+    metricId: String,
+    @Parameter(
+      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): MetricDefinition {
+    return metricDefinitionService.getMetricDefinition(
+      dataProductDefinitionId,
+      metricId,
+      dataProductDefinitionsPath,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
@@ -21,6 +21,24 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.MetricDefi
 @Tag(name = "Metric Definition API")
 class MetricDefinitionController(val metricDefinitionService: MetricDefinitionService) {
 
+  @GetMapping("/definitions/dashboards")
+  @Operation(
+    description = "Gets a flattened list of all dashboard definitions across all data product definitions",
+    security = [ SecurityRequirement(name = "bearer-jwt") ],
+  )
+  fun definitions(
+    @Parameter(
+      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
+    dataProductDefinitionsPath: String? = null,
+  ): List<DashboardDefinition> {
+    return metricDefinitionService.getAllDashboards(
+      dataProductDefinitionsPath,
+    )
+  }
+
   @GetMapping("/definitions/{dataProductDefinitionId}/dashboards/{dashboardId}")
   @Operation(
     description = "Gets the metric dashboard definition.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardChartTypeDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardChartTypeDefinition.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class DashboardChartTypeDefinition(@JsonValue val type: String) {
+  DOUGHNUT("doughnut"),
+  BAR("bar"),
+  LINE("line"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardDefinition.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+data class DashboardDefinition(
+  val id: String,
+  val name: String,
+  val description: String,
+  val metrics: List<DashboardMetricDefinition>,
+) {
+  data class DashboardMetricDefinition(
+    val id: String,
+    val visualisationType: List<DashboardChartTypeDefinition>,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+data class MetricDefinition(
+  val id: String,
+  val name: String,
+  val display: String,
+  val description: String,
+  val visualisationType: List<DashboardChartTypeDefinition>,
+  val specification: List<MetricSpecificationDefinition>,
+)
+
+data class MetricSpecificationDefinition(
+  val name: String,
+  val display: String,
+  val unit: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class Dashboard(
+  val id: String,
+  val name: String,
+  val description: String,
+  val metrics: List<DashboardMetric>,
+) {
+  data class DashboardMetric(
+    val id: String,
+    val visualisationType: List<DashboardChartType>,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DashboardChartType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DashboardChartType.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+import com.google.gson.annotations.SerializedName
+
+enum class DashboardChartType() {
+  @SerializedName("doughnut")
+  DOUGHNUT,
+
+  @SerializedName("bar")
+  BAR,
+
+  @SerializedName("line")
+  LINE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class Metric(
+  val id: String,
+  val dataset: String,
+  val name: String,
+  val display: String,
+  val description: String,
+  val visualisationType: List<DashboardChartType>,
+  val specification: List<MetricSpecification>,
+)
+
+data class MetricSpecification(
+  val name: String,
+  val display: String,
+  val unit: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
@@ -11,4 +11,6 @@ data class ProductDefinition(
   val dataset: List<Dataset> = emptyList(),
   val report: List<Report> = emptyList(),
   val policy: List<Policy> = emptyList(),
+  val dashboard: List<Dashboard>? = null,
+  val metrics: List<Metric>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -14,6 +14,13 @@ import java.lang.IllegalArgumentException
 
 @Service
 class MetricDefinitionService(val productDefinitionRepository: ProductDefinitionRepository) {
+
+  fun getAllDashboards(dataProductDefinitionsPath: String? = null): List<DashboardDefinition> {
+    return productDefinitionRepository.getProductDefinitions(dataProductDefinitionsPath)
+      .flatMap { it.dashboard ?: emptyList() }
+      .map { toDashboardDefinition(it) }
+  }
+
   fun getDashboardDefinition(
     dataProductDefinitionId: String,
     dashboardId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricSpecificationDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DashboardChartType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Metric
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetricSpecification
+import java.lang.IllegalArgumentException
+
+@Service
+class MetricDefinitionService(val productDefinitionRepository: ProductDefinitionRepository) {
+  fun getDashboardDefinition(
+    dataProductDefinitionId: String,
+    dashboardId: String,
+    dataProductDefinitionsPath: String? = null,
+  ): DashboardDefinition {
+    return toDashboardDefinition(
+      productDefinitionRepository.getProductDefinition(
+        dataProductDefinitionId,
+        dataProductDefinitionsPath,
+      ).dashboard?.firstOrNull { it.id == dashboardId }
+        ?: throw IllegalArgumentException("Dashboard with ID: $dashboardId not found for DPD $dataProductDefinitionId"),
+    )
+  }
+
+  fun getMetricDefinition(
+    dataProductDefinitionId: String,
+    metricId: String,
+    dataProductDefinitionsPath: String? = null,
+  ): MetricDefinition {
+    return toMetricDefinition(
+      productDefinitionRepository.getProductDefinition(
+        dataProductDefinitionId,
+        dataProductDefinitionsPath,
+      ).metrics?.firstOrNull { it.id == metricId }
+        ?: throw IllegalArgumentException("Metric with ID: $metricId not found for DPD $dataProductDefinitionId"),
+    )
+  }
+
+  private fun toMetricDefinition(metric: Metric): MetricDefinition {
+    return MetricDefinition(
+      id = metric.id,
+      name = metric.name,
+      display = metric.display,
+      description = metric.description,
+      visualisationType = metric.visualisationType.map { toDashboardChartTypeDefinition(it) },
+      specification = metric.specification.map { toMetricSpecificationDefinition(it) },
+    )
+  }
+
+  private fun toMetricSpecificationDefinition(metricSpecification: MetricSpecification): MetricSpecificationDefinition {
+    return MetricSpecificationDefinition(
+      metricSpecification.name,
+      metricSpecification.display,
+      metricSpecification.unit,
+    )
+  }
+
+  private fun toDashboardDefinition(dashboard: Dashboard): DashboardDefinition {
+    return DashboardDefinition(
+      id = dashboard.id,
+      name = dashboard.name,
+      description = dashboard.description,
+      metrics = dashboard.metrics.map { toDashboardMetricDefinition(it) },
+    )
+  }
+
+  private fun toDashboardMetricDefinition(metric: Dashboard.DashboardMetric): DashboardDefinition.DashboardMetricDefinition {
+    return DashboardDefinition.DashboardMetricDefinition(metric.id, metric.visualisationType.map { toDashboardChartTypeDefinition(it) })
+  }
+
+  private fun toDashboardChartTypeDefinition(visualisationType: DashboardChartType): DashboardChartTypeDefinition {
+    return DashboardChartTypeDefinition.valueOf(visualisationType.toString())
+  }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -3,6 +3,7 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.FilterHelper
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiAsyncController
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.DataApiSyncController
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.ReportDefinitionController
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.MetricDefinitionController
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DprOpenApiConfiguration
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.RedshiftDataApiConfig
@@ -13,6 +14,7 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.CaseloadProvider
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ResourceServerConfiguration
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.SyncDataApiService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.MetricDefinitionService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionMapper
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionSummaryMapper
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.web.util.UriBuilder
+
+class MetricDefinitionIntegrationTest : IntegrationTestBase() {
+  companion object {
+    @JvmStatic
+    @DynamicPropertySource
+    fun registerProperties(registry: DynamicPropertyRegistry) {
+      registry.add("dpr.lib.definition.locations") { "productDefinitionWithMetrics.json" }
+    }
+  }
+
+  @Test
+  fun `Dashboard definition is returned as expected`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/definitions/external-movements/dashboards/test-dashboard-1")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        """
+          {
+             "id": "test-dashboard-1",
+              "name": "Test Dashboard 1",
+              "description": "Test Dashboard 1 Description",
+              "metrics": [
+                {
+                  "id": "test-metric-id-1",
+                  "visualisationType": ["bar"]
+                }
+              ]
+          }
+        """.trimIndent(),
+      )
+  }
+
+  @Test
+  fun `Metric definition is returned as expected`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/definitions/external-movements/metrics/test-metric-id-1")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        """
+          {
+            "id": "test-metric-id-1",
+            "name": "testMetricId1",
+            "display": "Prisoner Images by Status Percentage",
+            "description": "Prisoner Images by Status Percentage",
+            "visualisationType": [
+              "bar",
+              "doughnut"
+            ],
+            "specification":
+            [
+              {
+                "name": "status",
+                "display": "Status"
+              },
+              {
+                "name": "count",
+                "display": "Count",
+                "unit": "percentage"
+              }
+            ]
+          }
+        """.trimIndent(),
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
@@ -15,6 +15,36 @@ class MetricDefinitionIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `All Dashboard definitions are returned as expected`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/definitions/dashboards")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .json(
+        """
+          [{
+             "id": "test-dashboard-1",
+              "name": "Test Dashboard 1",
+              "description": "Test Dashboard 1 Description",
+              "metrics": [
+                {
+                  "id": "test-metric-id-1",
+                  "visualisationType": ["bar"]
+                }
+              ]
+          }]
+        """.trimIndent(),
+      )
+  }
+
+  @Test
   fun `Dashboard definition is returned as expected`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition.DashboardMetricDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricSpecificationDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IsoLocalDateTimeTypeAdaptor
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.JsonFileProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+
+class MetricDefinitionServiceTest {
+
+  private val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+    listOf("productDefinitionWithMetrics.json"),
+    DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+  )
+
+  private val metricDefinitionService = MetricDefinitionService(productDefinitionRepository)
+
+  @Test
+  fun `getDashboardDefinition returns the dashboard definition`() {
+    val actual = metricDefinitionService.getDashboardDefinition(
+      dataProductDefinitionId = "external-movements",
+      dashboardId = "test-dashboard-1",
+    )
+    assertEquals(
+      DashboardDefinition(
+        id = "test-dashboard-1",
+        name = "Test Dashboard 1",
+        description = "Test Dashboard 1 Description",
+        metrics = listOf(
+          DashboardMetricDefinition(id = "test-metric-id-1", listOf(DashboardChartTypeDefinition.BAR)),
+        ),
+      ),
+      actual,
+    )
+  }
+
+  @Test
+  fun `getMetricDefinition returns the metric definition`() {
+    val actual = metricDefinitionService.getMetricDefinition(
+      dataProductDefinitionId = "external-movements",
+      metricId = "test-metric-id-1",
+    )
+    assertEquals(
+      MetricDefinition(
+        id = "test-metric-id-1",
+        name = "testMetricId1",
+        display = "Prisoner Images by Status Percentage",
+        description = "Prisoner Images by Status Percentage",
+        visualisationType = listOf(
+          DashboardChartTypeDefinition.BAR,
+          DashboardChartTypeDefinition.DOUGHNUT,
+        ),
+        specification = listOf(
+          MetricSpecificationDefinition(
+            name = "status",
+            display = "Status",
+          ),
+          MetricSpecificationDefinition(
+            name = "count",
+            display = "Count",
+            unit = "percentage",
+          ),
+        ),
+      ),
+      actual,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
@@ -22,6 +22,24 @@ class MetricDefinitionServiceTest {
   private val metricDefinitionService = MetricDefinitionService(productDefinitionRepository)
 
   @Test
+  fun `getAllDashboards returns all the dashboard definitions`() {
+    val actual = metricDefinitionService.getAllDashboards()
+    assertEquals(
+      listOf(
+        DashboardDefinition(
+          id = "test-dashboard-1",
+          name = "Test Dashboard 1",
+          description = "Test Dashboard 1 Description",
+          metrics = listOf(
+            DashboardMetricDefinition(id = "test-metric-id-1", listOf(DashboardChartTypeDefinition.BAR)),
+          ),
+        ),
+      ),
+      actual,
+    )
+  }
+
+  @Test
   fun `getDashboardDefinition returns the dashboard definition`() {
     val actual = metricDefinitionService.getDashboardDefinition(
       dataProductDefinitionId = "external-movements",

--- a/src/test/resources/productDefinitionWithMetrics.json
+++ b/src/test/resources/productDefinitionWithMetrics.json
@@ -1,0 +1,512 @@
+{
+  "id" : "external-movements",
+  "name" : "External Movements",
+  "description" : "Reports about prisoner external movements",
+  "metadata" : {
+    "author" : "Adam",
+    "version" : "1.2.3",
+    "owner" : "Eve"
+  },
+  "datasource" : [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }],
+  "dataset" : [ {
+    "id" : "external-movements",
+    "name" : "All movements",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "schema" : {
+      "field" : [ {
+        "name" : "prisonNumber",
+        "type" : "string",
+        "display" : "Prison Number"
+      }, {
+        "name" : "name",
+        "type" : "string",
+        "display" : "Name"
+      }, {
+        "name" : "date",
+        "type" : "date",
+        "display" : ""
+      }, {
+        "name" : "origin",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "origin_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "destination",
+        "type" : "string",
+        "display" : ""
+      },{
+        "name" : "destination_code",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "direction",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "type",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "reason",
+        "type" : "string",
+        "display" : ""
+      }, {
+        "name" : "is_closed",
+        "type" : "boolean",
+        "display" : ""
+      }]
+    }
+  },
+    {
+      "id": "prisoner-dataset",
+      "name": "prisoner dataset",
+      "datasource": "datamart",
+      "query": "SELECT prisoners.number AS prisonNumber, CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name FROM datamart.domain.prisoner_prisoner as prisoners",
+      "schema": {
+        "field": [
+          {
+            "name": "prisonNumber",
+            "type": "string",
+            "display": "Prisoner Number"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "display": "Prisoner Name"
+          }]
+      }
+    },
+    {
+      "id": "summary-dataset",
+      "name": "Summary Dataset",
+      "datasource": "datamart",
+      "query": "SELECT COUNT(*) AS TOTAL FROM ${tableId}",
+      "schema": {
+        "field": [{
+          "name": "total",
+          "type": "int",
+          "display": "Total"
+        }]
+      }
+    },
+    {
+      "id": "test-metric-dataset-id-1",
+      "name": "Test metric dataset",
+      "datasource": "datamart",
+      "query": "SELECT 'missing facial image' AS status, 100 AS count",
+      "schema": {
+        "field": [
+          {
+            "name": "status",
+            "type": "string",
+            "display": "Prisoner image Status"
+          },
+          {
+            "name": "count",
+            "type": "long",
+            "display": "Count"
+          }]
+      }
+    }
+  ],
+  "dashboard": [
+    {
+    "id": "test-dashboard-1",
+    "name": "Test Dashboard 1",
+    "description": "Test Dashboard 1 Description",
+    "metrics": [
+      {
+        "id": "test-metric-id-1",
+        "visualisationType": ["bar"]
+      }
+    ]
+    }
+  ],
+  "metrics": [
+    {
+      "id": "test-metric-id-1",
+      "name": "testMetricId1",
+      "dataset": "test-metric-dataset-id-1",
+      "display": "Prisoner Images by Status Percentage",
+      "description": "Prisoner Images by Status Percentage",
+      "visualisationType": [
+        "bar",
+        "doughnut"
+      ],
+      "specification":
+      [
+        {
+          "name": "status",
+          "display": "Status"
+        },
+        {
+          "name": "count",
+          "display": "Count",
+          "unit": "percentage"
+        }
+      ]
+    }
+  ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseload}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report" : [ {
+    "id" : "last-month",
+    "name" : "Last month",
+    "description" : "All movements in the past month",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list-section",
+      "section": [ "$ref:direction" ],
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "Radio",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "dataset": "$ref:prisoner-dataset",
+            "name": "$ref:prisonNumber",
+            "display": "$ref:name"
+          }
+        }
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "mandatory": false,
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "filter" : {
+          "type" : "text"
+        },
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ],
+    "summary": [{
+      "id": "summaryId",
+      "template": "page-header",
+      "dataset": "$ref:summary-dataset"
+    }]
+  }, {
+    "id" : "last-week",
+    "name" : "Last week",
+    "description" : "All movements in the past week",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "display" : "Prison Number",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "type" : "daterange",
+          "default" : "today(-1,weeks) - today()",
+          "mandatory": false
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true
+          }
+        }
+      } ]
+    },
+    "destination" : [ ]
+  },
+    {
+    "id" : "last-year",
+    "name" : "Last year",
+    "description" : "All movements in the past year",
+    "created" : "2023-09-20T14:41:00.000Z",
+    "classification": "report classification",
+    "version" : "1.2.3",
+    "dataset" : "$ref:external-movements",
+    "policy" : [ ],
+    "render" : "HTML",
+    "feature": [ {
+      "type": "print"
+    }],
+    "specification" : {
+      "template" : "list",
+      "field" : [ {
+        "name" : "$ref:prisonNumber",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:name",
+        "display" : "Name",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": false
+          }
+        }
+      }, {
+        "name" : "$ref:date",
+        "display" : "Date",
+        "filter" : {
+          "mandatory": true,
+          "type" : "dAtErAnGe",
+          "default" : "today(-1,months) - today()"
+        },
+        "sortable" : true,
+        "defaultsort" : true
+      }, {
+        "name" : "$ref:origin",
+        "display" : "From",
+        "filter" : {
+          "type" : "text",
+          "mandatory": true,
+          "pattern": "[A-Z]{3,3}"
+        },
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:destination",
+        "display" : "To",
+        "wordWrap" : "none",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "true"
+      }, {
+        "name" : "$ref:direction",
+        "display" : "Direction",
+        "wordWrap" : "break-words",
+        "filter" : {
+          "type" : "Radio",
+          "staticoptions" : [ {
+            "name" : "in",
+            "display" : "In"
+          }, {
+            "name" : "out",
+            "display" : "Out"
+          } ]
+        },
+        "sortable" : true,
+        "defaultsort" : false
+      }, {
+        "name" : "$ref:type",
+        "display" : "Type",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "false",
+        "wordWrap" : "normal"
+      }, {
+        "name" : "$ref:reason",
+        "display" : "Reason",
+        "sortable" : true,
+        "defaultsort" : false,
+        "visible": "mandatory",
+        "filter" : {
+          "type" : "autocomplete",
+          "dynamicoptions":{
+            "minimumLength": 2,
+            "returnAsStaticOptions": true,
+            "maximumOptions": 1
+          }
+        }
+      }, {
+        "name": "$ref:is_closed",
+        "display": "Closed",
+        "sortable": true,
+        "filter": {
+          "type": "Radio",
+          "default": "false",
+          "staticoptions": [
+            {
+              "name": "false",
+              "display": "Only open"
+            },
+            {
+              "name": "true",
+              "display": "Only closed"
+            }
+          ]
+        }
+      } ]
+    },
+    "destination" : [ ]
+  } ]
+}


### PR DESCRIPTION
These changes add 3 new endpoints:

- `/definitions/dashboards`
- `/definitions/{dataProductDefinitionId}/dashboards/{dashboardId}`
- `/definitions/{dataProductDefinitionId}/metrics/{metricId}`

These return all dashboard definitions, a given dashboard definition and a given metric definition respectively.