### PR TITLE
DPR2-1119 Dashboard definitions part of ReportDefinitionSummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 6.1.1
+Removed the /definitions/dashboards endpoint and added the dashboard definitions to the ReportDefinitionSummary.
+
 ## 6.1.0
 Added three new APIs to retrieve Dashboard and metric definitions.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/MetricDefinitionController.kt
@@ -21,24 +21,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.MetricDefi
 @Tag(name = "Metric Definition API")
 class MetricDefinitionController(val metricDefinitionService: MetricDefinitionService) {
 
-  @GetMapping("/definitions/dashboards")
-  @Operation(
-    description = "Gets a flattened list of all dashboard definitions across all data product definitions",
-    security = [ SecurityRequirement(name = "bearer-jwt") ],
-  )
-  fun definitions(
-    @Parameter(
-      description = DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
-      example = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
-    )
-    @RequestParam("dataProductDefinitionsPath", defaultValue = DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE)
-    dataProductDefinitionsPath: String? = null,
-  ): List<DashboardDefinition> {
-    return metricDefinitionService.getAllDashboards(
-      dataProductDefinitionsPath,
-    )
-  }
-
   @GetMapping("/definitions/{dataProductDefinitionId}/dashboards/{dashboardId}")
   @Operation(
     description = "Gets the metric dashboard definition.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ReportDefinitionSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ReportDefinitionSummary.kt
@@ -5,4 +5,5 @@ data class ReportDefinitionSummary(
   val name: String,
   val description: String? = null,
   val variants: List<VariantDefinitionSummary>,
+  val dashboards: List<DashboardDefinition>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ProductDefinition.kt
@@ -11,6 +11,6 @@ data class ProductDefinition(
   val dataset: List<Dataset> = emptyList(),
   val report: List<Report> = emptyList(),
   val policy: List<Policy> = emptyList(),
-  val dashboard: List<Dashboard>? = null,
+  val dashboards: List<Dashboard>? = null,
   val metrics: List<Metric>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -15,12 +15,6 @@ import java.lang.IllegalArgumentException
 @Service
 class MetricDefinitionService(val productDefinitionRepository: ProductDefinitionRepository) {
 
-  fun getAllDashboards(dataProductDefinitionsPath: String? = null): List<DashboardDefinition> {
-    return productDefinitionRepository.getProductDefinitions(dataProductDefinitionsPath)
-      .flatMap { it.dashboard ?: emptyList() }
-      .map { toDashboardDefinition(it) }
-  }
-
   fun getDashboardDefinition(
     dataProductDefinitionId: String,
     dashboardId: String,
@@ -30,7 +24,7 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
       productDefinitionRepository.getProductDefinition(
         dataProductDefinitionId,
         dataProductDefinitionsPath,
-      ).dashboard?.firstOrNull { it.id == dashboardId }
+      ).dashboards?.firstOrNull { it.id == dashboardId }
         ?: throw IllegalArgumentException("Dashboard with ID: $dashboardId not found for DPD $dataProductDefinitionId"),
     )
   }
@@ -46,6 +40,15 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
         dataProductDefinitionsPath,
       ).metrics?.firstOrNull { it.id == metricId }
         ?: throw IllegalArgumentException("Metric with ID: $metricId not found for DPD $dataProductDefinitionId"),
+    )
+  }
+
+  fun toDashboardDefinition(dashboard: Dashboard): DashboardDefinition {
+    return DashboardDefinition(
+      id = dashboard.id,
+      name = dashboard.name,
+      description = dashboard.description,
+      metrics = dashboard.metrics.map { toDashboardMetricDefinition(it) },
     )
   }
 
@@ -65,15 +68,6 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
       metricSpecification.name,
       metricSpecification.display,
       metricSpecification.unit,
-    )
-  }
-
-  private fun toDashboardDefinition(dashboard: Dashboard): DashboardDefinition {
-    return DashboardDefinition(
-      id = dashboard.id,
-      name = dashboard.name,
-      description = dashboard.description,
-      metrics = dashboard.metrics.map { toDashboardMetricDefinition(it) },
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapper.kt
@@ -1,14 +1,16 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinitionSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.VariantDefinitionSummary
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 
 @Component
-class ReportDefinitionSummaryMapper {
+class ReportDefinitionSummaryMapper(val metricDefinitionService: MetricDefinitionService) {
 
   fun map(
     productDefinition: ProductDefinition,
@@ -20,7 +22,11 @@ class ReportDefinitionSummaryMapper {
     variants = productDefinition.report
       .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
       .map { map(it) },
+    dashboards = map(productDefinition.dashboards),
   )
+
+  private fun map(dashboards: List<Dashboard>?): List<DashboardDefinition>? =
+    dashboards?.map { metricDefinitionService.toDashboardDefinition(it) }
 
   private fun map(
     report: Report,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
@@ -15,36 +15,6 @@ class MetricDefinitionIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `All Dashboard definitions are returned as expected`() {
-    webTestClient.get()
-      .uri { uriBuilder: UriBuilder ->
-        uriBuilder
-          .path("/definitions/dashboards")
-          .build()
-      }
-      .headers(setAuthorisation(roles = listOf(authorisedRole)))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .json(
-        """
-          [{
-             "id": "test-dashboard-1",
-              "name": "Test Dashboard 1",
-              "description": "Test Dashboard 1 Description",
-              "metrics": [
-                {
-                  "id": "test-metric-id-1",
-                  "visualisationType": ["bar"]
-                }
-              ]
-          }]
-        """.trimIndent(),
-      )
-  }
-
-  @Test
   fun `Dashboard definition is returned as expected`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
@@ -22,24 +22,6 @@ class MetricDefinitionServiceTest {
   private val metricDefinitionService = MetricDefinitionService(productDefinitionRepository)
 
   @Test
-  fun `getAllDashboards returns all the dashboard definitions`() {
-    val actual = metricDefinitionService.getAllDashboards()
-    assertEquals(
-      listOf(
-        DashboardDefinition(
-          id = "test-dashboard-1",
-          name = "Test Dashboard 1",
-          description = "Test Dashboard 1 Description",
-          metrics = listOf(
-            DashboardMetricDefinition(id = "test-metric-id-1", listOf(DashboardChartTypeDefinition.BAR)),
-          ),
-        ),
-      ),
-      actual,
-    )
-  }
-
-  @Test
   fun `getDashboardDefinition returns the dashboard definition`() {
     val actual = metricDefinitionService.getDashboardDefinition(
       dataProductDefinitionId = "external-movements",

--- a/src/test/resources/productDefinitionWithMetrics.json
+++ b/src/test/resources/productDefinitionWithMetrics.json
@@ -116,7 +116,7 @@
       }
     }
   ],
-  "dashboard": [
+  "dashboards": [
     {
     "id": "test-dashboard-1",
     "name": "Test Dashboard 1",


### PR DESCRIPTION
Removed the `/definitions/dashboards` endpoint and added the dashboard definitions to the ReportDefinitionSummary which is returned as part of the existing `/definitions` endpoint.