### PR TITLE
Dpr2 1220 amend definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 6.1.2
+Amended the dashboard and metric definitions by removing visualisationType from the dashboard. Added the optional boolean 'group' and list 'chart' fields to metrics.
+
 ## 6.1.1
 Removed the /definitions/dashboards endpoint and added the dashboard definitions to the ReportDefinitionSummary.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ChartTypeDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ChartTypeDefinition.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 
 import com.fasterxml.jackson.annotation.JsonValue
 
-enum class DashboardChartTypeDefinition(@JsonValue val type: String) {
+enum class ChartTypeDefinition(@JsonValue val type: String) {
   DOUGHNUT("doughnut"),
   BAR("bar"),
   LINE("line"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardDefinition.kt
@@ -8,6 +8,5 @@ data class DashboardDefinition(
 ) {
   data class DashboardMetricDefinition(
     val id: String,
-    val visualisationType: List<DashboardChartTypeDefinition>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
@@ -12,6 +12,6 @@ data class MetricSpecificationDefinition(
   val name: String,
   val display: String,
   val unit: String? = null,
-  val chart: List<DashboardChartTypeDefinition>? = null,
+  val chart: List<ChartTypeDefinition>? = null,
   val group: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
@@ -5,7 +5,6 @@ data class MetricDefinition(
   val name: String,
   val display: String,
   val description: String,
-  val visualisationType: List<DashboardChartTypeDefinition>,
   val specification: List<MetricSpecificationDefinition>,
 )
 
@@ -13,4 +12,6 @@ data class MetricSpecificationDefinition(
   val name: String,
   val display: String,
   val unit: String? = null,
+  val chart: List<DashboardChartTypeDefinition>? = null,
+  val group: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ChartType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ChartType.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
 import com.google.gson.annotations.SerializedName
 
-enum class DashboardChartType() {
+enum class ChartType() {
   @SerializedName("doughnut")
   DOUGHNUT,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
@@ -8,6 +8,5 @@ data class Dashboard(
 ) {
   data class DashboardMetric(
     val id: String,
-    val visualisationType: List<DashboardChartType>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
@@ -6,7 +6,6 @@ data class Metric(
   val name: String,
   val display: String,
   val description: String,
-  val visualisationType: List<DashboardChartType>,
   val specification: List<MetricSpecification>,
 )
 
@@ -14,4 +13,6 @@ data class MetricSpecification(
   val name: String,
   val display: String,
   val unit: String? = null,
+  val chart: List<DashboardChartType>? = null,
+  val group: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
@@ -13,6 +13,6 @@ data class MetricSpecification(
   val name: String,
   val display: String,
   val unit: String? = null,
-  val chart: List<DashboardChartType>? = null,
+  val chart: List<ChartType>? = null,
   val group: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -6,8 +6,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.D
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricSpecificationDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ChartType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Metric
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetricSpecification
 import java.lang.IllegalArgumentException

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricSpecificationDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DashboardChartType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ChartType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Metric
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetricSpecification
 import java.lang.IllegalArgumentException
@@ -67,7 +67,7 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
       name = metricSpecification.name,
       display = metricSpecification.display,
       unit = metricSpecification.unit,
-      chart = toDashboardChartTypeDefinition(metricSpecification.chart),
+      chart = toChartTypeDefinition(metricSpecification.chart),
       group = metricSpecification.group,
     )
   }
@@ -76,7 +76,7 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
     return DashboardDefinition.DashboardMetricDefinition(metric.id)
   }
 
-  private fun toDashboardChartTypeDefinition(chart: List<DashboardChartType>?): List<DashboardChartTypeDefinition>? {
-    return chart?.map { DashboardChartTypeDefinition.valueOf(it.toString()) }
+  private fun toChartTypeDefinition(chart: List<ChartType>?): List<ChartTypeDefinition>? {
+    return chart?.map { ChartTypeDefinition.valueOf(it.toString()) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionService.kt
@@ -58,24 +58,25 @@ class MetricDefinitionService(val productDefinitionRepository: ProductDefinition
       name = metric.name,
       display = metric.display,
       description = metric.description,
-      visualisationType = metric.visualisationType.map { toDashboardChartTypeDefinition(it) },
       specification = metric.specification.map { toMetricSpecificationDefinition(it) },
     )
   }
 
   private fun toMetricSpecificationDefinition(metricSpecification: MetricSpecification): MetricSpecificationDefinition {
     return MetricSpecificationDefinition(
-      metricSpecification.name,
-      metricSpecification.display,
-      metricSpecification.unit,
+      name = metricSpecification.name,
+      display = metricSpecification.display,
+      unit = metricSpecification.unit,
+      chart = toDashboardChartTypeDefinition(metricSpecification.chart),
+      group = metricSpecification.group,
     )
   }
 
   private fun toDashboardMetricDefinition(metric: Dashboard.DashboardMetric): DashboardDefinition.DashboardMetricDefinition {
-    return DashboardDefinition.DashboardMetricDefinition(metric.id, metric.visualisationType.map { toDashboardChartTypeDefinition(it) })
+    return DashboardDefinition.DashboardMetricDefinition(metric.id)
   }
 
-  private fun toDashboardChartTypeDefinition(visualisationType: DashboardChartType): DashboardChartTypeDefinition {
-    return DashboardChartTypeDefinition.valueOf(visualisationType.toString())
+  private fun toDashboardChartTypeDefinition(chart: List<DashboardChartType>?): List<DashboardChartTypeDefinition>? {
+    return chart?.map { DashboardChartTypeDefinition.valueOf(it.toString()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/MetricDefinitionIntegrationTest.kt
@@ -35,8 +35,7 @@ class MetricDefinitionIntegrationTest : IntegrationTestBase() {
               "description": "Test Dashboard 1 Description",
               "metrics": [
                 {
-                  "id": "test-metric-id-1",
-                  "visualisationType": ["bar"]
+                  "id": "test-metric-id-1"
                 }
               ]
           }
@@ -62,22 +61,40 @@ class MetricDefinitionIntegrationTest : IntegrationTestBase() {
           {
             "id": "test-metric-id-1",
             "name": "testMetricId1",
-            "display": "Prisoner Images by Status Percentage",
-            "description": "Prisoner Images by Status Percentage",
-            "visualisationType": [
-              "bar",
-              "doughnut"
-            ],
+            "display": "Missing Ethnicity",
+            "description": "Missing Ethnicity",
             "specification":
             [
               {
-                "name": "status",
-                "display": "Status"
+                "name": "establishment_id",
+                "display": "Establishment ID",
+                "group": true
               },
               {
-                "name": "count",
-                "display": "Count",
+                "name": "missing_ethnicity_percentage",
+                "display": "% Missing Ethnicity",
+                "chart": ["doughnut"],
                 "unit": "percentage"
+              },
+              {
+                "name": "present_ethnicity_percentage",
+                "display": "% With Ethnicity",
+                "chart": ["doughnut"],
+                "unit": "percentage"
+              },
+              {
+                "name": "no_of_prisoners",
+                "display": "No. of Prisoners with ethnicity",
+                "chart": ["bar"]
+              },
+              {
+                "name": "no_of_prisoners_without",
+                "display": "No. of Prisoners without ethnicity",
+                "chart": ["bar"]
+              },
+              {
+                "name": "random_data",
+                "display": "Random Data"
               }
             ]
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinitionSummary
@@ -124,7 +123,6 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
             metrics = listOf(
               DashboardDefinition.DashboardMetricDefinition(
                 id = "test-metric-id-1",
-                listOf(DashboardChartTypeDefinition.BAR),
               ),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition.DashboardMetricDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.MetricDefinition
@@ -61,24 +61,24 @@ class MetricDefinitionServiceTest {
           MetricSpecificationDefinition(
             name = "missing_ethnicity_percentage",
             display = "% Missing Ethnicity",
-            chart = listOf(DashboardChartTypeDefinition.DOUGHNUT),
+            chart = listOf(ChartTypeDefinition.DOUGHNUT),
             unit = "percentage",
           ),
           MetricSpecificationDefinition(
             name = "present_ethnicity_percentage",
             display = "% With Ethnicity",
-            chart = listOf(DashboardChartTypeDefinition.DOUGHNUT),
+            chart = listOf(ChartTypeDefinition.DOUGHNUT),
             unit = "percentage",
           ),
           MetricSpecificationDefinition(
             name = "no_of_prisoners",
             display = "No. of Prisoners with ethnicity",
-            chart = listOf(DashboardChartTypeDefinition.BAR),
+            chart = listOf(ChartTypeDefinition.BAR),
           ),
           MetricSpecificationDefinition(
             name = "no_of_prisoners_without",
             display = "No. of Prisoners without ethnicity",
-            chart = listOf(DashboardChartTypeDefinition.BAR),
+            chart = listOf(ChartTypeDefinition.BAR),
           ),
           MetricSpecificationDefinition(
             name = "random_data",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/MetricDefinitionServiceTest.kt
@@ -33,7 +33,7 @@ class MetricDefinitionServiceTest {
         name = "Test Dashboard 1",
         description = "Test Dashboard 1 Description",
         metrics = listOf(
-          DashboardMetricDefinition(id = "test-metric-id-1", listOf(DashboardChartTypeDefinition.BAR)),
+          DashboardMetricDefinition(id = "test-metric-id-1"),
         ),
       ),
       actual,
@@ -50,21 +50,39 @@ class MetricDefinitionServiceTest {
       MetricDefinition(
         id = "test-metric-id-1",
         name = "testMetricId1",
-        display = "Prisoner Images by Status Percentage",
-        description = "Prisoner Images by Status Percentage",
-        visualisationType = listOf(
-          DashboardChartTypeDefinition.BAR,
-          DashboardChartTypeDefinition.DOUGHNUT,
-        ),
+        display = "Missing Ethnicity",
+        description = "Missing Ethnicity",
         specification = listOf(
           MetricSpecificationDefinition(
-            name = "status",
-            display = "Status",
+            name = "establishment_id",
+            display = "Establishment ID",
+            group = true,
           ),
           MetricSpecificationDefinition(
-            name = "count",
-            display = "Count",
+            name = "missing_ethnicity_percentage",
+            display = "% Missing Ethnicity",
+            chart = listOf(DashboardChartTypeDefinition.DOUGHNUT),
             unit = "percentage",
+          ),
+          MetricSpecificationDefinition(
+            name = "present_ethnicity_percentage",
+            display = "% With Ethnicity",
+            chart = listOf(DashboardChartTypeDefinition.DOUGHNUT),
+            unit = "percentage",
+          ),
+          MetricSpecificationDefinition(
+            name = "no_of_prisoners",
+            display = "No. of Prisoners with ethnicity",
+            chart = listOf(DashboardChartTypeDefinition.BAR),
+          ),
+          MetricSpecificationDefinition(
+            name = "no_of_prisoners_without",
+            display = "No. of Prisoners without ethnicity",
+            chart = listOf(DashboardChartTypeDefinition.BAR),
+          ),
+          MetricSpecificationDefinition(
+            name = "random_data",
+            display = "Random Data",
           ),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
@@ -6,13 +6,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardChartTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition.DashboardMetricDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod.HTML
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard.DashboardMetric
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DashboardChartType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
@@ -209,7 +207,7 @@ class ReportDefinitionSummaryMapperTest {
       name = "n1",
       description = "abc",
       metrics = listOf(
-        DashboardMetric("m1", listOf(DashboardChartType.BAR)),
+        DashboardMetric("m1"),
       ),
     )
     val dashboardDefinition = DashboardDefinition(
@@ -217,7 +215,7 @@ class ReportDefinitionSummaryMapperTest {
       name = "n1",
       description = "abc",
       metrics = listOf(
-        DashboardMetricDefinition("m1", listOf(DashboardChartTypeDefinition.BAR)),
+        DashboardMetricDefinition("m1"),
       ),
     )
 

--- a/src/test/resources/productDefinitionWithMetrics.json
+++ b/src/test/resources/productDefinitionWithMetrics.json
@@ -123,8 +123,7 @@
     "description": "Test Dashboard 1 Description",
     "metrics": [
       {
-        "id": "test-metric-id-1",
-        "visualisationType": ["bar"]
+        "id": "test-metric-id-1"
       }
     ]
     }
@@ -134,22 +133,40 @@
       "id": "test-metric-id-1",
       "name": "testMetricId1",
       "dataset": "test-metric-dataset-id-1",
-      "display": "Prisoner Images by Status Percentage",
-      "description": "Prisoner Images by Status Percentage",
-      "visualisationType": [
-        "bar",
-        "doughnut"
-      ],
+      "display": "Missing Ethnicity",
+      "description": "Missing Ethnicity",
       "specification":
       [
         {
-          "name": "status",
-          "display": "Status"
+          "name": "establishment_id",
+          "display": "Establishment ID",
+          "group": true
         },
         {
-          "name": "count",
-          "display": "Count",
+          "name": "missing_ethnicity_percentage",
+          "display": "% Missing Ethnicity",
+          "chart": ["doughnut"],
           "unit": "percentage"
+        },
+        {
+          "name": "present_ethnicity_percentage",
+          "display": "% With Ethnicity",
+          "chart": ["doughnut"],
+          "unit": "percentage"
+        },
+        {
+          "name": "no_of_prisoners",
+          "display": "No. of Prisoners with ethnicity",
+          "chart": ["bar"]
+        },
+        {
+          "name": "no_of_prisoners_without",
+          "display": "No. of Prisoners without ethnicity",
+          "chart": ["bar"]
+        },
+        {
+          "name": "random_data",
+          "display": "Random Data"
         }
       ]
     }
@@ -158,13 +175,13 @@
     {
       "id": "caseload",
       "type": "row-level",
-      "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],
+      "action": ["(establishment_id='${caseload}')"],
       "rule": [
         {
           "effect": "permit",
           "condition": [
             {
-              "exists": ["${caseload}"]
+              "match": ["${role}", "ROLE_PRISONS_REPORTING_USER"]
             }
           ]
         }


### PR DESCRIPTION
Changed include:

1. Removed visualisationType from DashboardMetricDefinition.
2. Removed visualisationType from MetricDefinition.
3. Added the optional boolean group  to the metric specification.
4. Added the optional array field chart to the metric specification.

This is in-line with https://github.com/ministryofjustice/hmpps-digital-prison-reporting-frontend/pull/219 .