### PR TITLE
DPR2-1516 add sorting to results async endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 7.2.2
+Added sortColumn and sortAsc query parameter to the async results endpoint to support the interactive journey.
+
 ## 7.2.1
 Added report metadata with support for the interactive hint.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -360,6 +360,8 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
     )
     @RequestParam
     filters: Map<String, String>,
+    @RequestParam sortColumn: String?,
+    @RequestParam(defaultValue = "false") sortedAsc: Boolean,
     authentication: Authentication,
   ): ResponseEntity<List<Map<String, Any?>>> {
     return ResponseEntity
@@ -373,6 +375,8 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
           selectedPage = selectedPage,
           pageSize = pageSize,
           filters = filterHelper.filtersOnly(filters),
+          sortedAsc = sortedAsc,
+          sortColumn = sortColumn,
         ),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -44,13 +44,15 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     selectedPage: Long,
     pageSize: Long,
     filters: List<ConfiguredApiRepository.Filter>,
+    sortedAsc: Boolean = false,
+    sortColumn: String? = null,
     jdbcTemplate: NamedParameterJdbcTemplate = populateNamedParameterJdbcTemplate(),
   ): List<Map<String, Any?>> {
     val stopwatch = StopWatch.createStarted()
     val whereClause = buildFiltersWhereClause(filters)
     val result = jdbcTemplate
       .queryForList(
-        "SELECT * FROM reports.$tableId WHERE $whereClause LIMIT $pageSize OFFSET ($selectedPage - 1) * $pageSize;",
+        "SELECT * FROM reports.$tableId WHERE $whereClause ${buildOrderByClause(sortColumn, sortedAsc)} LIMIT $pageSize OFFSET ($selectedPage - 1) * $pageSize;",
         MapSqlParameterSource(),
       )
       .map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
@@ -132,7 +132,7 @@ abstract class RepositoryHelper {
   private fun constructProjectedColumns(dynamicFilterFieldId: Set<String>?) =
     dynamicFilterFieldId?.let { "DISTINCT ${dynamicFilterFieldId.joinToString(", ")}" } ?: "*"
 
-  private fun buildOrderByClause(sortColumn: String?, sortedAsc: Boolean) =
+  protected fun buildOrderByClause(sortColumn: String?, sortedAsc: Boolean) =
     sortColumn?.let { """ORDER BY $sortColumn ${calculateSortingDirection(sortedAsc)}""" } ?: ""
 
   private fun calculateSortingDirection(sortedAsc: Boolean): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -117,11 +117,20 @@ class AsyncDataApiService(
     selectedPage: Long,
     pageSize: Long,
     filters: Map<String, String>,
+    sortedAsc: Boolean,
+    sortColumn: String? = null,
   ): List<Map<String, Any?>> {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     val formulaEngine = FormulaEngine(productDefinition.report.specification?.field ?: emptyList(), env)
     return formatColumnsAndApplyFormulas(
-      redshiftDataApiRepository.getPaginatedExternalTableResult(tableId, selectedPage, pageSize, validateAndMapFilters(productDefinition, filters, true)),
+      redshiftDataApiRepository.getPaginatedExternalTableResult(
+        tableId,
+        selectedPage,
+        pageSize,
+        validateAndMapFilters(productDefinition, filters, true),
+        sortedAsc = sortedAsc,
+        sortColumn = sortColumn,
+      ),
       productDefinition.reportDataset.schema.field,
       formulaEngine,
     )
@@ -137,7 +146,12 @@ class AsyncDataApiService(
     filters: Map<String, String>,
   ): List<Map<String, Any?>> {
     val productDefinition = productDefinitionRepository.getSingleDashboardProductDefinition(reportId, dashboardId, dataProductDefinitionsPath)
-    return redshiftDataApiRepository.getPaginatedExternalTableResult(tableId, selectedPage, pageSize, validateAndMapFilters(productDefinition, filters, true))
+    return redshiftDataApiRepository.getPaginatedExternalTableResult(
+      tableId = tableId,
+      selectedPage = selectedPage,
+      pageSize = pageSize,
+      filters = validateAndMapFilters(productDefinition, filters, true),
+    )
       .map { row -> formatColumnNamesToSourceFieldNamesCasing(row, productDefinition.dashboardDataset.schema.field.map(SchemaField::name)) }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -359,13 +359,15 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
 
     given(
       asyncDataApiService.getStatementResult(
-        eq(tableId),
-        eq("external-movements"),
-        eq("last-month"),
-        eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
-        eq(selectedPage),
-        eq(pageSize),
-        eq(emptyMap()),
+        tableId = eq(tableId),
+        reportId = eq("external-movements"),
+        reportVariantId = eq("last-month"),
+        dataProductDefinitionsPath = eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
+        selectedPage = eq(selectedPage),
+        pageSize = eq(pageSize),
+        filters = eq(emptyMap()),
+        sortedAsc = eq(false),
+        sortColumn = eq(null),
       ),
     )
       .willReturn(expectedServiceResult)
@@ -387,10 +389,11 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the report getStatementResult endpoint with filters calls the configuredApiService with the correct arguments`() {
+  fun `Calling the report getStatementResult endpoint with filters and sorting calls the configuredApiService with the correct arguments`() {
     val tableId = "tableId"
     val selectedPage = 2L
     val pageSize = 20L
+    val sortColumn = "columnA"
     val expectedServiceResult =
       listOf(
         mapOf(
@@ -405,7 +408,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         ),
       )
 
-    given(asyncDataApiService.getStatementResult(any(), any(), any(), any(), any(), any(), any()))
+    given(asyncDataApiService.getStatementResult(any(), any(), any(), any(), any(), any(), any(), any(), any()))
       .willReturn(expectedServiceResult)
 
     webTestClient.get()
@@ -414,6 +417,8 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
           .path("/reports/external-movements/last-month/tables/$tableId/result")
           .queryParam("selectedPage", 2L)
           .queryParam("pageSize", 20L)
+          .queryParam("sortColumn", sortColumn)
+          .queryParam("sortedAsc", true)
           .queryParam("${DataApiSyncController.FiltersPrefix.FILTERS_PREFIX}direction", "out")
           .build()
       }
@@ -433,6 +438,8 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq(selectedPage),
         eq(pageSize),
         eq(mapOf("direction" to "out")),
+        eq(true),
+        eq(sortColumn),
       )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -421,7 +421,20 @@ class AsyncDataApiServiceTest {
     val tableId = TableIdGenerator().generateNewExternalTableId()
     val selectedPage = 1L
     val pageSize = 20L
-    whenever(redshiftDataApiRepository.getPaginatedExternalTableResult(any(), any(), any(), any(), anyOrNull()))
+    val sortColumn = "columnA"
+    val sortedAsc = true
+
+    whenever(
+      redshiftDataApiRepository.getPaginatedExternalTableResult(
+        tableId = any(),
+        selectedPage = any(),
+        pageSize = any(),
+        filters = any(),
+        sortedAsc = any(),
+        sortColumn = anyOrNull(),
+        jdbcTemplate = anyOrNull(),
+      ),
+    )
       .thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.getStatementResult(
@@ -431,11 +444,20 @@ class AsyncDataApiServiceTest {
       selectedPage = selectedPage,
       pageSize = pageSize,
       filters = mapOf("direction" to "in"),
+      sortedAsc = sortedAsc,
+      sortColumn = sortColumn,
     )
 
     assertEquals(expectedServiceResult, actual)
 
-    verify(redshiftDataApiRepository).getPaginatedExternalTableResult(tableId, selectedPage, pageSize, listOf(Filter("direction", "in")))
+    verify(redshiftDataApiRepository).getPaginatedExternalTableResult(
+      tableId = tableId,
+      selectedPage = selectedPage,
+      pageSize = pageSize,
+      filters = listOf(Filter("direction", "in")),
+      sortedAsc = sortedAsc,
+      sortColumn = sortColumn,
+    )
   }
 
   @Test
@@ -455,7 +477,7 @@ class AsyncDataApiServiceTest {
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, datasetHelper)
     val executionID = UUID.randomUUID().toString()
     whenever(
-      redshiftDataApiRepository.getPaginatedExternalTableResult(executionID, selectedPage, pageSize, emptyList()),
+      redshiftDataApiRepository.getPaginatedExternalTableResult(executionID, selectedPage, pageSize, emptyList(), false),
     ).thenReturn(expectedRepositoryResult)
 
     val actual = asyncDataApiService.getStatementResult(
@@ -465,6 +487,7 @@ class AsyncDataApiServiceTest {
       selectedPage = selectedPage,
       pageSize = pageSize,
       filters = emptyMap(),
+      sortedAsc = false,
     )
 
     assertEquals(expectedServiceResult, actual)
@@ -495,7 +518,8 @@ class AsyncDataApiServiceTest {
     val selectedPage = 1L
     val pageSize = 20L
     whenever(
-      redshiftDataApiRepository.getPaginatedExternalTableResult(tableId, selectedPage, pageSize, emptyList()),
+      redshiftDataApiRepository
+        .getPaginatedExternalTableResult(tableId, selectedPage, pageSize, emptyList()),
     ).thenReturn(expectedRepositoryResult)
 
     val actual = configuredApiService.getDashboardStatementResult(


### PR DESCRIPTION
Added sortColumn and sortAsc query parameters to the async results endpoint to support the interactive journey.