### PR TITLE
DPR2-1076 Fix Bean ambiguity issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 7.2.5
+Fixed issue with application startup due to AthenaApiRepository bean ambiguity.
+
 ## 7.2.4
 Caching the list of establishments and wings and returning the establishments as static options.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Below you can find the changes included in each release.
 
 ## 7.2.5
-Fixed issue with application startup due to AthenaApiRepository bean ambiguity.
+Fixed issue with application startup due to AthenaApiRepository bean ambiguity on autowiring.
 
 ## 7.2.4
 Caching the list of establishments and wings and returning the establishments as static options.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.athena.AthenaClient
 import software.amazon.awssdk.services.athena.model.AthenaError
@@ -25,6 +26,7 @@ const val QUERY_ABORTED = "ABORTED"
 const val QUERY_FAILED = "FAILED"
 
 @Service
+@Primary
 class AthenaApiRepository(
   val athenaClient: AthenaClient,
   val tableIdGenerator: TableIdGenerator,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -24,7 +24,6 @@ class AsyncDataApiService(
   val productDefinitionRepository: ProductDefinitionRepository,
   val configuredApiRepository: ConfiguredApiRepository,
   val redshiftDataApiRepository: RedshiftDataApiRepository,
-//  @Qualifier("athenaApiRepository")
   val athenaApiRepository: AthenaApiRepository,
   val tableIdGenerator: TableIdGenerator,
   val datasetHelper: DatasetHelper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -24,6 +24,7 @@ class AsyncDataApiService(
   val productDefinitionRepository: ProductDefinitionRepository,
   val configuredApiRepository: ConfiguredApiRepository,
   val redshiftDataApiRepository: RedshiftDataApiRepository,
+//  @Qualifier("athenaApiRepository")
   val athenaApiRepository: AthenaApiRepository,
   val tableIdGenerator: TableIdGenerator,
   val datasetHelper: DatasetHelper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/LegacyReportSupportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/LegacyReportSupportService.kt
@@ -1,9 +1,0 @@
-package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
-
-import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AthenaApiRepository
-
-@Service
-class LegacyReportSupportService(
-  val athenaApiRepository: AthenaApiRepository,
-)


### PR DESCRIPTION
These changes fix the issue with Bean ambiguity causing the application to crash at startup.
Since both AthenaApiRepository and EstablishmentCodesToWingsCacheService are annotated as Service and one is a subclass of the other Spring did not know which one to inject when AthenaApiRepository was autowired. 
Annotating AthenaApiRepository as primary fixes this.