### PR TITLE
DPR2-1076 use existing stopwatch method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 7.2.7
+Fixed issue with Stopwatch.duration call throwing an exception.
+
 ## 7.2.6
 Added user authorisation check against report policy for async report definition endpoints.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepository.kt
@@ -38,7 +38,7 @@ class EstablishmentsToWingsRepository(
       waitForQueryToComplete(executionId)
       val results = fetchAllResults(executionId)
       stopwatch.stop()
-      log.info("List of establishments and wings retrieved successfully in ${stopwatch.duration.seconds} sec.")
+      log.info("List of establishments and wings retrieved successfully in ${stopwatch.time}.")
       results
     } catch (e: Exception) {
       log.error("Error retrieving list of establishments and wings: ", e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/estcodesandwings/EstablishmentCodesToWingsCacheService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/estcodesandwings/EstablishmentCodesToWingsCacheService.kt
@@ -31,7 +31,7 @@ class EstablishmentCodesToWingsCacheService(
     if (establishmentToWingsMap.isNotEmpty()) {
       establishmentCodesCache.putAll(establishmentToWingsMap)
       stopWatch.stop()
-      log.info("Establishments and wings cache refreshed in ${stopWatch.duration.seconds} sec.")
+      log.info("Establishments and wings cache refreshed in ${stopWatch.time}.")
     }
   }
 }


### PR DESCRIPTION
Use existing time stopwatch method as getDuration() throws a classNotFound error.