### PR TITLE
DPR2-1076 added ProductDefinitionTokenPolicyChecker to conf imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 7.2.8
+Fixed issue with ProductDefinitionTokenPolicyChecker not visible for automatic DI in hosts of the library.
+
 ## 7.2.7
 Fixed issue with Stopwatch.duration call throwing an exception.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ProductDefinitionTokenPolicyChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ProductDefinitionTokenPolicyChecker.kt
@@ -13,6 +13,6 @@ class ProductDefinitionTokenPolicyChecker {
   ): Boolean {
     val policyEngine = PolicyEngine(withPolicy.policy, userToken)
     val result = policyEngine.execute()
-    return if (result == Policy.PolicyResult.POLICY_PERMIT) true else false
+    return result == Policy.PolicyResult.POLICY_PERMIT
   }
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -28,3 +28,4 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ContextAuthenticationHelper
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.estcodesandwings.LegacyEstablishmentCodesToWingsCacheConfig
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ProductDefinitionTokenPolicyChecker


### PR DESCRIPTION
Fixed issue with ProductDefinitionTokenPolicyChecker not visible for automatic DI in hosts of the library.