### PR TITLE
[DPR2-1521] refactor authCheck to only execute access level policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+## 7.2.9
+Added user authorisation check against report policy for sync report definition endpoints. 
+Refactored policy engine, so that authorisation check only executes access level PolicyType.
+
 ## 7.2.8
 Fixed issue with ProductDefinitionTokenPolicyChecker not visible for automatic DI in hosts of the library.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -259,6 +259,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
           statementId,
           reportId,
           reportVariantId,
+          userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
           dataProductDefinitionsPath,
         ),
       )
@@ -354,6 +355,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
             reportId,
             reportVariantId,
             filterHelper.filtersOnly(filters),
+            userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
             dataProductDefinitionsPath,
           ),
         )
@@ -412,8 +414,9 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
           filters = filterHelper.filtersOnly(filters),
           sortedAsc = sortedAsc,
           sortColumn = sortColumn,
-        ),
-      )
+          userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+          ),
+        )
   }
 
   @GetMapping("/reports/{reportId}/dashboards/{dashboardId}/tables/{tableId}/result")
@@ -456,8 +459,9 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
           selectedPage = selectedPage,
           pageSize = pageSize,
           filters = filterHelper.filtersOnly(filters),
-        ),
-      )
+          userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+          ),
+        )
   }
 
   @GetMapping("/reports/{reportId}/{reportVariantId}/tables/{tableId}/result/summary/{summaryId}")
@@ -493,7 +497,8 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
           reportVariantId = reportVariantId,
           dataProductDefinitionsPath = dataProductDefinitionsPath,
           filters = filterHelper.filtersOnly(filters),
-        ),
-      )
+          userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+          ),
+        )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleDashboardProductDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SingleDashboardProductDefinition.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.WithPolicy
 
 data class SingleDashboardProductDefinition(
   val id: String,
@@ -8,8 +9,8 @@ data class SingleDashboardProductDefinition(
   val description: String? = null,
   val metadata: MetaData,
   val datasource: Datasource,
-  val policy: List<Policy>,
+  override val policy: List<Policy>,
   val dashboardDataset: Dataset,
   val dashboard: Dashboard,
   val allDatasets: List<Dataset>,
-)
+) : WithPolicy

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -18,10 +18,10 @@ class PolicyEngine(
   }
 
   fun execute(policyType: PolicyType): String {
-    return doExecute(policy.filter { it.type == policyType })
+    return doExecute(policy.filter { it.type == policyType }.sortedByDescending { it.type })
   }
 
-  fun execute(): String = doExecute(policy)
+  fun execute(): String = doExecute(policy.sortedByDescending { it.type })
 
   private fun doExecute(policiesToCheck: List<Policy>): String {
     return if (policiesToCheck.isEmpty() || isAnyPolicyDenied(policiesToCheck)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
 
@@ -14,6 +15,18 @@ class PolicyEngine(
     const val ROLE = "\${role}"
     const val TOKEN = "\${token}"
     const val CASELOAD = "\${caseload}"
+  }
+
+  fun execute(policyType: PolicyType): String {
+    return doExecute(policy.filter { it.type == policyType })
+  }
+
+  private fun doExecute(policiesToCheck: List<Policy>): String {
+    return if (policiesToCheck.isEmpty() || isAnyPolicyDenied(policiesToCheck)) {
+      POLICY_DENY
+    } else {
+      policiesToCheck.joinToString(" AND ") { it.apply(this::interpolateVariables) }
+    }
   }
 
   fun execute(): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -21,19 +21,13 @@ class PolicyEngine(
     return doExecute(policy.filter { it.type == policyType })
   }
 
+  fun execute(): String = doExecute(policy)
+
   private fun doExecute(policiesToCheck: List<Policy>): String {
     return if (policiesToCheck.isEmpty() || isAnyPolicyDenied(policiesToCheck)) {
       POLICY_DENY
     } else {
       policiesToCheck.joinToString(" AND ") { it.apply(this::interpolateVariables) }
-    }
-  }
-
-  fun execute(): String {
-    return if (policy.isEmpty() || isAnyPolicyDenied(policy)) {
-      POLICY_DENY
-    } else {
-      policy.joinToString(" AND ") { it.apply(this::interpolateVariables) }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ProductDefinitionTokenPolicyChecker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ProductDefinitionTokenPolicyChecker.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.WithPolicy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 
@@ -12,7 +13,7 @@ class ProductDefinitionTokenPolicyChecker {
     userToken: DprAuthAwareAuthenticationToken?,
   ): Boolean {
     val policyEngine = PolicyEngine(withPolicy.policy, userToken)
-    val result = policyEngine.execute()
+    val result = policyEngine.execute(PolicyType.ACCESS)
     return result == Policy.PolicyResult.POLICY_PERMIT
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.WithPolicy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.UserAuthorisationException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
@@ -121,7 +121,7 @@ class SyncDataApiService(
         filters = validateAndMapFilters(productDefinition, filters, null),
         query = productDefinition.reportDataset.query,
         reportId = reportId,
-        policyEngineResult = policyEngine.execute(PolicyType.ROW_LEVEL),
+        policyEngineResult = policyEngine.execute(),
         dataSourceName = productDefinition.datasource.name,
         productDefinition = productDefinition,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
@@ -61,7 +61,7 @@ class SyncDataApiService(
         pageSize = pageSize,
         sortColumn = datasetForFilter?.let { findSortColumn(sortColumn, it) } ?: sortColumnFromQueryOrGetDefault(productDefinition, sortColumn),
         sortedAsc = sortedAsc,
-        policyEngineResult = datasetForFilter?.let { Policy.PolicyResult.POLICY_PERMIT } ?: policyEngine.execute(PolicyType.ROW_LEVEL),
+        policyEngineResult = datasetForFilter?.let { Policy.PolicyResult.POLICY_PERMIT } ?: policyEngine.execute(),
         dynamicFilterFieldId = reportFieldId,
         dataSourceName = productDefinition.datasource.name,
         reportFilter = productDefinition.report.filter,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -283,6 +283,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq(queryExecutionId),
         eq(reportId),
         eq(reportVariantId),
+        any<DprAuthAwareAuthenticationToken>(),
         eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
       ),
     )
@@ -369,6 +370,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         filters = eq(emptyMap()),
         sortedAsc = eq(false),
         sortColumn = eq(null),
+        userToken = any<DprAuthAwareAuthenticationToken>(),
       ),
     )
       .willReturn(expectedServiceResult)
@@ -409,7 +411,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         ),
       )
 
-    given(asyncDataApiService.getStatementResult(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+    given(asyncDataApiService.getStatementResult(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
       .willReturn(expectedServiceResult)
 
     webTestClient.get()
@@ -441,6 +443,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq(mapOf("direction" to "out")),
         eq(true),
         eq(sortColumn),
+        any<DprAuthAwareAuthenticationToken>(),
       )
   }
 
@@ -460,7 +463,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         ),
       )
 
-    given(asyncDataApiService.getDashboardStatementResult(any(), any(), any(), any(), any(), any(), any()))
+    given(asyncDataApiService.getDashboardStatementResult(any(), any(), any(), any(), any(), any(), any(), any()))
       .willReturn(expectedServiceResult)
 
     webTestClient.get()
@@ -486,6 +489,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
       eq(selectedPage),
       eq(pageSize),
       eq(emptyMap()),
+      any<DprAuthAwareAuthenticationToken>(),
     )
   }
 
@@ -505,7 +509,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         ),
       )
 
-    given(asyncDataApiService.getDashboardStatementResult(any(), any(), any(), any(), any(), any(), any()))
+    given(asyncDataApiService.getDashboardStatementResult(any(), any(), any(), any(), any(), any(), any(), any()))
       .willReturn(expectedServiceResult)
 
     webTestClient.get()
@@ -532,6 +536,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
       eq(selectedPage),
       eq(pageSize),
       eq(mapOf("direction" to "out")),
+      any<DprAuthAwareAuthenticationToken>(),
     )
   }
 
@@ -554,6 +559,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq("last-month"),
         eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
         eq(emptyMap()),
+        any<DprAuthAwareAuthenticationToken>(),
       ),
     )
       .willReturn(expectedServiceResult)
@@ -603,7 +609,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
     val tableId = "tableId"
     val expectedServiceResult = Count(10)
 
-    given(asyncDataApiService.count(any(), any(), any(), any(), any()))
+    given(asyncDataApiService.count(any(), any(), any(), any(), any(), any()))
       .willReturn(expectedServiceResult)
 
     webTestClient.get()
@@ -626,6 +632,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
         eq("external-movements"),
         eq("last-month"),
         eq(mapOf("direction" to "out")),
+        any<DprAuthAwareAuthenticationToken>(),
         eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
       )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -253,6 +253,13 @@ class AsyncDataApiServiceTest {
       ),
     ).thenReturn(statementExecutionResponse)
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = asyncDataApiService.validateAndExecuteStatementAsync(
       reportId = "missing-ethnicity-metrics",
       dashboardId = "test-dashboard-1",
@@ -346,7 +353,14 @@ class AsyncDataApiServiceTest {
       redshiftDataApiRepository.cancelStatementExecution(statementId),
     ).thenReturn(statementCancellationResponse)
 
-    val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month")
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month", authToken)
     verify(redshiftDataApiRepository, times(1)).cancelStatementExecution(statementId)
     verifyNoInteractions(athenaApiRepository)
     assertEquals(statementCancellationResponse, actual)
@@ -406,7 +420,14 @@ class AsyncDataApiServiceTest {
       athenaApiRepository.cancelStatementExecution(statementId),
     ).thenReturn(statementCancellationResponse)
 
-    val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month")
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month", authToken)
     verify(athenaApiRepository, times(1)).cancelStatementExecution(statementId)
     verifyNoInteractions(redshiftDataApiRepository)
     assertEquals(statementCancellationResponse, actual)
@@ -488,6 +509,13 @@ class AsyncDataApiServiceTest {
     )
       .thenReturn(expectedRepositoryResult)
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = configuredApiService.getStatementResult(
       tableId,
       reportId,
@@ -497,6 +525,7 @@ class AsyncDataApiServiceTest {
       filters = mapOf("direction" to "in"),
       sortedAsc = sortedAsc,
       sortColumn = sortColumn,
+      userToken = authToken,
     )
 
     assertEquals(expectedServiceResult, actual)
@@ -531,6 +560,13 @@ class AsyncDataApiServiceTest {
       redshiftDataApiRepository.getPaginatedExternalTableResult(executionID, selectedPage, pageSize, emptyList(), false),
     ).thenReturn(expectedRepositoryResult)
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = asyncDataApiService.getStatementResult(
       tableId = executionID,
       reportId = reportId,
@@ -539,6 +575,7 @@ class AsyncDataApiServiceTest {
       pageSize = pageSize,
       filters = emptyMap(),
       sortedAsc = false,
+      userToken = authToken,
     )
 
     assertEquals(expectedServiceResult, actual)
@@ -573,6 +610,13 @@ class AsyncDataApiServiceTest {
         .getPaginatedExternalTableResult(tableId, selectedPage, pageSize, emptyList()),
     ).thenReturn(expectedRepositoryResult)
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = configuredApiService.getDashboardStatementResult(
       tableId,
       "missing-ethnicity-metrics",
@@ -580,6 +624,7 @@ class AsyncDataApiServiceTest {
       selectedPage = selectedPage,
       pageSize = pageSize,
       filters = emptyMap(),
+      userToken = authToken,
     )
 
     assertEquals(expectedServiceResult, actual)
@@ -607,6 +652,13 @@ class AsyncDataApiServiceTest {
       redshiftDataApiRepository.getPaginatedExternalTableResult(tableId, selectedPage, pageSize, emptyList()),
     ).thenReturn(expectedRepositoryResult)
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val exception = Assertions.assertThrows(ValidationException::class.java) {
       configuredApiService.getDashboardStatementResult(
         tableId,
@@ -615,6 +667,7 @@ class AsyncDataApiServiceTest {
         selectedPage = selectedPage,
         pageSize = pageSize,
         filters = emptyMap(),
+        userToken = authToken,
       )
     }
     assertThat(exception).message().isEqualTo("The DPD is missing schema field: RANDOM_ROW.")
@@ -628,12 +681,20 @@ class AsyncDataApiServiceTest {
       redshiftDataApiRepository.getFullExternalTableResult(tableIdGenerator.getTableSummaryId(tableId, summaryId)),
     ).thenReturn(listOf(mapOf("TOTAL" to 1)))
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = configuredApiService.getSummaryResult(
       tableId,
       summaryId,
       reportId,
       reportVariantId,
       filters = emptyMap(),
+      userToken = authToken,
     )
 
     assertEquals(listOf(mapOf("total" to 1)), actual)
@@ -649,12 +710,20 @@ class AsyncDataApiServiceTest {
       .thenThrow(UncategorizedSQLException("EntityNotFoundException from glue - Entity Not Found", "", SQLException()))
       .thenReturn(listOf(mapOf("TOTAL" to 1)))
 
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
     val actual = configuredApiService.getSummaryResult(
       tableId,
       summaryId,
       reportId,
       reportVariantId,
       filters = emptyMap(),
+      userToken = authToken,
     )
 
     assertEquals(listOf(mapOf("total" to 1)), actual)
@@ -684,7 +753,14 @@ class AsyncDataApiServiceTest {
       redshiftDataApiRepository.count(tableId, listOf(Filter("direction", "in"))),
     ).thenReturn(expectedRepositoryResult)
 
-    val actual = configuredApiService.count(tableId, "external-movements", "last-month", filters)
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = configuredApiService.count(tableId, "external-movements", "last-month", filters, authToken)
 
     assertEquals(Count(expectedRepositoryResult), actual)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -80,6 +80,7 @@ class AsyncDataApiServiceTest {
   private val reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID
   private val reportVariantId = "last-month"
   private val policyEngineResult = "(origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
+  private val policyEngineResultTrue = "TRUE AND $policyEngineResult"
   private val tableIdGenerator: TableIdGenerator = TableIdGenerator()
   private val datasetHelper: DatasetHelper = DatasetHelper()
   private val productDefinitionTokenPolicyChecker = mock<ProductDefinitionTokenPolicyChecker>()
@@ -148,7 +149,7 @@ class AsyncDataApiServiceTest {
         filters = repositoryFilters,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         prompts = emptyList(),
         userToken = authToken,
       ),
@@ -168,7 +169,7 @@ class AsyncDataApiServiceTest {
       filters = repositoryFilters,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       prompts = emptyList(),
       userToken = authToken,
     )
@@ -461,7 +462,7 @@ class AsyncDataApiServiceTest {
         filters = repositoryFilters,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         prompts = prompts,
         userToken = authToken,
       ),
@@ -481,7 +482,7 @@ class AsyncDataApiServiceTest {
       filters = repositoryFilters,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       prompts = prompts,
       userToken = authToken,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.then
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinitionSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
@@ -81,6 +83,18 @@ class ReportDefinitionServiceTest {
     allDatasets = listOf(dataset),
   )
 
+  private val productDefinitionTokenPolicyChecker = mock<ProductDefinitionTokenPolicyChecker>()
+
+  @BeforeEach
+  fun setup() {
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+  }
+
   @Test
   fun `Getting report list for user maps correctly`() {
     val expectedResult = ReportDefinitionSummary(
@@ -104,7 +118,7 @@ class ReportDefinitionServiceTest {
     val summaryMapper = mock<ReportDefinitionSummaryMapper> {
       on { map(any(), any(), any()) } doReturn expectedResult
     }
-    val service = ReportDefinitionService(repository, mapper, summaryMapper)
+    val service = ReportDefinitionService(repository, mapper, summaryMapper, productDefinitionTokenPolicyChecker)
 
     val actualResult = service.getListForUser(RenderMethod.HTML, authToken)
 
@@ -135,7 +149,7 @@ class ReportDefinitionServiceTest {
     val mapper = mock<ReportDefinitionMapper> {
       on { map(any<SingleReportProductDefinition>(), any(), anyOrNull()) } doReturn expectedResult
     }
-    val service = ReportDefinitionService(repository, mapper, mock<ReportDefinitionSummaryMapper> {})
+    val service = ReportDefinitionService(repository, mapper, mock<ReportDefinitionSummaryMapper> {}, productDefinitionTokenPolicyChecker)
 
     val actualResult = service.getDefinition(
       minimalSingleDefinition.id,
@@ -169,7 +183,7 @@ class ReportDefinitionServiceTest {
     val summaryMapper = mock<ReportDefinitionSummaryMapper> {
       on { map(any(), any(), any()) } doReturn definitionWithNoVariants
     }
-    val service = ReportDefinitionService(repository, mapper, summaryMapper)
+    val service = ReportDefinitionService(repository, mapper, summaryMapper, productDefinitionTokenPolicyChecker)
 
     val actualResult = service.getListForUser(RenderMethod.HTML, authToken)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -85,11 +85,18 @@ class SyncDataApiServiceTest {
   private val reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID
   private val reportVariantId = "last-month"
   private val policyEngineResult = "(origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
-  private val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository)
+  private val productDefinitionTokenPolicyChecker = mock<ProductDefinitionTokenPolicyChecker>()
+  private val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository, productDefinitionTokenPolicyChecker)
 
   @BeforeEach
   fun setup() {
     whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
   }
 
   @Test
@@ -515,7 +522,7 @@ class SyncDataApiServiceTest {
       listOf("productDefinitionPolicyNoAction.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
     )
-    val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository)
+    val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository, productDefinitionTokenPolicyChecker)
     whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("USER-ROLE-1")))
     val policyEngineResult = "TRUE"
     val reportId = "definition-policy-no-action"
@@ -1247,7 +1254,7 @@ class SyncDataApiServiceTest {
       mapOf("9" to "1"),
     )
     val productDefRepo = mock<ProductDefinitionRepository>()
-    val configuredApiService = SyncDataApiService(productDefRepo, configuredApiRepository)
+    val configuredApiService = SyncDataApiService(productDefRepo, configuredApiRepository, productDefinitionTokenPolicyChecker)
     val dataSourceName = "name"
 
     whenever(productDefRepo.getProductDefinitions())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -84,8 +84,7 @@ class SyncDataApiServiceTest {
   private val authToken = mock<DprAuthAwareAuthenticationToken>()
   private val reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID
   private val reportVariantId = "last-month"
-  private val policyEngineResult = "(origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
-  private val policyEngineResultTrue = "TRUE AND (origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
+  private val policyEngineResult = "TRUE AND (origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
   private val productDefinitionTokenPolicyChecker = mock<ProductDefinitionTokenPolicyChecker>()
   private val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository, productDefinitionTokenPolicyChecker)
 
@@ -121,7 +120,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -136,7 +135,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -175,7 +174,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dynamicFilterFieldId = setOf(reportFieldId),
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
@@ -202,7 +201,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dynamicFilterFieldId = setOf(reportFieldId),
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
@@ -342,7 +341,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -357,7 +356,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -419,7 +418,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -434,7 +433,7 @@ class SyncDataApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -495,7 +494,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -510,7 +509,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -620,7 +619,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -639,7 +638,7 @@ class SyncDataApiServiceTest {
       pageSize = 10,
       sortColumn = "date",
       sortedAsc = true,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -1179,7 +1178,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -1194,7 +1193,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -1353,7 +1352,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResultTrue,
+        policyEngineResult = policyEngineResult,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -1368,7 +1367,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResultTrue,
+      policyEngineResult = policyEngineResult,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -85,6 +85,7 @@ class SyncDataApiServiceTest {
   private val reportId = EXTERNAL_MOVEMENTS_PRODUCT_ID
   private val reportVariantId = "last-month"
   private val policyEngineResult = "(origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
+  private val policyEngineResultTrue = "TRUE AND (origin_code='WWI' AND lower(direction)='out') OR (destination_code='WWI' AND lower(direction)='in')"
   private val productDefinitionTokenPolicyChecker = mock<ProductDefinitionTokenPolicyChecker>()
   private val configuredApiService = SyncDataApiService(productDefinitionRepository, configuredApiRepository, productDefinitionTokenPolicyChecker)
 
@@ -120,7 +121,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -135,7 +136,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -174,7 +175,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dynamicFilterFieldId = setOf(reportFieldId),
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
@@ -201,7 +202,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dynamicFilterFieldId = setOf(reportFieldId),
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
@@ -341,7 +342,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -356,7 +357,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -418,7 +419,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -433,7 +434,7 @@ class SyncDataApiServiceTest {
       pageSize,
       sortColumn,
       sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -494,7 +495,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -509,7 +510,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -619,7 +620,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -638,7 +639,7 @@ class SyncDataApiServiceTest {
       pageSize = 10,
       sortColumn = "date",
       sortedAsc = true,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -1178,7 +1179,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -1193,7 +1194,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )
@@ -1352,7 +1353,7 @@ class SyncDataApiServiceTest {
         pageSize = pageSize,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
-        policyEngineResult = policyEngineResult,
+        policyEngineResult = policyEngineResultTrue,
         dataSourceName = dataSourceName,
         reportFilter = singleReportProductDefinition.report.filter,
       ),
@@ -1367,7 +1368,7 @@ class SyncDataApiServiceTest {
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      policyEngineResult = policyEngineResult,
+      policyEngineResult = policyEngineResultTrue,
       dataSourceName = dataSourceName,
       reportFilter = singleReportProductDefinition.report.filter,
     )

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -99,6 +99,16 @@
   ],
   "policy": [
     {
+      "id": "role-based-policy",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": []
+        }
+      ]
+    },
+    {
       "id": "caseload",
       "type": "row-level",
       "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],

--- a/src/test/resources/productDefinitionWithFormula.json
+++ b/src/test/resources/productDefinitionWithFormula.json
@@ -52,6 +52,16 @@
   } ],
   "policy": [
     {
+      "id": "role-based-policy",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": []
+        }
+      ]
+    },
+    {
       "id": "caseload",
       "type": "row-level",
       "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],

--- a/src/test/resources/productDefinitionWithParameters.json
+++ b/src/test/resources/productDefinitionWithParameters.json
@@ -100,6 +100,16 @@
   ],
   "policy": [
     {
+      "id": "role-based-policy",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": []
+        }
+      ]
+    },
+    {
       "id": "caseload",
       "type": "row-level",
       "action": ["(origin_code='${caseload}' AND lower(direction)='out') OR (destination_code='${caseload}' AND lower(direction)='in')"],


### PR DESCRIPTION
- Updated remaining endpoints with authorisation policy check
- switched authCheck to only check access level policy types, was failing row level policies
- fixed tests adding default access level policy when needed