### PR TITLE
DPR2-1075 added support for wings and used est_code-description for e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.1
+Returning the list of wings as static options. Also added the establishment code suffixed 
+with a dash before the description in the list of establishments returned as static options.
 
 # 7.3.0
 Added support for DynamoDB storage of DPDs.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentToWing.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentToWing.kt
@@ -1,3 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings
 
-data class EstablishmentToWing(val establishmentCode: String, val description: String, val wing: String)
+data class EstablishmentToWing(val establishmentCode: String, val description: String, val wing: String) {
+  companion object {
+    const val ALL_WINGS = "All"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepository.kt
@@ -25,7 +25,7 @@ class EstablishmentsToWingsRepository(
   companion object {
     const val NOMIS_CATALOG = "nomis"
     const val DIGITAL_PRISON_REPORTING_DB = "DIGITAL_PRISON_REPORTING"
-    const val ESTABLISHMENTS_TO_WINGS_QUERY = "SELECT DISTINCT LIVING_UNITS.agy_loc_id as establishment_code, AGENCY_LOCATIONS.description as establishment_name, LIVING_UNITS.level_1_code as wing FROM OMS_OWNER.LIVING_UNITS JOIN OMS_OWNER.AGENCY_LOCATIONS ON LIVING_UNITS.agy_loc_id = AGENCY_LOCATIONS.agy_loc_id;"
+    const val ESTABLISHMENTS_TO_WINGS_QUERY = "SELECT DISTINCT LIVING_UNITS.agy_loc_id as establishment_code, AGENCY_LOCATIONS.description as establishment_name, LIVING_UNITS.AGY_LOC_ID || '-' || LIVING_UNITS.LEVEL_1_CODE as wing FROM OMS_OWNER.LIVING_UNITS JOIN OMS_OWNER.AGENCY_LOCATIONS ON LIVING_UNITS.agy_loc_id = AGENCY_LOCATIONS.agy_loc_id;"
   }
   fun executeStatementWaitAndGetResult(): MutableMap<String, List<EstablishmentToWing>> {
     return try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SpecialType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/SpecialType.kt
@@ -5,4 +5,7 @@ import com.google.gson.annotations.SerializedName
 enum class SpecialType {
   @SerializedName("establishment_code")
   ESTABLISHMENT_CODE,
+
+  @SerializedName("wing")
+  WING,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.T
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.VariantDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.WordWrap
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.DatasetHelper
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentToWing.Companion.ALL_WINGS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FeatureType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Parameter
@@ -107,7 +108,7 @@ class ReportDefinitionMapper(
         userToken,
         dataProductDefinitionsPath,
         allDatasets,
-      ) + maybeConvertToReportFields(parameters, allDatasets),
+      ) + maybeConvertToReportFields(parameters),
     )
   }
 
@@ -129,8 +130,8 @@ class ReportDefinitionMapper(
     )
   }
 
-  private fun maybeConvertToReportFields(parameters: List<Parameter>?, allDatasets: List<Dataset>) =
-    parameters?.map { convert(it, allDatasets) } ?: emptyList()
+  private fun maybeConvertToReportFields(parameters: List<Parameter>?) =
+    parameters?.map { convert(it) } ?: emptyList()
 
   private fun mapToReportFieldDefinitions(
     specification: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification,
@@ -152,7 +153,7 @@ class ReportDefinitionMapper(
     )
   }
 
-  private fun convert(parameter: Parameter, allDatasets: List<Dataset>): FieldDefinition {
+  private fun convert(parameter: Parameter): FieldDefinition {
     return FieldDefinition(
       name = parameter.name,
       display = parameter.display,
@@ -172,14 +173,28 @@ class ReportDefinitionMapper(
 
   private fun populateStaticOptionsForParameter(parameter: Parameter): List<FilterOption>? {
     return parameter.specialType
-      ?.takeIf { it == SpecialType.ESTABLISHMENT_CODE }
-      ?.let { mapEstablishmentsToFilterOptions() }
-      ?.takeIf { it.isNotEmpty() }
+      ?.let {
+        when (it) {
+          SpecialType.ESTABLISHMENT_CODE -> mapEstablishmentsToFilterOptions()
+          SpecialType.WING -> mapWingsToFilterOptions()
+        }
+      }?.takeIf { it.isNotEmpty() }
+  }
+
+  private fun mapWingsToFilterOptions(): List<FilterOption> {
+    return establishmentCodesToWingsCacheService
+      .getEstablishmentsAndPopulateCacheIfNeeded()
+      .takeIf { it.isNotEmpty() }
+      ?.flatMap { it.value }
+      ?.map { FilterOption(it.wing, it.wing) }
+      ?.plus(FilterOption(ALL_WINGS, ALL_WINGS))
+      ?: emptyList()
   }
 
   private fun mapEstablishmentsToFilterOptions(): List<FilterOption> {
-    return establishmentCodesToWingsCacheService.getEstablishmentsAndPopulateCacheIfNeeded()
-      .map { FilterOption(it.key, it.value.first().description) }
+    return establishmentCodesToWingsCacheService
+      .getEstablishmentsAndPopulateCacheIfNeeded()
+      .map { FilterOption(it.key, it.key + "-" + it.value.first().description) }
   }
 
   private fun map(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/establishmentsAndWings/EstablishmentsToWingsRepositoryTest.kt
@@ -43,10 +43,10 @@ class EstablishmentsToWingsRepositoryTest {
     setupMocksForGetStatus(statementId, athenaClient, "SUCCEEDED")
 
     val row1 = buildRow("establishment_code", "establishment_name", "wing")
-    val row2 = buildRow("AKI", "ACKLINGTON (HMP)", "L")
-    val row3 = buildRow("AKI", "ACKLINGTON (HMP)", "C")
-    val row4 = buildRow("BFI", "BEDFORD (HMP)", "D")
-    val row5 = buildRow("BFI", "BEDFORD (HMP)", "E")
+    val row2 = buildRow("AKI", "ACKLINGTON (HMP)", "AKI-L")
+    val row3 = buildRow("AKI", "ACKLINGTON (HMP)", "AKI-C")
+    val row4 = buildRow("BFI", "BEDFORD (HMP)", "BFI-D")
+    val row5 = buildRow("BFI", "BEDFORD (HMP)", "BFI-E")
     val getQueryResultsRequest: GetQueryResultsRequest =
       GetQueryResultsRequest.builder()
         .queryExecutionId(statementId)
@@ -64,12 +64,12 @@ class EstablishmentsToWingsRepositoryTest {
 
     val expected = mapOf(
       "AKI" to listOf(
-        EstablishmentToWing("AKI", "ACKLINGTON (HMP)", "L"),
-        EstablishmentToWing("AKI", "ACKLINGTON (HMP)", "C"),
+        EstablishmentToWing("AKI", "ACKLINGTON (HMP)", "AKI-L"),
+        EstablishmentToWing("AKI", "ACKLINGTON (HMP)", "AKI-C"),
       ),
       "BFI" to listOf(
-        EstablishmentToWing("BFI", "BEDFORD (HMP)", "D"),
-        EstablishmentToWing("BFI", "BEDFORD (HMP)", "E"),
+        EstablishmentToWing("BFI", "BEDFORD (HMP)", "BFI-D"),
+        EstablishmentToWing("BFI", "BEDFORD (HMP)", "BFI-E"),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -808,7 +808,7 @@ class ReportDefinitionMapperTest {
   }
 
   @Test
-  fun `getting single report with parameters with specialType of wing includes all the wings as static options`() {
+  fun `getting single report with parameters with specialType of wing includes all the wings as static options`(): Unit = runBlocking {
     val parameterName = "paramName"
     val parameterDisplay = "paramDisplay"
     val parameter = Parameter(


### PR DESCRIPTION
Added support for wings. 
The list of wings displays all the wings across all establishments in which the user is able to search for the wing they would like to select.
The wing format in the list is establishment_code-level_1_code i.e. "KMI-A".
This is in line with the legacy system.
Also the list of establishments shows establishment_code-description i.e. KMI-KIRKHAM.
