### PR TITLE
NO-JIRA- Fixed issue with Stopwatch duration call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.7
+Fixed issue with Stopwatch.duration call throwing an exception.
+
 # 7.3.6
 Add caching to DDB DPD repo.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -146,7 +146,7 @@ class RedshiftDataApiRepository(
         transformTimestampToLocalDateTime(it)
       }
     stopwatch.stop()
-    log.debug("Query Execution time in ms: {}", stopwatch.duration)
+    log.debug("Query Execution time in ms: {}", stopwatch.time)
     return result
   }
 


### PR DESCRIPTION
This is fixing the below error:
`Error: Unexpected error: Handler dispatch failed: java.lang.NoSuchMethodError: 'java.time.Duration org.apache.commons.lang3.time.StopWatch.getDuration()'`