### PR TITLE
DPR2-1606 Changed specialType:establishment_code to referenceType:establishment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Below you can find the changes included in each release.
 
 # 7.3.13
 Change specialType to referenceType for the establishment and wing parameters.
+Included RefreshCacheSchedulingService in the AutoConfiguration.imports.
 
 # 7.3.12
 Return only the establishment description as the FilterOption display value. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.13
+Change specialType to referenceType for the establishment and wing parameters.
+
 # 7.3.12
 Return only the establishment description as the FilterOption display value. 
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Parameter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Parameter.kt
@@ -7,5 +7,5 @@ data class Parameter(
   val filterType: FilterType,
   val display: String,
   val mandatory: Boolean,
-  val specialType: SpecialType? = null,
+  val referenceType: ReferenceType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReferenceType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReferenceType.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
 import com.google.gson.annotations.SerializedName
 
-enum class SpecialType {
-  @SerializedName("establishment_code")
-  ESTABLISHMENT_CODE,
+enum class ReferenceType {
+  @SerializedName("establishment")
+  ESTABLISHMENT,
 
   @SerializedName("wing")
   WING,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -20,12 +20,12 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishment
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FeatureType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Parameter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReferenceType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportMetadataHint
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SpecialType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Visible
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEngine.Companion.MAKE_URL_FORMULA_PREFIX
@@ -177,11 +177,11 @@ class ReportDefinitionMapper(
   }
 
   private fun populateStaticOptionsForParameter(parameter: Parameter): List<FilterOption>? {
-    return parameter.specialType
+    return parameter.referenceType
       ?.let {
         when (it) {
-          SpecialType.ESTABLISHMENT_CODE -> mapEstablishmentsToFilterOptions()
-          SpecialType.WING -> mapWingsToFilterOptions()
+          ReferenceType.ESTABLISHMENT -> mapEstablishmentsToFilterOptions()
+          ReferenceType.WING -> mapWingsToFilterOptions()
         }
       }?.takeIf { it.isNotEmpty() }
   }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -30,3 +30,4 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ContextAuthentic
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.estcodesandwings.LegacyEstablishmentCodesToWingsCacheConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ProductDefinitionTokenPolicyChecker
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.RefreshCacheSchedulingService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ExternalMovementRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PrisonerRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentsToWingsRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = ["spring.main.allow-bean-definition-overriding=true"])
@@ -54,6 +55,9 @@ abstract class IntegrationTestBase {
 
   @MockitoBean
   lateinit var stsAssumeRoleCredentialsProvider: StsAssumeRoleCredentialsProvider
+
+  @MockitoBean
+  lateinit var establishmentsToWingsRepository: EstablishmentsToWingsRepository
 
   companion object {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.given
 import org.mockito.kotlin.then
+import org.mockito.kotlin.whenever
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.expectBody
@@ -20,6 +22,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.F
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ReportDefinitionSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentToWing
 import java.time.LocalDate.now
 import java.time.format.DateTimeFormatter
 
@@ -729,6 +732,18 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     @Test
     fun `Single Definition with parameters is returned with the parameters converted to filters`() {
       try {
+        val bfiEstCode = "BFI"
+        val bfiDescription = "BEDFORD (HMP)"
+        val estToWingResult = mutableMapOf(
+          bfiEstCode to listOf(
+            EstablishmentToWing(
+              bfiEstCode,
+              bfiDescription,
+              "BFI-A",
+            ),
+          ),
+        )
+        whenever(establishmentsToWingsRepository.executeStatementWaitAndGetResult()).doReturn(estToWingResult)
         prisonerRepository.save(ConfiguredApiRepositoryTest.AllPrisoners.prisoner9848)
         externalMovementRepository.save(ConfiguredApiRepositoryTest.AllMovements.externalMovementDestinationCaseloadDirectionIn)
 
@@ -957,11 +972,17 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "calculated": false
                   },
                   {
-                    "name": "prisoner_number",
-                    "display": "Enter NOMS Number",
+                    "name": "establishment_code",
+                    "display": "Establishment",
                     "filter": {
-                      "type": "text",
-                      "mandatory": true
+                      "mandatory": true,
+                      "type": "autocomplete",
+                      "staticOptions": [
+                        {
+                          "name": "BFI",
+                          "display": "BEDFORD (HMP)"
+                        }
+                      ]
                     },
                     "sortable": false,
                     "defaultsort": false,
@@ -969,7 +990,31 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "mandatory": false,
                     "visible": false,
                     "calculated": false
-                  } 
+                  }, 
+                 {
+                  "name": "wing",
+                  "display": "Wing",
+                  "filter": {
+                    "mandatory": true,
+                    "type": "autocomplete",
+                    "staticOptions": [
+                      {
+                        "name": "BFI-A",
+                        "display": "BFI-A"
+                      },
+                      {
+                        "name":"All",
+                        "display":"All"
+                      }
+                    ]
+                  },
+                  "sortable": false,
+                  "defaultsort": false,
+                  "type": "string",
+                  "mandatory": false,
+                  "visible": false,
+                  "calculated": false
+                }
                 ]
               },
               "classification": "report classification",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -443,14 +443,20 @@ class AsyncDataApiServiceTest {
     val productDefinition = productDefinitionRepository.getProductDefinitions().first()
     val singleReportProductDefinition = productDefinitionRepository.getSingleReportProductDefinition(productDefinition.id, productDefinition.report.first().id)
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, datasetHelper, productDefinitionTokenPolicyChecker)
-    val parameterName = "prisoner_number"
-    val parameterValue = "somePrisonerNumber"
+    val parameter1Name = "establishment_code"
+    val parameter1Value = "BFI"
+    val parameter2Name = "wing"
+    val parameter2Value = "BFI-A"
     val filters = mapOf(
       "origin" to "someOrigin",
-      parameterName to parameterValue,
+      parameter1Name to parameter1Value,
+      parameter2Name to parameter2Value,
     )
     val repositoryFilters = listOf(Filter("origin", "someOrigin", STANDARD))
-    val prompts = listOf(Prompt(parameterName, parameterValue, FilterType.Text))
+    val prompts = listOf(
+      Prompt(parameter1Name, parameter1Value, FilterType.AutoComplete),
+      Prompt(parameter2Name, parameter2Value, FilterType.AutoComplete),
+    )
     val sortColumn = "date"
     val sortedAsc = true
     val executionId = UUID.randomUUID().toString()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterT
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MetaData
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReferenceType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
@@ -37,7 +38,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SpecialType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.StaticFilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SummaryField
@@ -756,7 +756,7 @@ class ReportDefinitionMapperTest {
   }
 
   @Test
-  fun `getting single report with parameters with specialType of establishment_code includes all the establishments as static options`() {
+  fun `getting single report with parameters with referenceType of establishment_code includes all the establishments as static options`() {
     val parameterName = "paramName"
     val parameterDisplay = "paramDisplay"
     val parameter = Parameter(
@@ -766,7 +766,7 @@ class ReportDefinitionMapperTest {
       filterType = FilterType.Text,
       display = parameterDisplay,
       mandatory = true,
-      specialType = SpecialType.ESTABLISHMENT_CODE,
+      referenceType = ReferenceType.ESTABLISHMENT,
     )
     val productDefinition = createProductDefinition("today()", parameters = listOf(parameter))
     val bfiEstCode = "BFI"
@@ -807,7 +807,7 @@ class ReportDefinitionMapperTest {
   }
 
   @Test
-  fun `getting single report with parameters with specialType of wing includes all the wings as static options`() {
+  fun `getting single report with parameters with referenceType of wing includes all the wings as static options`() {
     val parameterName = "paramName"
     val parameterDisplay = "paramDisplay"
     val parameter = Parameter(
@@ -817,7 +817,7 @@ class ReportDefinitionMapperTest {
       filterType = FilterType.Text,
       display = parameterDisplay,
       mandatory = true,
-      specialType = SpecialType.WING,
+      referenceType = ReferenceType.WING,
     )
     val productDefinition = createProductDefinition("today()", parameters = listOf(parameter))
     val bfiEstCode = "BFI"

--- a/src/test/resources/productDefinitionWithParameters.json
+++ b/src/test/resources/productDefinitionWithParameters.json
@@ -21,13 +21,23 @@
     "parameters": [
       {
         "index": 0,
-        "name": "prisoner_number",
-        "filterType": "text",
+        "name": "establishment_code",
+        "filterType": "autocomplete",
         "reportFieldType": "string",
-        "display": "Enter NOMS Number",
+        "display": "Establishment",
         "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
         "mandatory": "true",
-        "specialType": "establishment_code"
+        "referenceType": "establishment"
+      },
+      {
+        "index": 1,
+        "name": "wing",
+        "filterType": "autocomplete",
+        "reportFieldType": "string",
+        "display": "Wing",
+        "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
+        "mandatory": "true",
+        "referenceType": "wing"
       }
     ],
     "schema" : {


### PR DESCRIPTION
The main changes are:
- The report definition establishment code parameter now is expected to have a "referenceType" of "establishment" instead of a "specialType" of "establishment_code".
- RefreshCacheSchedulingService was included in the AutoConfiguration.imports.