### PR TITLE
DPR2-1251 remove stacktrace from userMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.15
+These changes remove the stack trace from the userMessage of the 500 responses and replace it with a generic error message.
+
 # 7.3.14
 The creation of DataApiAsyncController is now conditional on dpr.lib.aws.sts.enabled being true.
 The NPE try/catch blocks have been removed from the Controller.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
@@ -49,7 +49,7 @@ class DigitalPrisonReportingExceptionHandler {
       .body(
         ErrorResponse(
           status = INTERNAL_SERVER_ERROR,
-          userMessage = "Unexpected error: ${e.message}",
+          userMessage = "Unexpected error.",
           developerMessage = e.message,
         ),
       )


### PR DESCRIPTION
There is a userMessage and a developerMessage being returned as part of the error responses.
The developer message is collapsed behind an accordion on the FE.
These changes remove the stack trace from the userMessage when there is a 500 response and replace it with a generic error message.