### PR TITLE
DPR2-1676 Return 404 instead of 500 when there is no results table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.19
+Changes to return a 404 instead of 500 when the results endpoints are called and the relevant Redshift table has been removed.
+
 # 7.3.18
 Changed numeric quick filter values to whole words. 
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
@@ -45,7 +45,7 @@ class DigitalPrisonReportingExceptionHandler {
   @ExceptionHandler(UncategorizedSQLException::class)
   fun handleEntityNotFound(e: Exception): ResponseEntity<ErrorResponse> {
     val entityNotFoundMessage = "EntityNotFoundException from glue - Entity Not Found"
-    if(e.message?.contains(entityNotFoundMessage) == true) {
+    if (e.message?.contains(entityNotFoundMessage) == true) {
       log.warn("Table not found exception: {}", e.message)
       return ResponseEntity
         .status(NOT_FOUND)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
@@ -6,8 +6,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
-import org.springframework.http.HttpStatus.TOO_MANY_REQUESTS
 import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.TOO_MANY_REQUESTS
 import org.springframework.http.ResponseEntity
 import org.springframework.jdbc.UncategorizedSQLException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -41,10 +41,11 @@ class DigitalPrisonReportingExceptionHandler {
   fun handleTypeMismatch(e: Exception): ResponseEntity<ErrorResponse> {
     return respondWithBadRequest(e)
   }
+
   @ExceptionHandler(UncategorizedSQLException::class)
   fun handleEntityNotFound(e: Exception): ResponseEntity<ErrorResponse> {
     val entityNotFoundMessage = "EntityNotFoundException from glue - Entity Not Found"
-    if(e.message?.contains(entityNotFoundMessage) == true) {
+    if (e.message?.contains(entityNotFoundMessage) == true) {
       log.info("Table not found exception: {}", e.message)
       return ResponseEntity
         .status(NOT_FOUND)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/config/DigitalPrisonReportingExceptionHandler.kt
@@ -45,8 +45,8 @@ class DigitalPrisonReportingExceptionHandler {
   @ExceptionHandler(UncategorizedSQLException::class)
   fun handleEntityNotFound(e: Exception): ResponseEntity<ErrorResponse> {
     val entityNotFoundMessage = "EntityNotFoundException from glue - Entity Not Found"
-    if (e.message?.contains(entityNotFoundMessage) == true) {
-      log.info("Table not found exception: {}", e.message)
+    if(e.message?.contains(entityNotFoundMessage) == true) {
+      log.warn("Table not found exception: {}", e.message)
       return ResponseEntity
         .status(NOT_FOUND)
         .body(


### PR DESCRIPTION
With these changes a 404 is returned instead of 500 when the results endpoints are called and the relevant Redshift table has been removed.