### PR TITLE
DPR2-1677 The status endpoints check if a table is missing only if the status is FINISHED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.3.21
+The status endpoints check if a table is missing only if the status is 'FINISHED' and there is a table ID provided.
+
 # 7.3.20
 The status endpoints accept an optional tableId to check for table existence before returning the status.
 


### PR DESCRIPTION
The status endpoints check if a table is missing only if the status is 'FINISHED' and there is a table ID provided as a query parameter.
This has been causing the polling page to break when polling for the status as the table ID is generated and returned to the FE along with the execution ID when the query execution endpoint is called.
But the table does't exist yet since the query hasn't finished.
So when the FE is polling to request the status the API responds with 404.