### PR TITLE
Changed dashboard json structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.5.1
+Changed dashboard json structure.
+
 # 7.5.0
 Add Parent-Child template: https://github.com/ministryofjustice/hmpps-digital-prison-reporting-data-product-definitions-schema?tab=readme-ov-file#parent-child-template
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ColumnAggregateTypeDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ColumnAggregateTypeDefinition.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class ColumnAggregateTypeDefinition(@JsonValue val type: String) {
+  SUM("sum"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/MetricDefinition.kt
@@ -6,13 +6,13 @@ data class MetricDefinition(
   val display: String,
   val description: String,
   val charts: List<ChartDefinition>,
+  val columns: List<ColumnDefinition>,
 )
 
 data class ChartDefinition(
   val type: ChartTypeDefinition,
   val label: LabelDefinition,
-  val unit: String,
-  val columns: List<ColumnDefinition>,
+  val columns: List<String>,
 )
 
 data class LabelDefinition(
@@ -22,4 +22,6 @@ data class LabelDefinition(
 data class ColumnDefinition(
   val name: String,
   val display: String,
+  val unit: String,
+  val aggregate: ColumnAggregateTypeDefinition,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ColumnAggregateType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ColumnAggregateType.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+import com.google.gson.annotations.SerializedName
+
+enum class ColumnAggregateType {
+  @SerializedName("sum")
+  SUM,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Metric.kt
@@ -6,13 +6,13 @@ data class Metric(
   val display: String,
   val description: String,
   val charts: List<Chart>,
+  val columns: List<Column>,
 )
 
 data class Chart(
   val type: ChartType,
   val label: Label,
-  val unit: String,
-  val columns: List<Column>,
+  val columns: List<String>,
 )
 
 data class Label(
@@ -23,4 +23,6 @@ data class Label(
 data class Column(
   val name: String,
   val display: String,
+  val unit: String,
+  val aggregate: ColumnAggregateType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ColumnAggregateTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ColumnDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldDefinition
@@ -44,6 +45,7 @@ class DashboardDefinitionMapper(
       display = metric.display,
       description = metric.description,
       charts = metric.charts.map { toChartDefinition(it) },
+      columns = metric.columns.map { toColumnDefinition(it) },
     )
   }
 
@@ -51,13 +53,12 @@ class DashboardDefinitionMapper(
     return ChartDefinition(
       type = ChartTypeDefinition.valueOf(chart.type.toString()),
       label = toLabelDefinition(chart.label),
-      unit = chart.unit,
-      columns = chart.columns.map { toColumnDefinition(it) },
+      columns = chart.columns,
     )
   }
 
   private fun toColumnDefinition(it: Column) =
-    ColumnDefinition(it.name.removePrefix("\$ref:"), it.display)
+    ColumnDefinition(it.name.removePrefix("\$ref:"), it.display, it.unit, ColumnAggregateTypeDefinition.valueOf(it.aggregate.toString()))
 
   private fun toLabelDefinition(label: Label) =
     LabelDefinition(label.name.removePrefix("\$ref:"), label.display)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
@@ -39,6 +39,20 @@ class DashboardDefinitionIntegrationTest : IntegrationTestBase() {
                 "name": "Missing Ethnicity By Establishment Metric",
                 "display": "Missing Ethnicity By Establishment Metric",
                 "description": "Missing Ethnicity By Establishment Metric",
+                "columns": [
+                      {
+                        "name": "has_ethnicity",
+                        "display": "No. of Prisoners with ethnicity",
+                        "unit": "number",
+                        "aggregate": "sum"
+                      },
+                      {
+                        "name": "ethnicity_is_missing",
+                        "display": "No. of Prisoners without ethnicity",
+                        "unit": "number",
+                        "aggregate": "sum"
+                      }
+                ],
                 "charts": [
                   {
                     "type": "bar",
@@ -46,17 +60,7 @@ class DashboardDefinitionIntegrationTest : IntegrationTestBase() {
                       "name": "establishment_id",
                       "display": "Establishment ID"
                     },
-                    "unit": "number",
-                    "columns": [
-                      {
-                        "name": "has_ethnicity",
-                        "display": "No. of Prisoners with ethnicity"
-                      },
-                      {
-                        "name": "ethnicity_is_missing",
-                        "display": "No. of Prisoners without ethnicity"
-                      }
-                    ]
+                    "columns": ["has_ethnicity","ethnicity_is_missing"]
                   },
                   {
                     "type": "doughnut",
@@ -64,17 +68,7 @@ class DashboardDefinitionIntegrationTest : IntegrationTestBase() {
                       "name": "establishment_id",
                       "display": "Establishment ID"
                     },
-                    "unit": "percentage",
-                    "columns": [
-                      {
-                        "name": "has_ethnicity",
-                        "display": "No. of Prisoners with ethnicity"
-                      },
-                      {
-                        "name": "ethnicity_is_missing",
-                        "display": "No. of Prisoners without ethnicity"
-                      }
-                    ]
+                    "columns": ["has_ethnicity","ethnicity_is_missing"]
                   }
                 ]
               }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.DefinitionGsonConfig
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ChartTypeDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ColumnAggregateTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ColumnDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DynamicFilterOption
@@ -62,23 +63,25 @@ class DashboardDefinitionMapperTest {
             name = "Missing Ethnicity By Establishment Metric",
             display = "Missing Ethnicity By Establishment Metric",
             description = "Missing Ethnicity By Establishment Metric",
+            columns = listOf(
+              ColumnDefinition(name = "has_ethnicity", display = "No. of Prisoners with ethnicity", unit = "number", aggregate = ColumnAggregateTypeDefinition.SUM),
+              ColumnDefinition(name = "ethnicity_is_missing", display = "No. of Prisoners without ethnicity", unit = "number", aggregate = ColumnAggregateTypeDefinition.SUM),
+            ),
             charts = listOf(
               ChartDefinition(
                 type = ChartTypeDefinition.BAR,
                 label = LabelDefinition(name = "establishment_id", display = "Establishment ID"),
-                unit = "number",
                 columns = listOf(
-                  ColumnDefinition(name = "has_ethnicity", display = "No. of Prisoners with ethnicity"),
-                  ColumnDefinition(name = "ethnicity_is_missing", display = "No. of Prisoners without ethnicity"),
+                  "has_ethnicity",
+                  "ethnicity_is_missing",
                 ),
               ),
               ChartDefinition(
                 type = ChartTypeDefinition.DOUGHNUT,
                 label = LabelDefinition(name = "establishment_id", display = "Establishment ID"),
-                unit = "percentage",
                 columns = listOf(
-                  ColumnDefinition(name = "has_ethnicity", display = "No. of Prisoners with ethnicity"),
-                  ColumnDefinition(name = "ethnicity_is_missing", display = "No. of Prisoners without ethnicity"),
+                  "has_ethnicity",
+                  "ethnicity_is_missing",
                 ),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.R
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Chart
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ChartType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Column
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ColumnAggregateType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
@@ -216,12 +217,12 @@ class ReportDefinitionSummaryMapperTest {
           name = "n1",
           display = "d1",
           description = "d2",
+          columns = listOf(Column(name = "column1", display = "Column 1", unit = "dim_1", aggregate = ColumnAggregateType.SUM)),
           charts = listOf(
             Chart(
               type = ChartType.BAR,
-              unit = "dim_1",
               label = Label(name = "label1", display = "Label 1"),
-              columns = listOf(Column(name = "column1", display = "Column 1")),
+              columns = listOf("column1", "Column 1"),
             ),
           ),
         ),

--- a/src/test/resources/productDefinitionWithMetrics.json
+++ b/src/test/resources/productDefinitionWithMetrics.json
@@ -83,6 +83,20 @@
           "name": "Missing Ethnicity By Establishment Metric",
           "display": "Missing Ethnicity By Establishment Metric",
           "description": "Missing Ethnicity By Establishment Metric",
+          "columns": [
+            {
+              "name": "$ref:has_ethnicity",
+              "display": "No. of Prisoners with ethnicity",
+              "unit": "number" ,
+              "aggregate": "sum"
+            },
+            {
+              "name": "$ref:ethnicity_is_missing",
+              "display": "No. of Prisoners without ethnicity",
+              "unit": "number",
+              "aggregate": "sum"
+            }
+          ],
           "charts": [
             {
               "type": "bar",
@@ -90,17 +104,7 @@
                 "name": "$ref:establishment_id",
                 "display": "Establishment ID"
               },
-              "unit": "number",
-              "columns": [
-                {
-                  "name": "$ref:has_ethnicity",
-                  "display": "No. of Prisoners with ethnicity"
-                },
-                {
-                  "name": "$ref:ethnicity_is_missing",
-                  "display": "No. of Prisoners without ethnicity"
-                }
-              ]
+              "columns": ["has_ethnicity","ethnicity_is_missing"]
             },
             {
               "type": "doughnut",
@@ -108,17 +112,7 @@
                 "name": "$ref:establishment_id",
                 "display": "Establishment ID"
               },
-              "unit": "percentage",
-              "columns": [
-                {
-                  "name": "$ref:has_ethnicity",
-                  "display": "No. of Prisoners with ethnicity"
-                },
-                {
-                  "name": "$ref:ethnicity_is_missing",
-                  "display": "No. of Prisoners without ethnicity"
-                }
-              ]
+              "columns": ["has_ethnicity","ethnicity_is_missing"]
             }
           ]
         }


### PR DESCRIPTION
Made the following changes to the dashboard json structure in preparation for supporting dashboards with lists:
- Moved "unit" from chart to column.
- Introduced new optional "aggregate" attribute of type "sum" to column.
- Added columns to metric as a list of full json column objects.
- Replaced chart columns value with a list of strings referencing the columns in the metric.