### PR TITLE
Dpr2 1745 dashboard queries based on datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.5.1
+Dashboards support also Athena queries based on the datasource defined in the DPD.
+
 # 7.5.0
 Add Parent-Child template: https://github.com/ministryofjustice/hmpps-digital-prison-reporting-data-product-definitions-schema?tab=readme-ov-file#parent-child-template
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -34,7 +34,7 @@ import java.util.Collections.singletonList
 @RestController
 @Tag(name = "Data API - Asynchronous")
 @ConditionalOnProperty("dpr.lib.aws.sts.enabled", havingValue = "true")
-class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val filterHelper: FilterHelper) {
+class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val filterHelper: FilterHelper) {
 
   @GetMapping("/async/reports/{reportId}/{reportVariantId}")
   @Operation(
@@ -80,7 +80,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          asyncDataApiService!!.validateAndExecuteStatementAsync(
+          asyncDataApiService.validateAndExecuteStatementAsync(
             reportId = reportId,
             reportVariantId = reportVariantId,
             filters = filterHelper.filtersOnly(filters),
@@ -141,7 +141,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          asyncDataApiService!!.validateAndExecuteStatementAsync(
+          asyncDataApiService.validateAndExecuteStatementAsync(
             reportId = reportId,
             dashboardId = dashboardId,
             userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
@@ -206,7 +206,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.getStatementStatus(
+        asyncDataApiService.getStatementStatus(
           statementId = statementId,
           reportId = reportId,
           reportVariantId = reportVariantId,
@@ -249,7 +249,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.getStatementStatus(statementId, tableId),
+        asyncDataApiService.getStatementStatus(statementId, tableId),
       )
   }
 
@@ -276,7 +276,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.cancelStatementExecution(
+        asyncDataApiService.cancelStatementExecution(
           statementId,
           reportId,
           reportVariantId,
@@ -298,7 +298,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.cancelStatementExecution(statementId),
+        asyncDataApiService.cancelStatementExecution(statementId),
       )
   }
 
@@ -325,7 +325,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          asyncDataApiService!!.count(tableId),
+          asyncDataApiService.count(tableId),
         )
     } catch (exception: NoDataAvailableException) {
       val headers = HttpHeaders()
@@ -371,7 +371,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
       ResponseEntity
         .status(HttpStatus.OK)
         .body(
-          asyncDataApiService!!.count(
+          asyncDataApiService.count(
             tableId,
             reportId,
             reportVariantId,
@@ -425,7 +425,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.getStatementResult(
+        asyncDataApiService.getStatementResult(
           tableId = tableId,
           reportId = reportId,
           reportVariantId = reportVariantId,
@@ -472,7 +472,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.getDashboardStatementResult(
+        asyncDataApiService.getDashboardStatementResult(
           tableId = tableId,
           reportId = reportId,
           dashboardId = dashboardId,
@@ -511,7 +511,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService?, val 
     return ResponseEntity
       .status(HttpStatus.OK)
       .body(
-        asyncDataApiService!!.getSummaryResult(
+        asyncDataApiService.getSummaryResult(
           tableId = tableId,
           summaryId = summaryId,
           reportId = reportId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -4,8 +4,10 @@ import org.apache.commons.lang3.time.StopWatch
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -19,14 +21,22 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
   }
 
   abstract fun executeQueryAsync(
-    productDefinition: SingleReportProductDefinition,
     filters: List<ConfiguredApiRepository.Filter>,
-    sortColumn: String?,
+    sortColumn: String? = null,
     sortedAsc: Boolean,
     policyEngineResult: String,
     dynamicFilterFieldId: Set<String>? = null,
     prompts: List<Prompt>? = null,
     userToken: DprAuthAwareAuthenticationToken? = null,
+    query: String,
+    reportFilter: ReportFilter? = null,
+    datasource: Datasource,
+    reportSummaries: List<ReportSummary>? = null,
+    allDatasets: List<Dataset>,
+    productDefinitionId: String,
+    productDefinitionName: String,
+    reportOrDashboardId: String,
+    reportOrDashboardName: String,
   ): StatementExecutionResponse
 
   abstract fun getStatementStatus(statementId: String): StatementExecutionStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -11,9 +11,11 @@ import software.amazon.awssdk.services.athena.model.QueryExecutionContext
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import software.amazon.awssdk.services.athena.model.StopQueryExecutionRequest
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType.Date
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -37,7 +39,6 @@ class AthenaApiRepository(
 ) : AthenaAndRedshiftCommonRepository() {
 
   override fun executeQueryAsync(
-    productDefinition: SingleReportProductDefinition,
     filters: List<ConfiguredApiRepository.Filter>,
     sortColumn: String?,
     sortedAsc: Boolean,
@@ -45,10 +46,19 @@ class AthenaApiRepository(
     dynamicFilterFieldId: Set<String>?,
     prompts: List<Prompt>?,
     userToken: DprAuthAwareAuthenticationToken?,
+    query: String,
+    reportFilter: ReportFilter?,
+    datasource: Datasource,
+    reportSummaries: List<ReportSummary>?,
+    allDatasets: List<Dataset>,
+    productDefinitionId: String,
+    productDefinitionName: String,
+    reportOrDashboardId: String,
+    reportOrDashboardName: String,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val finalQuery = """
-          /* ${productDefinition.id} ${productDefinition.name} ${productDefinition.report.id} ${productDefinition.report.name} */
+          /* $productDefinitionId $productDefinitionName $reportOrDashboardId $reportOrDashboardName */
           CREATE TABLE AwsDataCatalog.reports.$tableId 
           WITH (
             format = 'PARQUET'
@@ -59,9 +69,9 @@ class AthenaApiRepository(
       buildFinalQuery(
         buildContextQuery(userToken),
         buildPromptsQuery(prompts),
-        buildDatasetQuery(productDefinition.reportDataset.query),
-        buildReportQuery(productDefinition.report.filter),
-        buildPolicyQuery(policyEngineResult, determinePreviousCteName(productDefinition.report.filter)),
+        buildDatasetQuery(query),
+        buildReportQuery(reportFilter),
+        buildPolicyQuery(policyEngineResult, determinePreviousCteName(reportFilter)),
         // The filters part will be replaced with the variables CTE
         "$FILTER_ AS (SELECT * FROM $POLICY_ WHERE $TRUE_WHERE_CLAUSE)",
         buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
@@ -71,7 +81,7 @@ class AthenaApiRepository(
           );
     """.trimIndent()
 
-    return executeQueryAsync(productDefinition.datasource, tableId, finalQuery)
+    return executeQueryAsync(datasource, tableId, finalQuery)
   }
 
   override fun executeQueryAsync(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -12,9 +12,11 @@ import software.amazon.awssdk.services.redshiftdata.model.CancelStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleDashboardProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -36,7 +38,6 @@ class RedshiftDataApiRepository(
   private val s3location: String = "dpr-working-development/reports",
 ) : AthenaAndRedshiftCommonRepository() {
   override fun executeQueryAsync(
-    productDefinition: SingleReportProductDefinition,
     filters: List<ConfiguredApiRepository.Filter>,
     sortColumn: String?,
     sortedAsc: Boolean,
@@ -44,6 +45,15 @@ class RedshiftDataApiRepository(
     dynamicFilterFieldId: Set<String>?,
     prompts: List<Prompt>?,
     userToken: DprAuthAwareAuthenticationToken?,
+    query: String,
+    reportFilter: ReportFilter?,
+    datasource: Datasource,
+    reportSummaries: List<ReportSummary>?,
+    allDatasets: List<Dataset>,
+    productDefinitionId: String,
+    productDefinitionName: String,
+    reportOrDashboardId: String,
+    reportOrDashboardName: String,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val generateSql = """
@@ -53,18 +63,18 @@ class RedshiftDataApiRepository(
           AS ( 
           ${
       buildFinalQuery(
-        datasetQuery = buildDatasetQuery(productDefinition.reportDataset.query),
-        reportQuery = buildReportQuery(productDefinition.report.filter),
-        policiesQuery = buildPolicyQuery(policyEngineResult, determinePreviousCteName(productDefinition.report.filter)),
+        datasetQuery = buildDatasetQuery(query),
+        reportQuery = buildReportQuery(reportFilter),
+        policiesQuery = buildPolicyQuery(policyEngineResult, determinePreviousCteName(reportFilter)),
         filtersQuery = buildFiltersQuery(filters),
         selectFromFinalStageQuery = buildFinalStageQuery(dynamicFilterFieldId, sortColumn, sortedAsc),
       )
     }
           );
-          ${buildSummaryQueries(productDefinition, tableId)}
+          ${buildSummaryQueries(tableId, reportSummaries, allDatasets)}
     """.trimIndent()
 
-    return executeQueryAsync(productDefinition.datasource, tableId, generateSql)
+    return executeQueryAsync(datasource, tableId, generateSql)
   }
 
   override fun executeQueryAsync(
@@ -120,9 +130,13 @@ class RedshiftDataApiRepository(
     }
   }
 
-  fun buildSummaryQueries(productDefinition: SingleReportProductDefinition, tableId: String): String {
-    return productDefinition.report.summary?.joinToString(" ") {
-      val query = identifiedHelper.findOrFail(productDefinition.allDatasets, it.dataset).query
+  fun buildSummaryQueries(
+    tableId: String,
+    reportSummaries: List<ReportSummary>?,
+    allDatasets: List<Dataset>,
+  ): String {
+    return reportSummaries?.joinToString(" ") {
+      val query = identifiedHelper.findOrFail(allDatasets, it.dataset).query
 
       redShiftSummaryTableHelper.buildSummaryQuery(
         query,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dashboard.kt
@@ -6,4 +6,5 @@ data class Dashboard(
   val description: String,
   val dataset: String,
   val metrics: List<Metric>,
+  val filter: ReportFilter? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -110,12 +110,6 @@ class AsyncDataApiService(
     checkAuth(productDefinition, userToken)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
     val (promptsMap, filtersOnly) = partitionToPromptsAndFilters(filters, productDefinition.dashboardDataset.parameters)
-//    return redshiftDataApiRepository
-//      .executeQueryAsync(
-//        productDefinition = productDefinition,
-//        policyEngineResult = policyEngine.execute(),
-//        filters = validateAndMapFilters(productDefinition, filters, false),
-//      )
     return getRepo(productDefinition.datasource.name)
       .executeQueryAsync(
         filters = validateAndMapFilters(productDefinition, toMap(filtersOnly), false),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -14,8 +14,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.QUERY_FINISHED
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RedshiftDataApiRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.WithPolicy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
@@ -73,17 +73,25 @@ class AsyncDataApiService(
     checkAuth(productDefinition, userToken)
     val dynamicFilter = buildAndValidateDynamicFilter(reportFieldId?.first(), prefix, productDefinition)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
-    val (promptsMap, filtersOnly) = partitionToPromptsAndFilters(filters, productDefinition)
-    return getRepo(productDefinition)
+    val (promptsMap, filtersOnly) = partitionToPromptsAndFilters(filters, productDefinition.reportDataset.parameters)
+    return getRepo(productDefinition.datasource.name)
       .executeQueryAsync(
-        productDefinition = productDefinition,
         filters = validateAndMapFilters(productDefinition, toMap(filtersOnly), false) + dynamicFilter,
         sortColumn = sortColumnFromQueryOrGetDefault(productDefinition, sortColumn),
         sortedAsc = sortedAsc,
         policyEngineResult = policyEngine.execute(),
         dynamicFilterFieldId = reportFieldId,
-        prompts = buildPrompts(promptsMap, productDefinition),
+        prompts = buildPrompts(promptsMap, productDefinition.reportDataset.parameters),
         userToken = userToken,
+        query = productDefinition.reportDataset.query,
+        reportFilter = productDefinition.report.filter,
+        datasource = productDefinition.datasource,
+        reportSummaries = productDefinition.report.summary,
+        allDatasets = productDefinition.allDatasets,
+        productDefinitionId = productDefinition.id,
+        productDefinitionName = productDefinition.name,
+        reportOrDashboardId = productDefinition.report.id,
+        reportOrDashboardName = productDefinition.report.name,
       )
   }
 
@@ -101,18 +109,35 @@ class AsyncDataApiService(
     )
     checkAuth(productDefinition, userToken)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
-    return redshiftDataApiRepository
+    val (promptsMap, filtersOnly) = partitionToPromptsAndFilters(filters, productDefinition.dashboardDataset.parameters)
+//    return redshiftDataApiRepository
+//      .executeQueryAsync(
+//        productDefinition = productDefinition,
+//        policyEngineResult = policyEngine.execute(),
+//        filters = validateAndMapFilters(productDefinition, filters, false),
+//      )
+    return getRepo(productDefinition.datasource.name)
       .executeQueryAsync(
-        productDefinition = productDefinition,
+        filters = validateAndMapFilters(productDefinition, toMap(filtersOnly), false),
+        sortedAsc = true,
         policyEngineResult = policyEngine.execute(),
-        filters = validateAndMapFilters(productDefinition, filters, false),
+        prompts = buildPrompts(promptsMap, productDefinition.dashboardDataset.parameters),
+        userToken = userToken,
+        query = productDefinition.dashboardDataset.query,
+        reportFilter = productDefinition.dashboard.filter,
+        datasource = productDefinition.datasource,
+        allDatasets = productDefinition.allDatasets,
+        productDefinitionId = productDefinition.id,
+        productDefinitionName = productDefinition.name,
+        reportOrDashboardId = productDefinition.dashboard.id,
+        reportOrDashboardName = productDefinition.dashboard.name,
       )
   }
 
   fun getStatementStatus(statementId: String, reportId: String, reportVariantId: String, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null, tableId: String? = null): StatementExecutionStatus {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     checkAuth(productDefinition, userToken)
-    val statementStatus = getRepo(productDefinition).getStatementStatus(statementId)
+    val statementStatus = getRepo(productDefinition.datasource.name).getStatementStatus(statementId)
     tableId?.takeIf { statementStatus.status == QUERY_FINISHED }?.let {
       if (redshiftDataApiRepository.isTableMissing(tableId)) {
         throw MissingTableException(tableId)
@@ -231,7 +256,7 @@ class AsyncDataApiService(
   fun cancelStatementExecution(statementId: String, reportId: String, reportVariantId: String, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): StatementCancellationResponse {
     val productDefinition = productDefinitionRepository.getSingleReportProductDefinition(reportId, reportVariantId, dataProductDefinitionsPath)
     checkAuth(productDefinition, userToken)
-    return getRepo(productDefinition).cancelStatementExecution(statementId)
+    return getRepo(productDefinition.datasource.name).cancelStatementExecution(statementId)
   }
 
   fun cancelStatementExecution(statementId: String): StatementCancellationResponse {
@@ -262,35 +287,35 @@ class AsyncDataApiService(
     return true
   }
 
-  private fun getRepo(productDefinition: SingleReportProductDefinition): AthenaAndRedshiftCommonRepository =
-    datasourceNameToRepo.getOrDefault(productDefinition.datasource.name.lowercase(), redshiftDataApiRepository)
+  private fun getRepo(datasourceName: String): AthenaAndRedshiftCommonRepository =
+    datasourceNameToRepo.getOrDefault(datasourceName.lowercase(), redshiftDataApiRepository)
 
   private fun buildPrompts(
     prompts: List<Map.Entry<String, String>>,
-    productDefinition: SingleReportProductDefinition,
+    parameters: List<Parameter>?,
   ): List<Prompt> =
     prompts.mapNotNull { entry ->
-      mapToMatchingParameter(productDefinition, entry)
+      mapToMatchingParameter(entry, parameters)
         ?.let { Prompt(entry.key, entry.value, it.filterType) }
     }
 
   private fun mapToMatchingParameter(
-    productDefinition: SingleReportProductDefinition,
     entry: Map.Entry<String, String>,
-  ) = productDefinition.reportDataset.parameters?.firstOrNull { parameter -> parameter.name == entry.key }
+    parameters: List<Parameter>?,
+  ) = parameters?.firstOrNull { parameter -> parameter.name == entry.key }
 
   private fun <K, V> toMap(entries: List<Map.Entry<K, V>>): Map<K, V> =
     entries.associate { it.toPair() }
 
   private fun partitionToPromptsAndFilters(
     filters: Map<String, String>,
-    productDefinition: SingleReportProductDefinition,
-  ) = filters.asIterable().partition { e -> isPrompt(productDefinition, e) }
+    parameters: List<Parameter>?,
+  ) = filters.asIterable().partition { e -> isPrompt(e, parameters) }
 
   private fun isPrompt(
-    productDefinition: SingleReportProductDefinition,
     e: Map.Entry<String, String>,
-  ) = productDefinition.reportDataset.parameters?.any { it.name == e.key } ?: false
+    parameters: List<Parameter>?,
+  ) = parameters?.any { it.name == e.key } ?: false
 
   private fun formatColumnsAndApplyFormulas(
     records: List<Map<String, Any?>>,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -111,12 +111,20 @@ SELECT *
     val startQueryExecutionRequest = setupMocks(whereClause = whereClauseCondition)
     whenever(dataset.query).thenReturn(dpdQuery)
     val actual = athenaApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "column_a",
       sortedAsc = true,
       policyEngineResult = policyEngineResult,
       userToken = userToken,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -129,13 +137,21 @@ SELECT *
     val prompts = listOf(Prompt("filterName1", "filterValue1", FilterType.Text), Prompt("filterName2", "filterValue2", FilterType.Text))
     whenever(dataset.query).thenReturn(defaultDatasetCte)
     val actual = athenaApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "column_a",
       sortedAsc = true,
       policyEngineResult = POLICY_PERMIT,
       prompts = prompts,
       userToken = userToken,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -148,13 +164,21 @@ SELECT *
     val prompts = listOf(Prompt("start_date", "01/01/2023", FilterType.Date))
     whenever(dataset.query).thenReturn(defaultDatasetCte)
     val actual = athenaApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "column_a",
       sortedAsc = true,
       policyEngineResult = POLICY_PERMIT,
       prompts = prompts,
       userToken = userToken,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -168,12 +192,20 @@ SELECT *
 
     whenever(dataset.query).thenReturn(dpdQuery)
     val actual = athenaApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "column_a",
       sortedAsc = true,
       policyEngineResult = POLICY_PERMIT,
       userToken = userToken,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)
@@ -187,12 +219,20 @@ SELECT *
 
     whenever(dataset.query).thenReturn(dpdQuery)
     val actual = athenaApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "column_a",
       sortedAsc = true,
       policyEngineResult = POLICY_PERMIT,
       userToken = userToken,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(tableId, executionId), actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepository.Filter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.NAME
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.PRISON_NUMBER
@@ -45,6 +46,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportF
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
 import java.time.LocalDateTime
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -89,6 +91,9 @@ class ConfiguredApiRepositoryTest {
 
   @Autowired
   lateinit var configuredApiRepository: ConfiguredApiRepository
+
+  @MockitoBean
+  lateinit var asyncDataApiService: AsyncDataApiService
 
   @BeforeEach
   fun setup() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTestContainersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTestContainersTest.kt
@@ -10,11 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
 import java.time.LocalDateTime
 
 @Testcontainers
@@ -30,6 +32,9 @@ class ConfiguredApiRepositoryTestContainersTest {
 
   @Autowired
   lateinit var configuredApiRepository: ConfiguredApiRepository
+
+  @MockitoBean
+  lateinit var asyncDataApiService: AsyncDataApiService
 
   companion object {
     @DynamicPropertySource

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepositoryTest.kt
@@ -76,6 +76,10 @@ class RedshiftDataApiRepositoryTest {
   private val tableIdGenerator = mock<TableIdGenerator>()
   private val productDefinition = mock<SingleReportProductDefinition>()
   private val datasource = mock<Datasource>()
+  private val productDefinitionId = "dpdId"
+  private val productDefinitionName = "dpdName"
+  private val reportId = "reportId"
+  private val reportName = "reportName"
   private val dataset = mock<Dataset>()
   private val executeStatementResponse = mock<ExecuteStatementResponse>()
   private val report = mock<Report>()
@@ -89,6 +93,10 @@ class RedshiftDataApiRepositoryTest {
     whenever(productDefinition.reportDataset).thenReturn(dataset)
     whenever(productDefinition.report).thenReturn(report)
     whenever(productDefinition.datasource).thenReturn(datasource)
+    whenever(productDefinition.id).thenReturn(productDefinitionId)
+    whenever(productDefinition.name).thenReturn(productDefinitionName)
+    whenever(productDefinition.report.id).thenReturn(reportId)
+    whenever(productDefinition.report.name).thenReturn(reportName)
     whenever(dataset.query).thenReturn(REPOSITORY_TEST_QUERY)
   }
 
@@ -117,11 +125,19 @@ class RedshiftDataApiRepositoryTest {
     ).thenReturn(executeStatementResponse)
 
     val actual = redshiftDataApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = listOf(Filter("direction", "out")),
       sortColumn = "date",
       sortedAsc = true,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(TABLE_ID, EXECUTION_ID), actual)
@@ -173,7 +189,6 @@ SELECT *
     ).thenReturn(executeStatementResponse)
 
     val actual = redshiftDataApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = listOf(
         startDateFilter,
         endDateFilter,
@@ -183,6 +198,15 @@ SELECT *
       sortColumn = "date",
       sortedAsc = true,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(TABLE_ID, executionId), actual)
@@ -327,11 +351,19 @@ SELECT *
     ).thenReturn(executeStatementResponse)
 
     val actual = redshiftDataApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "date",
       sortedAsc = true,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(TABLE_ID, EXECUTION_ID), actual)
@@ -382,11 +414,19 @@ SELECT *
     ).thenReturn(executeStatementResponse)
 
     val actual = redshiftDataApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = emptyList(),
       sortColumn = "date",
       sortedAsc = true,
       policyEngineResult = policyEngineResult,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(TABLE_ID, EXECUTION_ID), actual)
@@ -420,11 +460,19 @@ SELECT *
     whenever(report.filter).thenReturn(ReportFilter(name = REPORT_, query = reportQuery))
 
     val actual = redshiftDataApiRepository.executeQueryAsync(
-      productDefinition = productDefinition,
       filters = listOf(Filter("direction", "out")),
       sortColumn = "date",
       sortedAsc = true,
       policyEngineResult = REPOSITORY_TEST_POLICY_ENGINE_RESULT,
+      query = productDefinition.reportDataset.query,
+      reportFilter = productDefinition.report.filter,
+      datasource = productDefinition.datasource,
+      reportSummaries = productDefinition.report.summary,
+      allDatasets = productDefinition.allDatasets,
+      productDefinitionId = productDefinition.id,
+      productDefinitionName = productDefinition.name,
+      reportOrDashboardId = productDefinition.report.id,
+      reportOrDashboardName = productDefinition.report.name,
     )
 
     assertEquals(StatementExecutionResponse(TABLE_ID, EXECUTION_ID), actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ExternalMovem
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.PrisonerRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentsToWingsRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = ["spring.main.allow-bean-definition-overriding=true"])
 @ActiveProfiles("test")
@@ -58,6 +59,9 @@ abstract class IntegrationTestBase {
 
   @MockitoBean
   lateinit var establishmentsToWingsRepository: EstablishmentsToWingsRepository
+
+  @MockitoBean
+  lateinit var asyncDataApiService: AsyncDataApiService
 
   companion object {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -8,8 +8,8 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.jdbc.UncategorizedSQLException
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.web.util.UriBuilder
 import software.amazon.awssdk.services.redshiftdata.model.ActiveStatementsExceededException
 import software.amazon.awssdk.services.redshiftdata.model.ValidationException
@@ -24,15 +24,12 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshif
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
 import java.sql.SQLException
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
-  @MockBean
-  private lateinit var asyncDataApiService: AsyncDataApiService
 
-  @MockBean
+  @MockitoBean
   lateinit var productDefinitionRepository: ProductDefinitionRepository
 
   @Test
@@ -183,7 +180,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the report status endpoint calls the getStatementStatus of the ConfiguredApiService with the correct arguments`() {
+  fun `Calling the report status endpoint calls the getStatementStatus of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val reportId = "external-movements"
     val reportVariantId = "last-month"
@@ -233,7 +230,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the statement status endpoint calls the getStatementStatus of the ConfiguredApiService with the correct arguments`() {
+  fun `Calling the statement status endpoint calls the getStatementStatus of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val status = "FINISHED"
     val duration = 278109264L
@@ -277,7 +274,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the report cancellation endpoint calls the cancelStatementExecution of the ConfiguredApiService with the correct arguments`() {
+  fun `Calling the report cancellation endpoint calls the cancelStatementExecution of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val reportId = "external-movements"
     val reportVariantId = "last-month"
@@ -315,7 +312,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the statement cancellation endpoint calls the cancelStatementExecution of the ConfiguredApiService with the correct arguments`() {
+  fun `Calling the statement cancellation endpoint calls the cancelStatementExecution of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val statementCancellationResponse = StatementCancellationResponse(
       true,
@@ -347,7 +344,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the report getStatementResult endpoint calls the configuredApiService with the correct arguments`() {
+  fun `Calling the report getStatementResult endpoint calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val selectedPage = 2L
     val pageSize = 20L
@@ -398,7 +395,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the report getStatementResult endpoint with filters and sorting calls the configuredApiService with the correct arguments`() {
+  fun `Calling the report getStatementResult endpoint with filters and sorting calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val selectedPage = 2L
     val pageSize = 20L
@@ -490,7 +487,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the dashboard getStatementResult endpoint calls the configuredApiService with the correct arguments`() {
+  fun `Calling the dashboard getStatementResult endpoint calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val dpdId = "external-movements"
     val dashboardId = "dashboardId"
@@ -538,7 +535,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the dashboard getStatementResult endpoint with filters calls the configuredApiService with the correct arguments`() {
+  fun `Calling the dashboard getStatementResult endpoint with filters calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val dpdId = "external-movements"
     val dashboardId = "dashboardId"
@@ -623,7 +620,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the getSummaryResult endpoint calls the configuredApiService with the correct arguments`() {
+  fun `Calling the getSummaryResult endpoint calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val summaryId = "summaryId"
     val expectedServiceResult =
@@ -661,7 +658,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the getExternalTableRowCount endpoint calls the configuredApiService with the correct arguments`() {
+  fun `Calling the getExternalTableRowCount endpoint calls the AsyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val expectedServiceResult = Count(5)
 
@@ -687,7 +684,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Calling the getInteractiveExternalTableRowCount endpoint with filters calls the configuredApiService with the correct arguments`() {
+  fun `Calling the getInteractiveExternalTableRowCount endpoint with filters calls the asyncDataApiService with the correct arguments`() {
     val tableId = "tableId"
     val expectedServiceResult = Count(10)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -40,8 +40,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_END
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_START
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.STANDARD
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.*
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -321,6 +321,94 @@ class AsyncDataApiServiceTest {
     )
 
     verify(redshiftDataApiRepository, times(1)).executeQueryAsync(
+      filters = emptyList(),
+      sortedAsc = true,
+      policyEngineResult = policyEngineResult,
+      prompts = emptyList(),
+      userToken = authToken,
+      query = singleDashboardProductDefinition.dashboardDataset.query,
+      reportFilter = singleDashboardProductDefinition.dashboard.filter,
+      datasource = singleDashboardProductDefinition.datasource,
+      allDatasets = singleDashboardProductDefinition.allDatasets,
+      productDefinitionId = singleDashboardProductDefinition.id,
+      productDefinitionName = singleDashboardProductDefinition.name,
+      reportOrDashboardId = singleDashboardProductDefinition.dashboard.id,
+      reportOrDashboardName = singleDashboardProductDefinition.dashboard.name,
+    )
+    assertEquals(statementExecutionResponse, actual)
+  }
+
+  @Test
+  fun `should make the dashboard async call to the AthenaDataApiRepository for nomis datasource with all provided arguments when validateAndExecuteStatementAsync is called`() {
+    val reportId = "missing-ethnicity-metrics"
+    val dashboardId = "test-dashboard-1"
+    val productDefinitionRepository: ProductDefinitionRepository =  mock<ProductDefinitionRepository>()
+    val singleDashboardProductDefinition = mock<SingleDashboardProductDefinition>()
+    val dashboard = mock<Dashboard>()
+    val dashboardDataset = mock<Dataset>()
+    val query = "select * from a"
+    val schema = mock<Schema>()
+    val field = mock<SchemaField>()
+    val datasource = mock<Datasource>()
+    val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
+    val executionId = UUID.randomUUID().toString()
+    val tableId = executionId.replace("-", "_")
+    val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
+    val caseload = "caseloadA"
+    whenever(productDefinitionRepository.getSingleDashboardProductDefinition(
+      definitionId = reportId,
+      dashboardId = dashboardId,
+    )).thenReturn(singleDashboardProductDefinition)
+    whenever(singleDashboardProductDefinition.dashboard).thenReturn(dashboard)
+    whenever(singleDashboardProductDefinition.id).thenReturn(dashboardId)
+    whenever(singleDashboardProductDefinition.name).thenReturn("name")
+    whenever(dashboard.id).thenReturn(dashboardId)
+    whenever(dashboard.name).thenReturn("name2")
+    whenever(dashboard.filter).thenReturn(mock<ReportFilter>())
+    whenever(singleDashboardProductDefinition.dashboardDataset).thenReturn(dashboardDataset)
+    whenever(dashboardDataset.query).thenReturn(query)
+    whenever(dashboardDataset.schema).thenReturn(schema)
+    whenever(schema.field).thenReturn(listOf(field))
+    whenever(field.name).thenReturn("fieldName")
+    whenever(singleDashboardProductDefinition.allDatasets).thenReturn(listOf(dashboardDataset))
+    whenever(singleDashboardProductDefinition.datasource).thenReturn(datasource)
+    whenever(datasource.name).thenReturn("NOMIS")
+    whenever(authToken.getCaseLoads()).thenReturn(listOf(caseload))
+    whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("ROLE_PRISONS_REPORTING_USER")))
+    val policyEngineResult = Policy.PolicyResult.POLICY_DENY
+    whenever(
+      athenaApiRepository.executeQueryAsync(
+        filters = emptyList(),
+        sortedAsc = true,
+        policyEngineResult = policyEngineResult,
+        prompts = emptyList(),
+        userToken = authToken,
+        query = singleDashboardProductDefinition.dashboardDataset.query,
+        reportFilter = singleDashboardProductDefinition.dashboard.filter,
+        datasource = singleDashboardProductDefinition.datasource,
+        allDatasets = singleDashboardProductDefinition.allDatasets,
+        productDefinitionId = singleDashboardProductDefinition.id,
+        productDefinitionName = singleDashboardProductDefinition.name,
+        reportOrDashboardId = singleDashboardProductDefinition.dashboard.id,
+        reportOrDashboardName = singleDashboardProductDefinition.dashboard.name,
+      ),
+    ).thenReturn(statementExecutionResponse)
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.validateAndExecuteStatementAsync(
+      reportId = reportId,
+      dashboardId = dashboardId,
+      userToken = authToken,
+      filters = emptyMap(),
+    )
+
+    verify(athenaApiRepository, times(1)).executeQueryAsync(
       filters = emptyList(),
       sortedAsc = true,
       policyEngineResult = policyEngineResult,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -40,7 +40,15 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_END
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_START
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.STANDARD
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.*
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Schema
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleDashboardProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
@@ -342,7 +350,7 @@ class AsyncDataApiServiceTest {
   fun `should make the dashboard async call to the AthenaDataApiRepository for nomis datasource with all provided arguments when validateAndExecuteStatementAsync is called`() {
     val reportId = "missing-ethnicity-metrics"
     val dashboardId = "test-dashboard-1"
-    val productDefinitionRepository: ProductDefinitionRepository =  mock<ProductDefinitionRepository>()
+    val productDefinitionRepository: ProductDefinitionRepository = mock<ProductDefinitionRepository>()
     val singleDashboardProductDefinition = mock<SingleDashboardProductDefinition>()
     val dashboard = mock<Dashboard>()
     val dashboardDataset = mock<Dataset>()
@@ -355,10 +363,12 @@ class AsyncDataApiServiceTest {
     val tableId = executionId.replace("-", "_")
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     val caseload = "caseloadA"
-    whenever(productDefinitionRepository.getSingleDashboardProductDefinition(
-      definitionId = reportId,
-      dashboardId = dashboardId,
-    )).thenReturn(singleDashboardProductDefinition)
+    whenever(
+      productDefinitionRepository.getSingleDashboardProductDefinition(
+        definitionId = reportId,
+        dashboardId = dashboardId,
+      ),
+    ).thenReturn(singleDashboardProductDefinition)
     whenever(singleDashboardProductDefinition.dashboard).thenReturn(dashboard)
     whenever(singleDashboardProductDefinition.id).thenReturn(dashboardId)
     whenever(singleDashboardProductDefinition.name).thenReturn("name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_START
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.STANDARD
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -152,13 +153,21 @@ class AsyncDataApiServiceTest {
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     whenever(
       redshiftDataApiRepository.executeQueryAsync(
-        productDefinition = singleReportProductDefinition,
         filters = repositoryFilters,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
         policyEngineResult = policyEngineResultTrue,
         prompts = emptyList(),
         userToken = authToken,
+        query = singleReportProductDefinition.reportDataset.query,
+        reportFilter = singleReportProductDefinition.report.filter,
+        datasource = singleReportProductDefinition.datasource,
+        reportSummaries = singleReportProductDefinition.report.summary,
+        allDatasets = singleReportProductDefinition.allDatasets,
+        productDefinitionId = singleReportProductDefinition.id,
+        productDefinitionName = singleReportProductDefinition.name,
+        reportOrDashboardId = singleReportProductDefinition.report.id,
+        reportOrDashboardName = singleReportProductDefinition.report.name,
       ),
     ).thenReturn(statementExecutionResponse)
 
@@ -172,13 +181,21 @@ class AsyncDataApiServiceTest {
     val actual = asyncDataApiService.validateAndExecuteStatementAsync(reportId, reportVariantId, filters, sortColumn, sortedAsc, authToken)
 
     verify(redshiftDataApiRepository, times(1)).executeQueryAsync(
-      productDefinition = singleReportProductDefinition,
       filters = repositoryFilters,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
       policyEngineResult = policyEngineResultTrue,
       prompts = emptyList(),
       userToken = authToken,
+      query = singleReportProductDefinition.reportDataset.query,
+      reportFilter = singleReportProductDefinition.report.filter,
+      datasource = singleReportProductDefinition.datasource,
+      reportSummaries = singleReportProductDefinition.report.summary,
+      allDatasets = singleReportProductDefinition.allDatasets,
+      productDefinitionId = singleReportProductDefinition.id,
+      productDefinitionName = singleReportProductDefinition.name,
+      reportOrDashboardId = singleReportProductDefinition.report.id,
+      reportOrDashboardName = singleReportProductDefinition.report.name,
     )
     assertEquals(statementExecutionResponse, actual)
   }
@@ -206,13 +223,21 @@ class AsyncDataApiServiceTest {
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     whenever(
       athenaApiRepository.executeQueryAsync(
-        productDefinition = singleReportProductDefinition,
         filters = repositoryFilters,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
         policyEngineResult = policyEngineResult,
         prompts = emptyList(),
         userToken = authToken,
+        query = singleReportProductDefinition.reportDataset.query,
+        reportFilter = singleReportProductDefinition.report.filter,
+        datasource = singleReportProductDefinition.datasource,
+        reportSummaries = singleReportProductDefinition.report.summary,
+        allDatasets = singleReportProductDefinition.allDatasets,
+        productDefinitionId = singleReportProductDefinition.id,
+        productDefinitionName = singleReportProductDefinition.name,
+        reportOrDashboardId = singleReportProductDefinition.report.id,
+        reportOrDashboardName = singleReportProductDefinition.report.name,
       ),
     ).thenReturn(statementExecutionResponse)
 
@@ -226,13 +251,21 @@ class AsyncDataApiServiceTest {
     val actual = asyncDataApiService.validateAndExecuteStatementAsync(reportId, reportVariantId, filters, sortColumn, sortedAsc, authToken)
 
     verify(athenaApiRepository, times(1)).executeQueryAsync(
-      productDefinition = singleReportProductDefinition,
       filters = repositoryFilters,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
       policyEngineResult = policyEngineResult,
       prompts = emptyList(),
       userToken = authToken,
+      query = singleReportProductDefinition.reportDataset.query,
+      reportFilter = singleReportProductDefinition.report.filter,
+      datasource = singleReportProductDefinition.datasource,
+      reportSummaries = singleReportProductDefinition.report.summary,
+      allDatasets = singleReportProductDefinition.allDatasets,
+      productDefinitionId = singleReportProductDefinition.id,
+      productDefinitionName = singleReportProductDefinition.name,
+      reportOrDashboardId = singleReportProductDefinition.report.id,
+      reportOrDashboardName = singleReportProductDefinition.report.name,
     )
     verifyNoInteractions(redshiftDataApiRepository)
     assertEquals(statementExecutionResponse, actual)
@@ -246,7 +279,7 @@ class AsyncDataApiServiceTest {
       identifiedHelper = IdentifiedHelper(),
     )
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
-    val productDefinition = productDefinitionRepository.getProductDefinitions().first()
+    val productDefinition: ProductDefinition = productDefinitionRepository.getProductDefinitions().first()
     val singleDashboardProductDefinition = productDefinitionRepository.getSingleDashboardProductDefinition(productDefinition.id, productDefinition.dashboards!!.first().id)
     val executionId = UUID.randomUUID().toString()
     val tableId = executionId.replace("-", "_")
@@ -257,9 +290,19 @@ class AsyncDataApiServiceTest {
     val policyEngineResult = "(establishment_id='$caseload')"
     whenever(
       redshiftDataApiRepository.executeQueryAsync(
-        productDefinition = singleDashboardProductDefinition,
-        policyEngineResult = policyEngineResult,
         filters = emptyList(),
+        sortedAsc = true,
+        policyEngineResult = policyEngineResult,
+        prompts = emptyList(),
+        userToken = authToken,
+        query = singleDashboardProductDefinition.dashboardDataset.query,
+        reportFilter = singleDashboardProductDefinition.dashboard.filter,
+        datasource = singleDashboardProductDefinition.datasource,
+        allDatasets = singleDashboardProductDefinition.allDatasets,
+        productDefinitionId = singleDashboardProductDefinition.id,
+        productDefinitionName = singleDashboardProductDefinition.name,
+        reportOrDashboardId = singleDashboardProductDefinition.dashboard.id,
+        reportOrDashboardName = singleDashboardProductDefinition.dashboard.name,
       ),
     ).thenReturn(statementExecutionResponse)
 
@@ -278,9 +321,19 @@ class AsyncDataApiServiceTest {
     )
 
     verify(redshiftDataApiRepository, times(1)).executeQueryAsync(
-      productDefinition = singleDashboardProductDefinition,
-      policyEngineResult = policyEngineResult,
       filters = emptyList(),
+      sortedAsc = true,
+      policyEngineResult = policyEngineResult,
+      prompts = emptyList(),
+      userToken = authToken,
+      query = singleDashboardProductDefinition.dashboardDataset.query,
+      reportFilter = singleDashboardProductDefinition.dashboard.filter,
+      datasource = singleDashboardProductDefinition.datasource,
+      allDatasets = singleDashboardProductDefinition.allDatasets,
+      productDefinitionId = singleDashboardProductDefinition.id,
+      productDefinitionName = singleDashboardProductDefinition.name,
+      reportOrDashboardId = singleDashboardProductDefinition.dashboard.id,
+      reportOrDashboardName = singleDashboardProductDefinition.dashboard.name,
     )
     assertEquals(statementExecutionResponse, actual)
   }
@@ -696,13 +749,21 @@ class AsyncDataApiServiceTest {
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     whenever(
       redshiftDataApiRepository.executeQueryAsync(
-        productDefinition = singleReportProductDefinition,
         filters = repositoryFilters,
         sortColumn = sortColumn,
         sortedAsc = sortedAsc,
         policyEngineResult = policyEngineResultTrue,
         prompts = prompts,
         userToken = authToken,
+        query = singleReportProductDefinition.reportDataset.query,
+        reportFilter = singleReportProductDefinition.report.filter,
+        datasource = singleReportProductDefinition.datasource,
+        reportSummaries = singleReportProductDefinition.report.summary,
+        allDatasets = singleReportProductDefinition.allDatasets,
+        productDefinitionId = singleReportProductDefinition.id,
+        productDefinitionName = singleReportProductDefinition.name,
+        reportOrDashboardId = singleReportProductDefinition.report.id,
+        reportOrDashboardName = singleReportProductDefinition.report.name,
       ),
     ).thenReturn(statementExecutionResponse)
 
@@ -716,13 +777,21 @@ class AsyncDataApiServiceTest {
     val actual = asyncDataApiService.validateAndExecuteStatementAsync("external-movements-with-parameters", reportVariantId, filters, sortColumn, sortedAsc, authToken)
 
     verify(redshiftDataApiRepository, times(1)).executeQueryAsync(
-      productDefinition = singleReportProductDefinition,
       filters = repositoryFilters,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
       policyEngineResult = policyEngineResultTrue,
       prompts = prompts,
       userToken = authToken,
+      query = singleReportProductDefinition.reportDataset.query,
+      reportFilter = singleReportProductDefinition.report.filter,
+      datasource = singleReportProductDefinition.datasource,
+      reportSummaries = singleReportProductDefinition.report.summary,
+      allDatasets = singleReportProductDefinition.allDatasets,
+      productDefinitionId = singleReportProductDefinition.id,
+      productDefinitionName = singleReportProductDefinition.name,
+      reportOrDashboardId = singleReportProductDefinition.report.id,
+      reportOrDashboardName = singleReportProductDefinition.report.name,
     )
     assertEquals(statementExecutionResponse, actual)
   }


### PR DESCRIPTION
These changes allow dashboards to run queries based on the datasource.
Dashboards now support also Athena queries, reportFilter (prefilter_) and non interactive filters.
Prompts are supported if passed in as non interactive filters but to make the FE aware of these changes also to the dashboard definition response will need to be made to convert the parameters to filterFields.
