### PR TITLE
IR-778 Add ability to get the list of caseloads a user has and use this for policy checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.6.1
+Support policy checks a list of available caseloads a user is allowed to access.
+
 # 7.6.0
 Dashboard definition response converts dataset parameters to filters.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -155,7 +155,7 @@ class AthenaApiRepository(
     """WITH $CONTEXT AS (
       SELECT 
       '${userToken?.jwt?.subject}' AS username, 
-      '${userToken?.getCaseLoads()?.first()}' AS caseload, 
+      '${userToken?.getActiveCaseLoad()}' AS caseload, 
       'GENERAL' AS account_type 
       FROM DUAL
       )"""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policy
 
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOADS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.ROLE
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.TOKEN
 
@@ -54,7 +55,8 @@ data class Condition(
     val varMappings = mapOf(
       TOKEN to authToken,
       ROLE to authToken?.authorities?.map { it.authority },
-      CASELOAD to authToken?.getCaseLoads()?.firstOrNull(),
+      CASELOAD to authToken?.getActiveCaseLoad(),
+      CASELOADS to authToken?.getCaseLoads(),
     )
     return varMappings[varPlaceholder] != null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/CaseloadProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/CaseloadProvider.kt
@@ -4,5 +4,7 @@ import org.springframework.security.oauth2.jwt.Jwt
 
 interface CaseloadProvider {
 
-  fun getActiveCaseloadIds(jwt: Jwt): List<String>
+  fun getActiveCaseloadId(jwt: Jwt): String
+
+  fun getCaseloadIds(jwt: Jwt): List<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
@@ -6,18 +6,14 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAv
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Caseload
 
 const val WARNING_NO_ACTIVE_CASELOAD = "User has not set an active caseload."
+const val WARNING_NO_CASELOADS = "User does not have any caseloads."
 
 class DefaultCaseloadProvider(private val webClient: WebClient) : CaseloadProvider {
 
-  override fun getActiveCaseloadIds(jwt: Jwt): List<String> {
-    val caseloadResponse = webClient
-      .get()
-      .header("Authorization", "Bearer ${jwt.tokenValue}")
-      .retrieve()
-      .bodyToMono(CaseloadResponse::class.java)
-      .block()
+  override fun getActiveCaseloadId(jwt: Jwt): String {
+    val caseloadResponse = getUsersCaseload(jwt)
 
-    if (caseloadResponse!!.accountType != "GENERAL") {
+    if (caseloadResponse.accountType != "GENERAL") {
       throw NoDataAvailableException("'${caseloadResponse.accountType}' account types are currently not supported.")
     }
 
@@ -25,7 +21,26 @@ class DefaultCaseloadProvider(private val webClient: WebClient) : CaseloadProvid
       throw NoDataAvailableException(WARNING_NO_ACTIVE_CASELOAD)
     }
 
-    return listOf(caseloadResponse.activeCaseload.id)
+    return caseloadResponse.activeCaseload.id
+  }
+
+  override fun getCaseloadIds(jwt: Jwt): List<String> {
+    val caseloadResponse = getUsersCaseload(jwt)
+
+    if (caseloadResponse.caseloads.isEmpty()) {
+      throw NoDataAvailableException(WARNING_NO_CASELOADS)
+    }
+
+    return caseloadResponse.caseloads.sortedBy { it.id }.map { it.id }
+  }
+
+  private fun getUsersCaseload(jwt: Jwt): CaseloadResponse {
+    return webClient
+      .get()
+      .header("Authorization", "Bearer ${jwt.tokenValue}")
+      .retrieve()
+      .bodyToMono(CaseloadResponse::class.java)
+      .block()!!
   }
 
   data class CaseloadResponse(val username: String, val active: Boolean, val accountType: String, val activeCaseload: Caseload?, val caseloads: List<Caseload>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DprAuthAwareAuthenticationToken.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DprAuthAwareAuthenticationToken.kt
@@ -12,15 +12,24 @@ class DprAuthAwareAuthenticationToken(
 ) : JwtAuthenticationToken(jwt, authorities) {
 
   private val lock = Any()
+  private var activeCaseload: String? = null
   private var caseloads: List<String>? = null
 
   override fun getPrincipal(): String {
     return aPrincipal
   }
 
+  fun getActiveCaseLoad(): String? = synchronized(lock) {
+    if (this.activeCaseload == null) {
+      this.activeCaseload = caseloadProvider.getActiveCaseloadId(this.jwt)
+    }
+
+    return this.activeCaseload
+  }
+
   fun getCaseLoads(): List<String> = synchronized(lock) {
     if (this.caseloads == null) {
-      this.caseloads = caseloadProvider.getActiveCaseloadIds(this.jwt)
+      this.caseloads = caseloadProvider.getCaseloadIds(this.jwt)
     }
 
     return this.caseloads!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policye
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.PolicyType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOADS
 
 class PolicyEngine(
   val policy: List<Policy>,
@@ -15,6 +16,7 @@ class PolicyEngine(
     const val ROLE = "\${role}"
     const val TOKEN = "\${token}"
     const val CASELOAD = "\${caseload}"
+    const val CASELOADS = "\${caseloads}"
   }
 
   fun execute(policyType: PolicyType): String {
@@ -35,15 +37,18 @@ class PolicyEngine(
     policies.map { it.execute(authToken, ::interpolateVariables) }.any { it == POLICY_DENY }
 
   private fun interpolateVariables(s: String): String {
-    var interpolated = s
-    if (s.contains(CASELOAD)) {
-      if (authToken == null || authToken.getCaseLoads().isEmpty()) {
-        return POLICY_DENY
+    if (authToken == null) return POLICY_DENY
+
+    return when {
+      s.contains(CASELOAD) -> {
+        val activeCaseLoad = authToken.getActiveCaseLoad()
+        if (activeCaseLoad.isNullOrEmpty()) POLICY_DENY else s.replace(CASELOAD, activeCaseLoad)
       }
-      // Note: This is currently for a single active caseload
-      // Addition of single quotes could be in DPD instead
-      interpolated = s.replace(CASELOAD, authToken.getCaseLoads().first())
+      s.contains(CASELOADS) -> {
+        val caseLoads = authToken.getCaseLoads()
+        if (caseLoads.isEmpty()) POLICY_DENY else s.replace(CASELOADS, caseLoads.joinToString(",", "'", "'"))
+      }
+      else -> s
     }
-    return interpolated
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -354,6 +354,7 @@ SELECT *
     val jwt = mock<Jwt>()
     whenever(userToken.jwt).thenReturn(jwt)
     whenever(jwt.subject).thenReturn(testUsername)
+    whenever(userToken.getActiveCaseLoad()).thenReturn(testCaseload)
     whenever(userToken.getCaseLoads()).thenReturn(listOf(testCaseload))
 
     return startQueryExecutionRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
@@ -88,7 +88,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
       """,
       )
 
-    assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(1)
+    assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(2)
   }
 
   class ReportDefinitionListTest : IntegrationTestBase() {
@@ -127,7 +127,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
       """,
         )
 
-      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(1)
+      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(2)
     }
 
     @Test
@@ -295,7 +295,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
       """,
         )
 
-      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(1)
+      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(2)
     }
 
     @Test
@@ -341,7 +341,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
       """,
         )
 
-      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(1)
+      assertThat(wireMockServer.findAll(RequestPatternBuilder().withUrl("/me/caseloads")).size).isEqualTo(2)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
@@ -29,9 +29,21 @@ class DefaultCaseloadProviderTest {
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
       DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
-    val actual = caseloadProvider.getActiveCaseloadIds(jwt)
+    val actual = caseloadProvider.getActiveCaseloadId(jwt)
 
-    assertEquals(listOf(expectedCaseloadResponse.activeCaseload!!.id), actual)
+    assertEquals(expectedCaseloadResponse.activeCaseload!!.id, actual)
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  fun `get available caseloads`() {
+    val jwt = createJwtHeaders()
+    val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
+      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)"), Caseload("LEI", "Leeds (HMP)")))
+    mockWebClientCall(expectedCaseloadResponse)
+    val actual = caseloadProvider.getCaseloadIds(jwt)
+
+    assertEquals(expectedCaseloadResponse.caseloads.sortedBy { it.id }.map { it.id }, actual)
   }
 
   @Test
@@ -40,7 +52,7 @@ class DefaultCaseloadProviderTest {
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
       DefaultCaseloadProvider.CaseloadResponse("user1", true, "GLOBAL_SEARCH", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
-    val exception = assertThrows<NoDataAvailableException> { caseloadProvider.getActiveCaseloadIds(jwt) }
+    val exception = assertThrows<NoDataAvailableException> { caseloadProvider.getActiveCaseloadId(jwt) }
 
     assertEquals(exception.reason, "'GLOBAL_SEARCH' account types are currently not supported.")
   }
@@ -51,7 +63,7 @@ class DefaultCaseloadProviderTest {
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
       DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", null, listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
-    val exception = assertThrows<NoDataAvailableException> { caseloadProvider.getActiveCaseloadIds(jwt) }
+    val exception = assertThrows<NoDataAvailableException> { caseloadProvider.getActiveCaseloadId(jwt) }
 
     assertEquals(exception.reason, "User has not set an active caseload.")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -104,6 +104,7 @@ class AsyncDataApiServiceTest {
 
   @BeforeEach
   fun setup() {
+    whenever(authToken.getActiveCaseLoad()).thenReturn("WWI")
     whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
   }
 
@@ -293,6 +294,7 @@ class AsyncDataApiServiceTest {
     val tableId = executionId.replace("-", "_")
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     val caseload = "caseloadA"
+    whenever(authToken.getActiveCaseLoad()).thenReturn(caseload)
     whenever(authToken.getCaseLoads()).thenReturn(listOf(caseload))
     whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("ROLE_PRISONS_REPORTING_USER")))
     val policyEngineResult = "(establishment_id='$caseload')"
@@ -383,6 +385,7 @@ class AsyncDataApiServiceTest {
     whenever(singleDashboardProductDefinition.allDatasets).thenReturn(listOf(dashboardDataset))
     whenever(singleDashboardProductDefinition.datasource).thenReturn(datasource)
     whenever(datasource.name).thenReturn("NOMIS")
+    whenever(authToken.getActiveCaseLoad()).thenReturn(caseload)
     whenever(authToken.getCaseLoads()).thenReturn(listOf(caseload))
     whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("ROLE_PRISONS_REPORTING_USER")))
     val policyEngineResult = Policy.PolicyResult.POLICY_DENY

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -26,6 +26,7 @@ class PolicyEngineTest {
       listOf("(origin_code='\${caseload}' AND lower(direction)='out') OR (destination_code='\${caseload}' AND lower(direction)='in')"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
+    whenever(authToken.getActiveCaseLoad()).thenReturn("ABC")
     whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC"))
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in')"
@@ -58,6 +59,7 @@ class PolicyEngineTest {
       listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
+    whenever(authToken.getActiveCaseLoad()).thenReturn(null)
     whenever(authToken.getCaseLoads()).thenReturn(emptyList())
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
@@ -71,6 +73,7 @@ class PolicyEngineTest {
       listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
       listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${caseload}"))))),
     )
+    whenever(authToken.getActiveCaseLoad()).thenReturn(null)
     whenever(authToken.getCaseLoads()).thenReturn(emptyList())
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
@@ -84,7 +87,7 @@ class PolicyEngineTest {
       listOf("TRUE"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
-    val policyEngine = PolicyEngine(listOf(policy))
+    val policyEngine = PolicyEngine(listOf(policy), authToken = authToken)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_PERMIT)
   }
 
@@ -199,9 +202,16 @@ class PolicyEngineTest {
       listOf("TRUE"),
       listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${token}"))))),
     )
+    val policy3 = Policy(
+      "caseload",
+      ROW_LEVEL,
+      listOf("origin_code in (\${caseloads})"),
+      listOf(Rule(Effect.PERMIT, emptyList())),
+    )
+    whenever(authToken.getActiveCaseLoad()).thenReturn("ABC")
     whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC"))
-    val policyEngine = PolicyEngine(listOf(policy1, policy2), authToken)
-    val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in') AND ${PolicyResult.POLICY_PERMIT}"
+    val policyEngine = PolicyEngine(listOf(policy1, policy2, policy3), authToken)
+    val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in') AND ${PolicyResult.POLICY_PERMIT} AND origin_code in ('ABC')"
     assertThat(policyEngine.execute()).isEqualTo(expected)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -93,6 +93,7 @@ class SyncDataApiServiceTest {
 
   @BeforeEach
   fun setup() {
+    whenever(authToken.getActiveCaseLoad()).thenReturn("WWI")
     whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
     whenever(
       productDefinitionTokenPolicyChecker.determineAuth(


### PR DESCRIPTION
This allows to filter by a list of caseloads a user has access to:

https://github.com/ministryofjustice/hmpps-digital-prison-reporting-data-product-definitions-schema/pull/33


```json
"policy": [
    {
      "id": "caseloads",
      "type": "row-level",
      "action": ["establishment_code in (${caseloads})"],
      "rule": [
        {
          "effect": "permit",
          "condition": [
            {
              "exists": ["${caseloads}"]
            }
          ]
        }
      ]
    }
  ],
```