### PR TITLE
IR-778 🐛 Update case load handling in PolicyEngine to correct string formatting and update test cases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -46,7 +46,7 @@ class PolicyEngine(
       }
       s.contains(CASELOADS) -> {
         val caseLoads = authToken.getCaseLoads()
-        if (caseLoads.isEmpty()) POLICY_DENY else s.replace(CASELOADS, caseLoads.joinToString(",", "'", "'"))
+        if (caseLoads.isEmpty()) POLICY_DENY else s.replace(CASELOADS, caseLoads.joinToString { "\'${it}\'" })
       }
       else -> s
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -203,15 +203,15 @@ class PolicyEngineTest {
       listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${token}"))))),
     )
     val policy3 = Policy(
-      "caseload",
+      "caseloads",
       ROW_LEVEL,
       listOf("origin_code in (\${caseloads})"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
     whenever(authToken.getActiveCaseLoad()).thenReturn("ABC")
-    whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC"))
+    whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC", "BBC", "HEI", "MDI"))
     val policyEngine = PolicyEngine(listOf(policy1, policy2, policy3), authToken)
-    val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in') AND ${PolicyResult.POLICY_PERMIT} AND origin_code in ('ABC')"
+    val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in') AND ${PolicyResult.POLICY_PERMIT} AND origin_code in ('ABC', 'BBC', 'HEI', 'MDI')"
     assertThat(policyEngine.execute()).isEqualTo(expected)
   }
 


### PR DESCRIPTION
This fixes a bug with the caseload list generation.

Was: 
```
MDI,BXI,LEI
```

Should be:
```
'MDI','BXI','LEI'
```

Updated test to check this.