### PR TITLE
IR-778 Update the caseload structure as the active caseload does not have an object but a string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
@@ -21,7 +21,7 @@ class DefaultCaseloadProvider(private val webClient: WebClient) : CaseloadProvid
       throw NoDataAvailableException(WARNING_NO_ACTIVE_CASELOAD)
     }
 
-    return caseloadResponse.activeCaseload.id
+    return caseloadResponse.activeCaseload
   }
 
   override fun getCaseloadIds(jwt: Jwt): List<String> {
@@ -43,5 +43,5 @@ class DefaultCaseloadProvider(private val webClient: WebClient) : CaseloadProvid
       .block()!!
   }
 
-  data class CaseloadResponse(val username: String, val active: Boolean, val accountType: String, val activeCaseload: Caseload?, val caseloads: List<Caseload>)
+  data class CaseloadResponse(val username: String, val active: Boolean, val accountType: String, val activeCaseload: String?, val caseloads: List<Caseload>)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
@@ -53,6 +53,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
             "username": "TESTUSER1",
             "active": true,
             "accountType": "GENERAL",
+            "activeCaseload": null,
             "caseloads": [
               {
                 "id": "WWI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -134,10 +134,7 @@ abstract class IntegrationTestBase {
             "username": "TESTUSER1",
             "active": true,
             "accountType": "GENERAL",
-            "activeCaseload": {
-              "id": "$activeCaseloadId",
-              "name": "WANDSWORTH (HMP)"
-            },
+            "activeCaseload": "$activeCaseloadId",
             "caseloads": [
               {
                 "id": "WWI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
@@ -27,11 +27,11 @@ class DefaultCaseloadProviderTest {
   fun `get active caseload ID`() {
     val jwt = createJwtHeaders()
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
-      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
+      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", "WWI", listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
     val actual = caseloadProvider.getActiveCaseloadId(jwt)
 
-    assertEquals(expectedCaseloadResponse.activeCaseload!!.id, actual)
+    assertEquals(expectedCaseloadResponse.activeCaseload!!, actual)
   }
 
   @Test
@@ -39,7 +39,7 @@ class DefaultCaseloadProviderTest {
   fun `get available caseloads`() {
     val jwt = createJwtHeaders()
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
-      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)"), Caseload("LEI", "Leeds (HMP)")))
+      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", "WWI", listOf(Caseload("WWI", "WANDSWORTH (HMP)"), Caseload("LEI", "Leeds (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
     val actual = caseloadProvider.getCaseloadIds(jwt)
 
@@ -50,7 +50,7 @@ class DefaultCaseloadProviderTest {
   fun `getActiveCaseloadId should throw NoDataAvailableException for any account type other than GENERAL`() {
     val jwt = createJwtHeaders()
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
-      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GLOBAL_SEARCH", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
+      DefaultCaseloadProvider.CaseloadResponse("user1", true, "GLOBAL_SEARCH", "WWI", listOf(Caseload("WWI", "WANDSWORTH (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
     val exception = assertThrows<NoDataAvailableException> { caseloadProvider.getActiveCaseloadId(jwt) }
 


### PR DESCRIPTION
The structure of the `/me/caseloads` and `/users/me/caseloads` does not have a `activeCaseload` as an object but a string.  Response is 
```json
{
  "username": "TESTUSER1",
  "active": true,
  "accountType": "GENERAL",
  "activeCaseload": "BXI",
  "caseloads": [
    {
      "id": "WWI",
      "name": "WANDSWORTH (HMP)"
    }
  ]
}
```

This can be seen [here](https://manage-users-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/user-controller/getMyCaseloads) and [here](https://nomis-user-roles-api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/me-resource/getMyCaseloads) 

Therefore the structure of the `CaseloadResponse` has been changed to 

```kotlin
 data class CaseloadResponse(val username: String, val active: Boolean, val accountType: String, val activeCaseload: String?, val caseloads: List<Caseload>)
```
