### PR TITLE
Dpr2 1792 caseloads filter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 Below you can find the changes included in each release.
 
 # 7.9.1
-Support for filters of type 'caseloads'.
+Support for filters of type 'caseloads' and 'multiselect'. 
+These are passed as one query parameter per filter with a comma separated list of values:
+`filters.someMultiselectFilter=a,b,c`
 
 # 7.9.0
 For scheduled datasets, use the generated dataset if it is available. Currently supports datamart datasources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Below you can find the changes included in each release.
 
-# 7.8.3
+# 7.9.1
+Support for filters of type 'caseloads'.
+
+# 7.9.0
 For scheduled datasets, use the generated dataset if it is available. Currently supports datamart datasources.
 
 # 7.8.2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
@@ -37,10 +37,13 @@ class DataApiSyncController(val dataApiSyncService: SyncDataApiService, val filt
     const val RANGE_FILTER_END_SUFFIX = ".end"
     const val FILTERS_QUERY_DESCRIPTION = """The filter query parameters have to start with the prefix "$FILTERS_PREFIX" followed by the name of the filter.
       For range filters, like date for instance, these need to be followed by a $RANGE_FILTER_START_SUFFIX or $RANGE_FILTER_END_SUFFIX suffix accordingly.
+      For multiselect filters, these are passed as one query parameter per filter with a comma separated list of values:
+      filters.someMultiselectFilter=a,b,c
     """
     const val FILTERS_QUERY_EXAMPLE = """{
         "filters.date$RANGE_FILTER_START_SUFFIX": "2023-04-25",
-        "filters.date$RANGE_FILTER_END_SUFFIX": "2023-05-30"
+        "filters.date$RANGE_FILTER_END_SUFFIX": "2023-05-30",
+        "filters.someMultiselectFilter": "a,b,c"
         }"""
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 enum class FilterType(@JsonValue val type: String) {
   Radio("Radio"),
   Select("Select"),
+  MultiSelect("multiselect"),
   DateRange("daterange"),
   AutoComplete("autocomplete"),
   Text("text"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/FilterType.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 enum class FilterType(@JsonValue val type: String) {
   Radio("Radio"),
   Select("Select"),
-  MultiSelect("multiselect"),
+  Multiselect("multiselect"),
   DateRange("daterange"),
   AutoComplete("autocomplete"),
   Text("text"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -156,7 +156,7 @@ class AthenaApiRepository(
     """WITH $CONTEXT AS (
       SELECT 
       '${userToken?.jwt?.subject}' AS username, 
-      '${userToken?.getActiveCaseLoad()}' AS caseload, 
+      '${userToken?.getActiveCaseLoadId()}' AS caseload, 
       'GENERAL' AS account_type 
       FROM DUAL
       )"""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -128,6 +128,8 @@ class RedshiftDataApiRepository(
       FilterType.DATE_RANGE_END -> "${filter.field} < (CAST('${filter.value}' AS timestamp) + INTERVAL '1' day)"
       FilterType.DYNAMIC -> "${filter.field} ILIKE '${filter.value}%'"
       FilterType.BOOLEAN -> "${filter.field} = ${filter.value.toBoolean()}"
+      FilterType.MULTISELECT -> filter.value.split(",")
+        .joinToString(separator = " OR ", prefix = "(", postfix = ")") { "${filter.field} = '$it'" }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RepositoryHelper.kt
@@ -29,6 +29,7 @@ abstract class RepositoryHelper {
     const val CONTEXT = """context_"""
 
     const val DEFAULT_REPORT_CTE = "report_ AS (SELECT * FROM dataset_)"
+    const val MULTISELECT_QUERY_PLACEHOLDER = "multiselectValue"
   }
 
   @Autowired
@@ -100,6 +101,7 @@ abstract class RepositoryHelper {
   protected open fun buildCondition(filter: ConfiguredApiRepository.Filter): String {
     val lowerCaseField = "lower(${filter.field})"
     val key = filter.getKey()
+    var index = 0
 
     return when (filter.type) {
       FilterType.STANDARD -> "$lowerCaseField = :$key"
@@ -109,6 +111,8 @@ abstract class RepositoryHelper {
       FilterType.DATE_RANGE_END -> "${filter.field} < (CAST(:$key AS timestamp) + INTERVAL '1' day)"
       FilterType.DYNAMIC -> "${filter.field} ILIKE '${filter.value}%'"
       FilterType.BOOLEAN -> "${filter.field} = :$key"
+      FilterType.MULTISELECT -> filter.value.split(",")
+        .joinToString(separator = " OR ", prefix = "(", postfix = ")") { "${filter.field} = :$MULTISELECT_QUERY_PLACEHOLDER${index++}" }
     }
   }
 
@@ -147,5 +151,6 @@ abstract class RepositoryHelper {
     DATE_RANGE_END(RANGE_FILTER_END_SUFFIX),
     DYNAMIC,
     BOOLEAN,
+    MULTISELECT,
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 enum class FilterType {
   Radio,
   Select,
+  Caseloads,
   DateRange,
   AutoComplete,
   Text,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/FilterType.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 enum class FilterType {
   Radio,
   Select,
+  Multiselect,
   Caseloads,
   DateRange,
   AutoComplete,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -55,8 +55,8 @@ data class Condition(
     val varMappings = mapOf(
       TOKEN to authToken,
       ROLE to authToken?.authorities?.map { it.authority },
-      CASELOAD to authToken?.getActiveCaseLoad(),
-      CASELOADS to authToken?.getCaseLoads(),
+      CASELOAD to authToken?.getActiveCaseLoadId(),
+      CASELOADS to authToken?.getCaseLoadIds(),
     )
     return varMappings[varPlaceholder] != null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/CaseloadProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/CaseloadProvider.kt
@@ -1,10 +1,11 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security
 
 import org.springframework.security.oauth2.jwt.Jwt
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Caseload
 
 interface CaseloadProvider {
 
   fun getActiveCaseloadId(jwt: Jwt): String
 
-  fun getCaseloadIds(jwt: Jwt): List<String>
+  fun getCaseloads(jwt: Jwt): List<Caseload>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProvider.kt
@@ -24,14 +24,14 @@ class DefaultCaseloadProvider(private val webClient: WebClient) : CaseloadProvid
     return caseloadResponse.activeCaseload.id
   }
 
-  override fun getCaseloadIds(jwt: Jwt): List<String> {
+  override fun getCaseloads(jwt: Jwt): List<Caseload> {
     val caseloadResponse = getUsersCaseload(jwt)
 
     if (caseloadResponse.caseloads.isEmpty()) {
       throw NoDataAvailableException(WARNING_NO_CASELOADS)
     }
 
-    return caseloadResponse.caseloads.sortedBy { it.id }.map { it.id }
+    return caseloadResponse.caseloads.sortedBy { it.id }.map { Caseload(it.id, it.name) }
   }
 
   private fun getUsersCaseload(jwt: Jwt): CaseloadResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DprAuthAwareAuthenticationToken.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DprAuthAwareAuthenticationToken.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Caseload
 
 class DprAuthAwareAuthenticationToken(
   val jwt: Jwt,
@@ -13,13 +14,13 @@ class DprAuthAwareAuthenticationToken(
 
   private val lock = Any()
   private var activeCaseload: String? = null
-  private var caseloads: List<String>? = null
+  private var caseloads: List<Caseload>? = null
 
   override fun getPrincipal(): String {
     return aPrincipal
   }
 
-  fun getActiveCaseLoad(): String? = synchronized(lock) {
+  fun getActiveCaseLoadId(): String? = synchronized(lock) {
     if (this.activeCaseload == null) {
       this.activeCaseload = caseloadProvider.getActiveCaseloadId(this.jwt)
     }
@@ -27,11 +28,17 @@ class DprAuthAwareAuthenticationToken(
     return this.activeCaseload
   }
 
-  fun getCaseLoads(): List<String> = synchronized(lock) {
+  fun getCaseLoadIds(): List<String> = synchronized(lock) {
     if (this.caseloads == null) {
-      this.caseloads = caseloadProvider.getCaseloadIds(this.jwt)
+      this.caseloads = caseloadProvider.getCaseloads(this.jwt)
     }
+    return this.caseloads!!.map { it.id }
+  }
 
+  fun getCaseLoads(): List<Caseload> = synchronized(lock) {
+    if (this.caseloads == null) {
+      this.caseloads = caseloadProvider.getCaseloads(this.jwt)
+    }
     return this.caseloads!!
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DefinitionMapper.kt
@@ -204,7 +204,7 @@ abstract class DefinitionMapper(
     .map { FilterOption(it.value.toString(), it.value.toString()) }
 
   private fun populateFilterType(filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition) =
-    if (filterDefinition.type == Caseloads) FilterType.MultiSelect else FilterType.valueOf(filterDefinition.type.toString())
+    if (filterDefinition.type == Caseloads) FilterType.Multiselect else FilterType.valueOf(filterDefinition.type.toString())
 
   private fun populateDefaultValue(
     filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DefinitionMapper.kt
@@ -11,8 +11,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.G
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.QuickFilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentToWing
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentToWing.Companion.ALL_WINGS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType.Caseloads
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReferenceType
@@ -55,16 +55,17 @@ abstract class DefinitionMapper(
   protected fun map(
     filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition,
     staticOptions: List<FilterOption>?,
+    userToken: DprAuthAwareAuthenticationToken? = null,
   ): FilterDefinition {
     return FilterDefinition(
-      type = FilterType.valueOf(filterDefinition.type.toString()),
+      type = populateFilterType(filterDefinition),
       staticOptions = staticOptions,
       dynamicOptions = filterDefinition.dynamicOptions?.let {
         DynamicFilterOption(
           minimumLength = filterDefinition.dynamicOptions.minimumLength,
         )
       },
-      defaultValue = replaceTokens(filterDefinition.default),
+      defaultValue = populateDefaultValue(filterDefinition, userToken),
       min = replaceTokens(filterDefinition.min),
       max = replaceTokens(filterDefinition.max),
       mandatory = filterDefinition.mandatory,
@@ -85,6 +86,9 @@ abstract class DefinitionMapper(
     dataProductDefinitionsPath: String?,
     allDatasets: List<Dataset>,
   ): List<FilterOption>? {
+    if (filterDefinition.type == Caseloads) {
+      return userToken?.getCaseLoads()?.map { FilterOption(it.id, it.name) }
+    }
     return filterDefinition.dynamicOptions?.takeIf { it.returnAsStaticOptions }?.let { dynamicFilterOption ->
       dynamicFilterOption.dataset?.let { dynamicFilterDatasetId ->
         return populateStaticOptionsForFilterWithDataset(
@@ -107,6 +111,29 @@ abstract class DefinitionMapper(
 
   protected fun maybeConvertToReportFields(parameters: List<Parameter>?) =
     parameters?.map { mapParameterToField(it) } ?: emptyList()
+
+  protected fun populateStaticOptionsForFilterWithDataset(
+    dynamicFilterOption: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DynamicFilterOption,
+    allDatasets: List<Dataset>,
+    dynamicFilterDatasetId: String,
+    maxStaticOptions: Long?,
+  ): List<FilterOption> {
+    val matchingFilterDataset = identifiedHelper.findOrFail(allDatasets, dynamicFilterDatasetId)
+    val matchingSchemaFieldsForFilterDataset = matchingFilterDataset.schema.field
+    val nameSchemaField = identifiedHelper.findOrFail(matchingSchemaFieldsForFilterDataset, dynamicFilterOption.name)
+    val displaySchemaField = identifiedHelper.findOrFail(matchingSchemaFieldsForFilterDataset, dynamicFilterOption.display)
+    return syncDataApiService.validateAndFetchDataForFilterWithDataset(
+      pageSize = maxStaticOptions ?: DEFAULT_MAX_STATIC_OPTIONS,
+      sortColumn = nameSchemaField.name,
+      dataset = matchingFilterDataset,
+    )
+      .map { FilterOption(it[nameSchemaField.name].toString(), it[displaySchemaField.name].toString()) }
+  }
+
+  protected fun map(definition: StaticFilterOption): FilterOption = FilterOption(
+    name = definition.name,
+    display = definition.display,
+  )
 
   private fun mapParameterToField(parameter: Parameter): FieldDefinition {
     return FieldDefinition(
@@ -176,23 +203,18 @@ abstract class DefinitionMapper(
     .flatMap { it.entries }
     .map { FilterOption(it.value.toString(), it.value.toString()) }
 
-  protected fun populateStaticOptionsForFilterWithDataset(
-    dynamicFilterOption: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DynamicFilterOption,
-    allDatasets: List<Dataset>,
-    dynamicFilterDatasetId: String,
-    maxStaticOptions: Long?,
-  ): List<FilterOption> {
-    val matchingFilterDataset = identifiedHelper.findOrFail(allDatasets, dynamicFilterDatasetId)
-    val matchingSchemaFieldsForFilterDataset = matchingFilterDataset.schema.field
-    val nameSchemaField = identifiedHelper.findOrFail(matchingSchemaFieldsForFilterDataset, dynamicFilterOption.name)
-    val displaySchemaField = identifiedHelper.findOrFail(matchingSchemaFieldsForFilterDataset, dynamicFilterOption.display)
-    return syncDataApiService.validateAndFetchDataForFilterWithDataset(
-      pageSize = maxStaticOptions ?: DEFAULT_MAX_STATIC_OPTIONS,
-      sortColumn = nameSchemaField.name,
-      dataset = matchingFilterDataset,
-    )
-      .map { FilterOption(it[nameSchemaField.name].toString(), it[displaySchemaField.name].toString()) }
-  }
+  private fun populateFilterType(filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition) =
+    if (filterDefinition.type == Caseloads) FilterType.MultiSelect else FilterType.valueOf(filterDefinition.type.toString())
+
+  private fun populateDefaultValue(
+    filterDefinition: uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition,
+    userToken: DprAuthAwareAuthenticationToken?,
+  ) =
+    if (filterDefinition.type == Caseloads) {
+      userToken?.getCaseLoadIds()?.joinToString(",")
+    } else {
+      replaceTokens(filterDefinition.default)
+    }
 
   private fun replaceTokens(defaultValue: String?): String? {
     if (defaultValue == null) {
@@ -212,9 +234,4 @@ abstract class DefinitionMapper(
 
     return result
   }
-
-  protected fun map(definition: StaticFilterOption): FilterOption = FilterOption(
-    name = definition.name,
-    display = definition.display,
-  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngine.kt
@@ -41,11 +41,11 @@ class PolicyEngine(
 
     return when {
       s.contains(CASELOAD) -> {
-        val activeCaseLoad = authToken.getActiveCaseLoad()
+        val activeCaseLoad = authToken.getActiveCaseLoadId()
         if (activeCaseLoad.isNullOrEmpty()) POLICY_DENY else s.replace(CASELOAD, activeCaseLoad)
       }
       s.contains(CASELOADS) -> {
-        val caseLoads = authToken.getCaseLoads()
+        val caseLoads = authToken.getCaseLoadIds()
         if (caseLoads.isEmpty()) POLICY_DENY else s.replace(CASELOADS, caseLoads.joinToString { "\'${it}\'" })
       }
       else -> s

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapper.kt
@@ -216,6 +216,7 @@ class ReportDefinitionMapper(
             dataProductDefinitionsPath = dataProductDefinitionsPath,
             allDatasets = allDatasets,
           ),
+          userToken = userToken,
         )
       },
       sortable = field.sortable,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepositoryTest.kt
@@ -354,8 +354,8 @@ SELECT *
     val jwt = mock<Jwt>()
     whenever(userToken.jwt).thenReturn(jwt)
     whenever(jwt.subject).thenReturn(testUsername)
-    whenever(userToken.getActiveCaseLoad()).thenReturn(testCaseload)
-    whenever(userToken.getCaseLoads()).thenReturn(listOf(testCaseload))
+    whenever(userToken.getActiveCaseLoadId()).thenReturn(testCaseload)
+    whenever(userToken.getCaseLoadIds()).thenReturn(listOf(testCaseload))
 
     return startQueryExecutionRequest
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/ConfiguredApiRepositoryTest.kt
@@ -41,6 +41,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_END
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DATE_RANGE_START
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.DYNAMIC
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.MULTISELECT
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.RepositoryHelper.FilterType.STANDARD
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Report
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
@@ -694,6 +696,41 @@ class ConfiguredApiRepositoryTest {
       reportFilter = productDefinition.report.filter,
     )
     Assertions.assertEquals(5, actual.size)
+  }
+
+  @Test
+  fun `should return only the rows which match the multiselect filter`() {
+    val actual = configuredApiRepository.executeQuery(
+      query = REPOSITORY_TEST_QUERY,
+      filters = listOf(Filter("destination_code", "HEI,NSI,LCI", MULTISELECT)),
+      selectedPage = 1,
+      pageSize = 20,
+      sortColumn = "date",
+      sortedAsc = true,
+      policyEngineResult = PolicyResult.POLICY_PERMIT,
+      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
+      reportFilter = productDefinition.report.filter,
+    )
+    Assertions.assertEquals(3, actual.size)
+  }
+
+  @Test
+  fun `should return only the rows which match all the filters when a multiselect filter is present`() {
+    val actual = configuredApiRepository.executeQuery(
+      query = REPOSITORY_TEST_QUERY,
+      filters = listOf(
+        Filter("destination_code", "WWI,NSI,LCI", MULTISELECT),
+        Filter("direction", "out", STANDARD),
+      ),
+      selectedPage = 1,
+      pageSize = 20,
+      sortColumn = "date",
+      sortedAsc = true,
+      policyEngineResult = PolicyResult.POLICY_PERMIT,
+      dataSourceName = REPOSITORY_TEST_DATASOURCE_NAME,
+      reportFilter = productDefinition.report.filter,
+    )
+    Assertions.assertEquals(1, actual.size)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
@@ -10,7 +10,7 @@ class DashboardDefinitionIntegrationTest : IntegrationTestBase() {
     @JvmStatic
     @DynamicPropertySource
     fun registerProperties(registry: DynamicPropertyRegistry) {
-      registry.add("dpr.lib.definition.locations") { "productDefinitionWithMetrics.json" }
+      registry.add("dpr.lib.definition.locations") { "productDefinitionWithDashboard.json" }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -142,6 +142,14 @@ abstract class IntegrationTestBase {
               {
                 "id": "WWI",
                 "name": "WANDSWORTH (HMP)"
+              },
+              {
+                "id": "AKI",
+                "name": "Acklington (HMP)"
+              },
+              {
+                "id": "LWSTMC",
+                "name": "Lowestoft (North East Suffolk) Magistrat"
               }
             ]
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/ReportDefinitionIntegrationTest.kt
@@ -101,7 +101,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       @JvmStatic
       @DynamicPropertySource
       fun registerProperties(registry: DynamicPropertyRegistry) {
-        registry.add("dpr.lib.definition.locations") { "productDefinitionWithMetrics.json" }
+        registry.add("dpr.lib.definition.locations") { "productDefinitionWithDashboard.json" }
       }
     }
 
@@ -203,7 +203,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     fun `Definition list is returned as expected when the definitions are retrieved from a service endpoint call`() {
       val response = Mockito.mock<QueryResponse>()
       val productDefinitionJson = this::class.java.classLoader.getResource("productDefinition.json")!!.readText()
-      val otherProductDefinitionJson = this::class.java.classLoader.getResource("productDefinitionWithMetrics.json")!!.readText()
+      val otherProductDefinitionJson = this::class.java.classLoader.getResource("productDefinitionWithDashboard.json")!!.readText()
       given(response.items()).willReturn(
         listOf(
           mapOf("definition" to AttributeValue.fromS(productDefinitionJson)),
@@ -363,7 +363,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
       assertThat(lastMonthVariant.name).isEqualTo("Last month")
       assertThat(lastMonthVariant.description).isEqualTo("All movements in the past month")
       assertThat(lastMonthVariant.specification).isNotNull
-      assertThat(lastMonthVariant.specification?.fields).hasSize(9)
+      assertThat(lastMonthVariant.specification?.fields).hasSize(10)
       assertThat(lastMonthVariant.printable).isEqualTo(true)
 
       val directionField = lastMonthVariant.specification?.fields?.find { it.name == "direction" }
@@ -631,6 +631,44 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                     "mandatory": false,
                     "visible": true,
                     "calculated": false
+                  },
+                   {
+                     "name":"origin_code",
+                     "display":"Origin Code",
+                     "wordWrap":null,
+                     "filter":{
+                        "type":"multiselect",
+                        "mandatory":false,
+                        "pattern":null,
+                        "staticOptions":[
+                          {
+                              "name":"AKI",
+                              "display":"Acklington (HMP)"
+                           },
+                           {
+                              "name":"LWSTMC",
+                              "display":"Lowestoft (North East Suffolk) Magistrat"
+                           },
+                           {
+                              "name":"WWI",
+                              "display":"WANDSWORTH (HMP)"
+                           }
+                        ],
+                        "dynamicOptions":null,
+                        "defaultValue":"AKI,LWSTMC,WWI",
+                        "min":null,
+                        "max":null,
+                        "interactive":false,
+                        "defaultGranularity":null,
+                        "defaultQuickFilterValue":null
+                     },
+                     "sortable":true,
+                     "defaultsort":false,
+                     "type":"string",
+                     "mandatory":false,
+                     "visible":true,
+                     "calculated":false,
+                     "header":false
                   }
                 ]
               },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultCaseloadProviderTest.kt
@@ -41,9 +41,9 @@ class DefaultCaseloadProviderTest {
     val expectedCaseloadResponse: DefaultCaseloadProvider.CaseloadResponse =
       DefaultCaseloadProvider.CaseloadResponse("user1", true, "GENERAL", Caseload("WWI", "WANDSWORTH (HMP)"), listOf(Caseload("WWI", "WANDSWORTH (HMP)"), Caseload("LEI", "Leeds (HMP)")))
     mockWebClientCall(expectedCaseloadResponse)
-    val actual = caseloadProvider.getCaseloadIds(jwt)
+    val actual = caseloadProvider.getCaseloads(jwt)
 
-    assertEquals(expectedCaseloadResponse.caseloads.sortedBy { it.id }.map { it.id }, actual)
+    assertEquals(expectedCaseloadResponse.caseloads.sortedBy { it.id }, actual)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -113,8 +113,8 @@ class AsyncDataApiServiceTest {
 
   @BeforeEach
   fun setup() {
-    whenever(authToken.getActiveCaseLoad()).thenReturn("WWI")
-    whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn("WWI")
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf("WWI"))
   }
 
   @Test
@@ -292,7 +292,7 @@ class AsyncDataApiServiceTest {
   @Test
   fun `should make the dashboard async call to the RedshiftDataApiRepository with all provided arguments when validateAndExecuteStatementAsync is called`() {
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-      listOf("productDefinitionWithMetrics.json"),
+      listOf("productDefinitionWithDashboard.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
       identifiedHelper = IdentifiedHelper(),
     )
@@ -303,8 +303,8 @@ class AsyncDataApiServiceTest {
     val tableId = executionId.replace("-", "_")
     val statementExecutionResponse = StatementExecutionResponse(tableId, executionId)
     val caseload = "caseloadA"
-    whenever(authToken.getActiveCaseLoad()).thenReturn(caseload)
-    whenever(authToken.getCaseLoads()).thenReturn(listOf(caseload))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn(caseload)
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf(caseload))
     whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("ROLE_PRISONS_REPORTING_USER")))
     val policyEngineResult = "(establishment_id='$caseload')"
     whenever(
@@ -394,8 +394,8 @@ class AsyncDataApiServiceTest {
     whenever(singleDashboardProductDefinition.allDatasets).thenReturn(listOf(dashboardDataset))
     whenever(singleDashboardProductDefinition.datasource).thenReturn(datasource)
     whenever(datasource.name).thenReturn("NOMIS")
-    whenever(authToken.getActiveCaseLoad()).thenReturn(caseload)
-    whenever(authToken.getCaseLoads()).thenReturn(listOf(caseload))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn(caseload)
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf(caseload))
     whenever(authToken.authorities).thenReturn(listOf(SimpleGrantedAuthority("ROLE_PRISONS_REPORTING_USER")))
     val policyEngineResult = Policy.PolicyResult.POLICY_DENY
     whenever(
@@ -1003,7 +1003,7 @@ class AsyncDataApiServiceTest {
   @Test
   fun `should call the repository with all provided arguments when getDashboardStatementResult is called`() {
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-      listOf("productDefinitionWithMetrics.json"),
+      listOf("productDefinitionWithDashboard.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
       identifiedHelper = IdentifiedHelper(),
     )
@@ -1055,7 +1055,7 @@ class AsyncDataApiServiceTest {
   @Test
   fun `getDashboardStatementResult throws an exception when the result columns are not in the dataset schema`() {
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-      listOf("productDefinitionWithMetrics.json"),
+      listOf("productDefinitionWithDashboard.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
       identifiedHelper = IdentifiedHelper(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesan
 class DashboardDefinitionMapperTest {
 
   private val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-    listOf("productDefinitionWithMetrics.json"),
+    listOf("productDefinitionWithDashboard.json"),
     DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
     identifiedHelper = IdentifiedHelper(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -26,8 +26,8 @@ class PolicyEngineTest {
       listOf("(origin_code='\${caseload}' AND lower(direction)='out') OR (destination_code='\${caseload}' AND lower(direction)='in')"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
-    whenever(authToken.getActiveCaseLoad()).thenReturn("ABC")
-    whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC"))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn("ABC")
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf("ABC"))
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in')"
     assertThat(policyEngine.execute()).isEqualTo(expected)
@@ -59,8 +59,8 @@ class PolicyEngineTest {
       listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
-    whenever(authToken.getActiveCaseLoad()).thenReturn(null)
-    whenever(authToken.getCaseLoads()).thenReturn(emptyList())
+    whenever(authToken.getActiveCaseLoadId()).thenReturn(null)
+    whenever(authToken.getCaseLoadIds()).thenReturn(emptyList())
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
   }
@@ -73,8 +73,8 @@ class PolicyEngineTest {
       listOf("(origin_code=\${caseload} AND direction='OUT') OR (destination_code=\${caseload} AND direction='IN')"),
       listOf(Rule(Effect.PERMIT, listOf(Condition(exists = listOf("\${caseload}"))))),
     )
-    whenever(authToken.getActiveCaseLoad()).thenReturn(null)
-    whenever(authToken.getCaseLoads()).thenReturn(emptyList())
+    whenever(authToken.getActiveCaseLoadId()).thenReturn(null)
+    whenever(authToken.getCaseLoadIds()).thenReturn(emptyList())
     val policyEngine = PolicyEngine(listOf(policy), authToken)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
   }
@@ -208,8 +208,8 @@ class PolicyEngineTest {
       listOf("origin_code in (\${caseloads})"),
       listOf(Rule(Effect.PERMIT, emptyList())),
     )
-    whenever(authToken.getActiveCaseLoad()).thenReturn("ABC")
-    whenever(authToken.getCaseLoads()).thenReturn(listOf("ABC", "BBC", "HEI", "MDI"))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn("ABC")
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf("ABC", "BBC", "HEI", "MDI"))
     val policyEngine = PolicyEngine(listOf(policy1, policy2, policy3), authToken)
     val expected = "(origin_code='ABC' AND lower(direction)='out') OR (destination_code='ABC' AND lower(direction)='in') AND ${PolicyResult.POLICY_PERMIT} AND origin_code in ('ABC', 'BBC', 'HEI', 'MDI')"
     assertThat(policyEngine.execute()).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -14,6 +14,8 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterOption
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.MultiSelect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.Text
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.establishmentsAndWings.EstablishmentToWing
@@ -55,6 +57,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policye
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.DefinitionMapper.Companion.DEFAULT_MAX_STATIC_OPTIONS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Caseload
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -794,7 +797,7 @@ class ReportDefinitionMapperTest {
       sortable = false,
       calculated = false,
       filter = uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterDefinition(
-        type = uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.Text,
+        type = Text,
         mandatory = true,
       ),
       visible = false,
@@ -978,6 +981,51 @@ class ReportDefinitionMapperTest {
     verifyNoInteractions(configuredApiService)
   }
 
+  @Test
+  fun `Report fields with 'caseloads' filter type are mapped to 'multiselect' and have the static options populated `() {
+    whenever(authToken.getCaseLoads()).thenReturn(
+      listOf(
+        Caseload("KMI", "KIRKHAM"),
+        Caseload("WWI", "WANDSWORTH (HMP)"),
+      ),
+    )
+    whenever(authToken.getCaseLoadIds()).thenReturn(
+      listOf(
+        "KMI",
+        "WWI",
+      ),
+    )
+    val defaultValue = createProductDefinition(
+      "today(-2,DAYS)",
+      reportField = ReportField(
+        name = "\$ref:13",
+        display = "reportFieldDisplay",
+        filter = FilterDefinition(
+          type = FilterType.Caseloads,
+        ),
+      ),
+    )
+
+    val result = ReportDefinitionMapper(configuredApiService, identifiedHelper, establishmentCodesToWingsCacheService).mapReport(definition = defaultValue, userToken = authToken)
+
+    assertThat(result.variant.specification?.fields?.first()).isEqualTo(
+      FieldDefinition(
+        name = "13",
+        display = "reportFieldDisplay",
+        // type is the same as schema field type
+        type = FieldType.Date,
+        filter = uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterDefinition(
+          type = MultiSelect,
+          defaultValue = "KMI,WWI",
+          staticOptions = listOf(
+            FilterOption("KMI", "KIRKHAM"),
+            FilterOption("WWI", "WANDSWORTH (HMP)"),
+          ),
+        ),
+      ),
+    )
+  }
+
   private fun createReportFieldDefinition(
     parameter: Parameter,
     expectedStaticOptions: List<FilterOption>?,
@@ -1109,6 +1157,18 @@ class ReportDefinitionMapperTest {
     formula: String? = null,
     parameters: List<Parameter>? = null,
     interactive: Boolean? = null,
+    reportField: ReportField = ReportField(
+      name = "\$ref:13",
+      display = reportFieldDisplay,
+      filter = FilterDefinition(
+        type = FilterType.DateRange,
+        default = defaultFilterValue,
+        min = min,
+        max = max,
+      ),
+      formula = formula,
+      visible = visible,
+    ),
   ): SingleReportProductDefinition {
     return SingleReportProductDefinition(
       id = "1",
@@ -1149,18 +1209,7 @@ class ReportDefinitionMapperTest {
           template = Template.List,
           section = null,
           field = listOf(
-            ReportField(
-              name = "\$ref:13",
-              display = reportFieldDisplay,
-              filter = FilterDefinition(
-                type = FilterType.DateRange,
-                default = defaultFilterValue,
-                min = min,
-                max = max,
-              ),
-              formula = formula,
-              visible = visible,
-            ),
+            reportField,
           ),
         ),
         classification = "someClassification",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterOption
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.MultiSelect
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.Multiselect
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterType.Text
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.SingleVariantReportDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
@@ -1015,7 +1015,7 @@ class ReportDefinitionMapperTest {
         // type is the same as schema field type
         type = FieldType.Date,
         filter = uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterDefinition(
-          type = MultiSelect,
+          type = Multiselect,
           defaultValue = "KMI,WWI",
           staticOptions = listOf(
             FilterOption("KMI", "KIRKHAM"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -93,8 +93,8 @@ class SyncDataApiServiceTest {
 
   @BeforeEach
   fun setup() {
-    whenever(authToken.getActiveCaseLoad()).thenReturn("WWI")
-    whenever(authToken.getCaseLoads()).thenReturn(listOf("WWI"))
+    whenever(authToken.getActiveCaseLoadId()).thenReturn("WWI")
+    whenever(authToken.getCaseLoadIds()).thenReturn(listOf("WWI"))
     whenever(
       productDefinitionTokenPolicyChecker.determineAuth(
         withPolicy = any(),

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -252,6 +252,15 @@
             }
           ]
         }
+      },{
+        "name" : "$ref:origin_code",
+        "display": "Origin Code",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "caseloads",
+          "mandatory": "false"
+        }
       } ]
     },
     "destination" : [ ],

--- a/src/test/resources/productDefinitionWithDashboard.json
+++ b/src/test/resources/productDefinitionWithDashboard.json
@@ -11,8 +11,7 @@
     {
       "id": "datamart",
       "name": "datamart"
-    }
-  ],
+    }  ],
   "dataset": [
     {
       "id": "establishments",


### PR DESCRIPTION
These changes provide support for filters of type `caseloads` and `multiselect`. 
These are passed to the API request as one query parameter per filter with a comma separated list of values:
`filters.someMultiselectFilter=a,b,c`
Filters of type 'caseloads' in the DPD are converted to filters of type multiselect in the definition response having their static options list populated with the user caseloads.
In the DPD the reportField name has to reference an existing dataset schema field for a projected column which is returned from the main dataset query.
This is the standard functionality as for all filters in order to be included correctly to the filters CTE in the overall query.
So for a multiselect its values will be checked in an OR condition.
