### PR TITLE
DPR2-1841 new dashboard status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 7.10.8
+New dashboard status endpoint to support running dashboards for legacy nomis/bodmis reports. 
+
 # 7.10.6
 Fixed issue with more than one multiselect filters in which the same filter value was applied to different columns.   
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -211,6 +211,61 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
       ),
     )
 
+  @GetMapping("/reports/{reportId}/dashboards/{dashboardId}/statements/{statementId}/status")
+  @Operation(
+    description = "Returns the status of the dashboard statement execution based on the statement ID provided." +
+      "The following status values can be returned: \n" +
+      "ABORTED - The query run was stopped by the user.\n" +
+      "ALL - A status value that includes all query statuses. This value can be used to filter results.\n" +
+      "FAILED - The query run failed.\n" +
+      "FINISHED - The query has finished running.\n" +
+      "PICKED - The query has been chosen to be run.\n" +
+      "STARTED - The query run has started.\n" +
+      "SUBMITTED - The query was submitted, but not yet processed.\n" +
+      "Note: When the status is FAILED the error field of the response will be populated." +
+      "ResultRows is the number of rows returned from the SQL statement. A -1 indicates the value is null." +
+      "ResultSize is the size in bytes of the returned results. A -1 indicates the value is null.\n" +
+      "For Athena: \n" +
+      "Athena automatically retries your queries in cases of certain transient errors. " +
+      "As a result, you may see the query state transition from STARTED or FAILED to SUBMITTED.\n",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+  )
+  fun getDashboardExecutionStatus(
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("dashboardId") reportVariantId: String,
+    @PathVariable("statementId") statementId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam(
+      "dataProductDefinitionsPath",
+      defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    dataProductDefinitionsPath: String? = null,
+    @Parameter(
+      description = "External table ID.",
+      example = "reports._6b3c6dfb_f601_4795_8ee5_2ad65b7fb283",
+    )
+    @RequestParam(
+      "tableId",
+      required = false,
+    )
+    tableId: String? = null,
+    authentication: Authentication,
+  ): ResponseEntity<StatementExecutionStatus> = ResponseEntity
+    .status(HttpStatus.OK)
+    .body(
+      asyncDataApiService.getDashboardStatementStatus(
+        statementId = statementId,
+        productDefinitionId = reportId,
+        dashboardId = reportVariantId,
+        userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+        dataProductDefinitionsPath,
+        tableId,
+      ),
+    )
+
   @GetMapping("/statements/{statementId}/status")
   @Operation(
     description = "Returns the status of the statement execution based on the statement ID provided." +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -144,6 +144,18 @@ class AsyncDataApiService(
     return statementStatus
   }
 
+  fun getDashboardStatementStatus(statementId: String, productDefinitionId: String, dashboardId: String, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null, tableId: String? = null): StatementExecutionStatus {
+    val productDefinition = productDefinitionRepository.getSingleDashboardProductDefinition(productDefinitionId, dashboardId, dataProductDefinitionsPath)
+    checkAuth(productDefinition, userToken)
+    val statementStatus = getRepo(productDefinition.datasource.name).getStatementStatus(statementId)
+    tableId?.takeIf { statementStatus.status == QUERY_FINISHED }?.let {
+      if (redshiftDataApiRepository.isTableMissing(tableId)) {
+        throw MissingTableException(tableId)
+      }
+    }
+    return statementStatus
+  }
+
   fun getStatementStatus(statementId: String, tableId: String? = null): StatementExecutionStatus {
     val statementStatus = redshiftDataApiRepository.getStatementStatus(statementId)
     tableId?.takeIf { statementStatus.status == QUERY_FINISHED }?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -230,6 +230,56 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Calling the dashboard status endpoint calls the getStatementStatus of the AsyncDataApiService with the correct arguments`() {
+    val queryExecutionId = "queryExecutionId"
+    val reportId = "external-movements"
+    val dashboardId = "test-dashboard"
+    val status = "FINISHED"
+    val duration = 278109264L
+    val resultRows = 10L
+    val resultSize = 100L
+    val statementExecutionStatus = StatementExecutionStatus(
+      status,
+      duration,
+      resultRows,
+      resultSize,
+    )
+    given(
+      asyncDataApiService.getDashboardStatementStatus(
+        eq(queryExecutionId),
+        eq(reportId),
+        eq(dashboardId),
+        any<DprAuthAwareAuthenticationToken>(),
+        eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
+        anyOrNull(),
+      ),
+    )
+      .willReturn(statementExecutionStatus)
+
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/reports/$reportId/dashboards/$dashboardId/statements/$queryExecutionId/status")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody()
+      .json(
+        """{
+          "status": "$status",
+          "duration": $duration,
+          "resultRows": $resultRows,
+          "resultSize": $resultSize,
+          "error": null
+        }
+      """,
+      )
+  }
+
+  @Test
   fun `Calling the statement status endpoint calls the getStatementStatus of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val status = "FINISHED"


### PR DESCRIPTION
These changes add a new dashboard status endpoint to support running dashboards for legacy nomis/bodmis reports. 