### PR TITLE
DPR2-1843 new dashboard cancel statement endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Below you can find the changes included in each release.
 
 # 7.10.8
+New dashboard execution cancellation endpoint to support running dashboards for legacy nomis/bodmis reports.
+
+# 7.10.7
 New dashboard status endpoint to support running dashboards for legacy nomis/bodmis reports. 
 
 # 7.10.6

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -232,7 +232,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
   )
   fun getDashboardExecutionStatus(
     @PathVariable("reportId") reportId: String,
-    @PathVariable("dashboardId") reportVariantId: String,
+    @PathVariable("dashboardId") dashboardId: String,
     @PathVariable("statementId") statementId: String,
     @Parameter(
       description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
@@ -259,7 +259,7 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
       asyncDataApiService.getDashboardStatementStatus(
         statementId = statementId,
         productDefinitionId = reportId,
-        dashboardId = reportVariantId,
+        dashboardId = dashboardId,
         userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
         dataProductDefinitionsPath,
         tableId,
@@ -326,6 +326,37 @@ class DataApiAsyncController(val asyncDataApiService: AsyncDataApiService, val f
         statementId,
         reportId,
         reportVariantId,
+        userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
+        dataProductDefinitionsPath,
+      ),
+    )
+
+  @DeleteMapping("/reports/{reportId}/dashboards/{dashboardId}/statements/{statementId}")
+  @Operation(
+    description = "Cancels the execution of a running query.",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+  )
+  fun cancelDashboardQueryExecution(
+    @PathVariable("reportId") definitionId: String,
+    @PathVariable("dashboardId") dashboardId: String,
+    @PathVariable("statementId") statementId: String,
+    @Parameter(
+      description = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_DESCRIPTION,
+      example = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    @RequestParam(
+      "dataProductDefinitionsPath",
+      defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    dataProductDefinitionsPath: String? = null,
+    authentication: Authentication,
+  ): ResponseEntity<StatementCancellationResponse> = ResponseEntity
+    .status(HttpStatus.OK)
+    .body(
+      asyncDataApiService.cancelDashboardStatementExecution(
+        statementId,
+        definitionId,
+        dashboardId,
         userToken = if (authentication is DprAuthAwareAuthenticationToken) authentication else null,
         dataProductDefinitionsPath,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -268,6 +268,12 @@ class AsyncDataApiService(
     return getRepo(productDefinition.datasource.name).cancelStatementExecution(statementId)
   }
 
+  fun cancelDashboardStatementExecution(statementId: String, definitionId: String, dashboardId: String, userToken: DprAuthAwareAuthenticationToken?, dataProductDefinitionsPath: String? = null): StatementCancellationResponse {
+    val productDefinition = productDefinitionRepository.getSingleDashboardProductDefinition(definitionId, dashboardId, dataProductDefinitionsPath)
+    checkAuth(productDefinition, userToken)
+    return getRepo(productDefinition.datasource.name).cancelStatementExecution(statementId)
+  }
+
   fun cancelStatementExecution(statementId: String): StatementCancellationResponse = redshiftDataApiRepository.cancelStatementExecution(statementId)
 
   fun count(tableId: String): Count = Count(redshiftDataApiRepository.count(tableId))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -362,6 +362,44 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Calling the dashboard cancellation endpoint calls the cancelStatementExecution of the AsyncDataApiService with the correct arguments`() {
+    val queryExecutionId = "queryExecutionId"
+    val reportId = "external-movements"
+    val dashboardId = "test-dashboard"
+    val statementCancellationResponse = StatementCancellationResponse(
+      true,
+    )
+    given(
+      asyncDataApiService.cancelDashboardStatementExecution(
+        eq(queryExecutionId),
+        eq(reportId),
+        eq(dashboardId),
+        any<DprAuthAwareAuthenticationToken>(),
+        eq(ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE),
+      ),
+    )
+      .willReturn(statementCancellationResponse)
+
+    webTestClient.delete()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/reports/$reportId/dashboards/$dashboardId/statements/$queryExecutionId")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody()
+      .json(
+        """{
+          "cancellationSucceeded": true
+        }
+      """,
+      )
+  }
+
+  @Test
   fun `Calling the statement cancellation endpoint calls the cancelStatementExecution of the AsyncDataApiService with the correct arguments`() {
     val queryExecutionId = "queryExecutionId"
     val statementCancellationResponse = StatementCancellationResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -479,6 +479,42 @@ class AsyncDataApiServiceTest {
     assertEquals(statementExecutionStatus, actual)
   }
 
+  @Test
+  fun `should call the RedshiftDataApiRepository for datamart with the statement execution ID when getDashboardStatementStatus is called`() {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("productDefinitionWithDashboard.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+      identifiedHelper = IdentifiedHelper(),
+    )
+    val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
+    val statementId = "statementId"
+    val status = "FINISHED"
+    val duration = 278109264L
+    val resultRows = 10L
+    val resultSize = 100L
+    val statementExecutionStatus = StatementExecutionStatus(
+      status,
+      duration,
+      resultRows,
+      resultSize,
+    )
+    whenever(
+      redshiftDataApiRepository.getStatementStatus(statementId),
+    ).thenReturn(statementExecutionStatus)
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.getDashboardStatementStatus(statementId, "missing-ethnicity-metrics", "age-breakdown-dashboard-1", authToken)
+    verify(redshiftDataApiRepository, times(1)).getStatementStatus(statementId)
+    verifyNoInteractions(athenaApiRepository)
+    assertEquals(statementExecutionStatus, actual)
+  }
+
   @ParameterizedTest
   @ValueSource(strings = ["productDefinitionNomis.json", "productDefinitionBodmis.json"])
   fun `should call the AthenaApiRepository for nomis and bodmis with the statement execution ID when getStatementStatus is called`(definitionFile: String) {
@@ -511,6 +547,48 @@ class AsyncDataApiServiceTest {
     ).thenReturn(true)
 
     val actual = asyncDataApiService.getStatementStatus(statementId, "external-movements", "last-month", authToken)
+    verify(athenaApiRepository, times(1)).getStatementStatus(statementId)
+    verifyNoInteractions(redshiftDataApiRepository)
+    assertEquals(statementExecutionStatus, actual)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["NOMIS", "BODMIS"])
+  fun `should call the AthenaApiRepository for nomis and bodmis with the statement execution ID when getDashboardStatementStatus is called`(datasourceName: String) {
+    val productDefinitionRepository = mock<ProductDefinitionRepository>()
+    val singleReportProductDefinition = mock<SingleDashboardProductDefinition>()
+    val datasource = mock<Datasource>()
+    val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
+    val definitionId = "definitionId"
+    val dashboardId = "test-dashboard"
+    val statementId = "statementId"
+    val status = "FINISHED"
+    val duration = 278109264L
+    val resultRows = 10L
+    val resultSize = 100L
+    val statementExecutionStatus = StatementExecutionStatus(
+      status,
+      duration,
+      resultRows,
+      resultSize,
+    )
+    whenever(
+      productDefinitionRepository.getSingleDashboardProductDefinition(definitionId, dashboardId),
+    ).thenReturn(singleReportProductDefinition)
+    whenever(singleReportProductDefinition.datasource).thenReturn(datasource)
+    whenever(datasource.name).thenReturn(datasourceName)
+    whenever(
+      athenaApiRepository.getStatementStatus(statementId),
+    ).thenReturn(statementExecutionStatus)
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.getDashboardStatementStatus(statementId, definitionId, dashboardId, authToken)
     verify(athenaApiRepository, times(1)).getStatementStatus(statementId)
     verifyNoInteractions(redshiftDataApiRepository)
     assertEquals(statementExecutionStatus, actual)
@@ -662,6 +740,35 @@ class AsyncDataApiServiceTest {
     ).thenReturn(true)
 
     val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month", authToken)
+    verify(redshiftDataApiRepository, times(1)).cancelStatementExecution(statementId)
+    verifyNoInteractions(athenaApiRepository)
+    assertEquals(statementCancellationResponse, actual)
+  }
+
+  @Test
+  fun `should call the RedshiftDataApiRepository for datamart with the statement execution ID when cancelDashboardStatementExecution is called`() {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("productDefinitionWithDashboard.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+      identifiedHelper = IdentifiedHelper(),
+    )
+    val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
+    val statementId = "statementId"
+    val statementCancellationResponse = StatementCancellationResponse(
+      true,
+    )
+    whenever(
+      redshiftDataApiRepository.cancelStatementExecution(statementId),
+    ).thenReturn(statementCancellationResponse)
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.cancelDashboardStatementExecution(statementId, "missing-ethnicity-metrics", "age-breakdown-dashboard-1", authToken)
     verify(redshiftDataApiRepository, times(1)).cancelStatementExecution(statementId)
     verifyNoInteractions(athenaApiRepository)
     assertEquals(statementCancellationResponse, actual)
@@ -823,6 +930,39 @@ class AsyncDataApiServiceTest {
     ).thenReturn(true)
 
     val actual = asyncDataApiService.cancelStatementExecution(statementId, "external-movements", "last-month", authToken)
+    verify(athenaApiRepository, times(1)).cancelStatementExecution(statementId)
+    verifyNoInteractions(redshiftDataApiRepository)
+    assertEquals(statementCancellationResponse, actual)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["NOMIS", "BODMIS"])
+  fun `should call the AthenaApiRepository for nomis and bodmis with the statement execution ID when cancelDashboardStatementExecution is called`(datasourceName: String) {
+    val productDefinitionRepository = mock<ProductDefinitionRepository>()
+    val singleReportProductDefinition = mock<SingleDashboardProductDefinition>()
+    val datasource = mock<Datasource>()
+    val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
+    val definitionId = "definitionId"
+    val dashboardId = "test-dashboard"
+    val statementId = "statementId"
+    val statementCancellationResponse = StatementCancellationResponse(true)
+    whenever(
+      productDefinitionRepository.getSingleDashboardProductDefinition(definitionId, dashboardId),
+    ).thenReturn(singleReportProductDefinition)
+    whenever(singleReportProductDefinition.datasource).thenReturn(datasource)
+    whenever(datasource.name).thenReturn(datasourceName)
+    whenever(
+      athenaApiRepository.cancelStatementExecution(statementId),
+    ).thenReturn(statementCancellationResponse)
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        userToken = any(),
+      ),
+    ).thenReturn(true)
+
+    val actual = asyncDataApiService.cancelDashboardStatementExecution(statementId, definitionId, dashboardId, authToken)
     verify(athenaApiRepository, times(1)).cancelStatementExecution(statementId)
     verifyNoInteractions(redshiftDataApiRepository)
     assertEquals(statementCancellationResponse, actual)


### PR DESCRIPTION
Added new dashboard execution cancellation endpoint to support running dashboards for legacy nomis/bodmis reports.