### PR TITLE
Feature/dpr2 1873 run multiple athena queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 8.0.3
+Added support for multiphase queries for dashboards. This is an experimental feature at this point.
+
 # 8.0.2
 Renamed dashboard fields which were defining collections from plural to singular to comply with existing naming conventions in DPDs. 
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
@@ -38,6 +39,7 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     reportOrDashboardId: String,
     reportOrDashboardName: String,
     preGeneratedDatasetTableId: String? = null,
+    multiphaseQuery: List<DatasetQuery>? = null,
   ): StatementExecutionResponse
 
   abstract fun getStatementStatus(statementId: String): StatementExecutionStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MultiphaseQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.QueryExecution
@@ -40,7 +40,7 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     reportOrDashboardId: String,
     reportOrDashboardName: String,
     preGeneratedDatasetTableId: String? = null,
-    multiphaseQuery: List<DatasetQuery>? = null,
+    multiphaseQuery: List<MultiphaseQuery>? = null,
   ): StatementExecutionResponse
 
   abstract fun getStatementStatus(statementId: String): StatementExecutionStatus

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.QueryExecution
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
@@ -86,5 +87,62 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
     stopwatch.stop()
     log.debug("Query Execution time in ms: {}", stopwatch.time)
     return result.isNullOrEmpty()
+  }
+
+  fun getStatementStatusForMultiphaseQuery(rootExecutionId: String): StatementExecutionStatus {
+    val executions = getExecutions(rootExecutionId)
+    return executions.firstOrNull { it.currentState == QUERY_FAILED }?.let {
+      return StatementExecutionStatus(
+        status = QUERY_FAILED,
+        duration = 1,
+        resultRows = 0,
+        error = it.error,
+        stateChangeReason = it.error,
+      )
+    }
+      ?: executions.firstOrNull { it.currentState == QUERY_CANCELLED }?.let {
+        return StatementExecutionStatus(
+          status = QUERY_ABORTED,
+          duration = 1,
+          resultRows = 0,
+          resultSize = 0,
+        )
+      }
+      ?: return StatementExecutionStatus(
+        status = executions.maxByOrNull { it.index }!!.currentState!!,
+        duration = 1,
+        resultRows = 0,
+      )
+  }
+
+  private fun getExecutions(rootExecutionId: String): List<QueryExecution> {
+    val jdbcTemplate: NamedParameterJdbcTemplate = populateNamedParameterJdbcTemplate()
+    val stopwatch = StopWatch.createStarted()
+    val mapSqlParameterSource = MapSqlParameterSource()
+    log.debug("Retrieving query executions...")
+    mapSqlParameterSource.addValue("rootExecutionId", rootExecutionId)
+    val result = jdbcTemplate
+      .queryForList(
+        "SELECT * FROM admin.execution_manager WHERE root_execution_id = :rootExecutionId;",
+        mapSqlParameterSource,
+      )
+      .map {
+        transformTimestampToLocalDateTime(it)
+      }
+    stopwatch.stop()
+    log.debug("Query to get executions for root execution {} completed in {}ms", rootExecutionId, stopwatch.time)
+    return result.map {
+      QueryExecution(
+        rootExecutionId = it["root_execution_id"] as String,
+        currentExecutionId = it["current_execution_id"] as String?,
+        datasource = it["datasource"] as String,
+        catalog = it["catalog"] as String?,
+        database = it["database"] as String?,
+        index = it["index"] as Int,
+        query = it["query"] as String,
+        currentState = it["current_state"] as String?,
+        error = it["error"] as String?,
+      )
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaAndRedshiftCommonRepository.kt
@@ -91,6 +91,7 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
 
   fun getStatementStatusForMultiphaseQuery(rootExecutionId: String): StatementExecutionStatus {
     val executions = getExecutions(rootExecutionId)
+    log.debug("All mapped QueryExecutions: {}", executions)
     return executions.firstOrNull { it.currentState == QUERY_FAILED }?.let {
       return StatementExecutionStatus(
         status = QUERY_FAILED,
@@ -131,6 +132,7 @@ abstract class AthenaAndRedshiftCommonRepository : RepositoryHelper() {
       }
     stopwatch.stop()
     log.debug("Query to get executions for root execution {} completed in {}ms", rootExecutionId, stopwatch.time)
+    log.debug("All execution rows from the admin table: {}", result)
     return result.map {
       QueryExecution(
         rootExecutionId = it["root_execution_id"] as String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -116,12 +116,11 @@ class AthenaApiRepository(
             ) 
             AS (
             SELECT * FROM TABLE(system.query(query =>
-             '${
+             '${(
       listOf(buildContextQuery(userToken), buildPromptsQuery(prompts), buildDatasetQuery(multiphaseQuerySortedByIndex[0].query))
         .joinToString(",") +
         "\nSELECT * FROM $DATASET_"
-          .replace("'", "''")
-    }'
+      ).replace("'", "''")}'
              )) 
             );
     """.trimIndent()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -106,8 +106,6 @@ class AthenaApiRepository(
     datasource: Datasource,
     multiphaseQuery: List<DatasetQuery>,
   ): StatementExecutionResponse {
-    // 1. datasource needs to come from multiphase query
-    // 2. table ID returned needs to be the last one
     val multiphaseQuerySortedByIndex = multiphaseQuery.sortedBy { it.index }
     val firstTableId = tableIdGenerator.generateNewExternalTableId()
     val firstQuery = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -12,9 +12,9 @@ import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import software.amazon.awssdk.services.athena.model.StopQueryExecutionRequest
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType.Date
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MultiphaseQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
@@ -59,7 +59,7 @@ class AthenaApiRepository(
     reportOrDashboardId: String,
     reportOrDashboardName: String,
     preGeneratedDatasetTableId: String?,
-    multiphaseQuery: List<DatasetQuery>?,
+    multiphaseQuery: List<MultiphaseQuery>?,
   ): StatementExecutionResponse = multiphaseQuery?.takeIf { it.isNotEmpty() }?.let {
     executeMultiphaseQuery(
       productDefinitionId,
@@ -104,7 +104,7 @@ class AthenaApiRepository(
     sortColumn: String?,
     sortedAsc: Boolean,
     datasource: Datasource,
-    multiphaseQuery: List<DatasetQuery>,
+    multiphaseQuery: List<MultiphaseQuery>,
   ): StatementExecutionResponse {
     val multiphaseQuerySortedByIndex = multiphaseQuery.sortedBy { it.index }
     val firstTableId = tableIdGenerator.generateNewExternalTableId()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -203,7 +203,7 @@ class RedshiftDataApiRepository(
     return executeQueryAsync(productDefinition.datasource, tableId, generateSql)
   }
 
-  fun checkAndBuildDatasetQuery(query: String, generatedTableId: String?): String = generatedTableId?.let { tableId ->
+  private fun checkAndBuildDatasetQuery(query: String, generatedTableId: String?): String = generatedTableId?.let { tableId ->
     """WITH $DATASET_ AS (SELECT * FROM reports.$tableId)"""
   } ?: buildDatasetQuery(query)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -13,8 +13,8 @@ import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementReque
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MultiphaseQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleDashboardProductDefinition
@@ -56,7 +56,7 @@ class RedshiftDataApiRepository(
     reportOrDashboardId: String,
     reportOrDashboardName: String,
     preGeneratedDatasetTableId: String?,
-    multiphaseQuery: List<DatasetQuery>?,
+    multiphaseQuery: List<MultiphaseQuery>?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val generateSql = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/RedshiftDataApiRepository.kt
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementReque
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest
 import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Datasource
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportSummary
@@ -55,6 +56,7 @@ class RedshiftDataApiRepository(
     reportOrDashboardId: String,
     reportOrDashboardName: String,
     preGeneratedDatasetTableId: String?,
+    multiphaseQuery: List<DatasetQuery>?,
   ): StatementExecutionResponse {
     val tableId = tableIdGenerator.generateNewExternalTableId()
     val generateSql = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
@@ -8,7 +8,7 @@ data class Dataset(
   val schema: Schema,
   val parameters: List<Parameter>? = null,
   val schedule: String? = null,
-  val multiphaseQuery: List<DatasetQuery>? = null,
+  val multiphaseQuery: List<MultiphaseQuery>? = null,
 ) : Identified() {
   override fun getIdentifier() = this.id
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Dataset.kt
@@ -8,6 +8,7 @@ data class Dataset(
   val schema: Schema,
   val parameters: List<Parameter>? = null,
   val schedule: String? = null,
+  val multiphaseQuery: List<DatasetQuery>? = null,
 ) : Identified() {
   override fun getIdentifier() = this.id
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DatasetQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/DatasetQuery.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
+
+data class DatasetQuery(
+  val index: Int,
+  val datasource: Datasource,
+  val query: String,
+  val parameters: List<Parameter>? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/MultiphaseQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/MultiphaseQuery.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model
 
-data class DatasetQuery(
+data class MultiphaseQuery(
   val index: Int,
   val datasource: Datasource,
   val query: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/QueryExecution.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/QueryExecution.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata
+
+data class QueryExecution(
+  val rootExecutionId: String,
+  val currentExecutionId: String? = null,
+  val datasource: String,
+  val catalog: String? = null,
+  val database: String? = null,
+  val index: Int,
+  val query: String,
+  val currentState: String? = null,
+  val error: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/redshiftdata/StatementExecutionStatus.kt
@@ -22,7 +22,7 @@ data class StatementExecutionStatus(
     example = "0",
     description = "The size in bytes of the returned results. A -1 indicates the value is null.",
   )
-  val resultSize: Long?,
+  val resultSize: Long? = null,
   @Schema(description = "Contains a short description of the error that occurred.")
   val error: String? = null,
   @Schema(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -96,6 +96,7 @@ class AsyncDataApiService(
         reportOrDashboardId = productDefinition.report.id,
         reportOrDashboardName = productDefinition.report.name,
         preGeneratedDatasetTableId = preGeneratedTableId,
+        multiphaseQuery = productDefinition.reportDataset.multiphaseQuery,
       )
   }
 
@@ -129,6 +130,7 @@ class AsyncDataApiService(
         productDefinitionName = productDefinition.name,
         reportOrDashboardId = productDefinition.dashboard.id,
         reportOrDashboardName = productDefinition.dashboard.name,
+        multiphaseQuery = productDefinition.dashboardDataset.multiphaseQuery,
       )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
 import jakarta.validation.ValidationException
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.jdbc.UncategorizedSQLException
@@ -48,6 +49,7 @@ class AsyncDataApiService(
     const val INVALID_DYNAMIC_FILTER_MESSAGE = "Error. This filter is not a dynamic filter."
     const val MISSING_MANDATORY_FILTER_MESSAGE = "Mandatory filter value not provided:"
     const val FILTER_VALUE_DOES_NOT_MATCH_PATTERN_MESSAGE = "Filter value does not match pattern:"
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   private val datasourceNameToRepo: Map<String, AthenaAndRedshiftCommonRepository>
@@ -116,6 +118,9 @@ class AsyncDataApiService(
     checkAuth(productDefinition, userToken)
     val policyEngine = PolicyEngine(productDefinition.policy, userToken)
     val (promptsMap, filtersOnly) = partitionToPromptsAndFilters(filters, productDefinition.dashboardDataset.parameters)
+    log.debug("All filters from user are: {}", filters)
+    log.debug("Prompts are: {}", promptsMap)
+    log.debug("Filters only are: {}", filtersOnly)
     return getRepo(productDefinition.datasource.name)
       .executeQueryAsync(
         filters = validateAndMapFilters(productDefinition, toMap(filtersOnly), false),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
@@ -17,10 +17,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHel
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dashboard
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DashboardVisualisationColumn
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.DatasetQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Identified.Companion.REF_PREFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.MultiphaseQuery
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
@@ -71,7 +71,7 @@ class DashboardDefinitionMapper(
     )
   }
 
-  private fun collectAllParametersAndMapToDistinctReportFields(queries: List<DatasetQuery>): List<FieldDefinition> {
+  private fun collectAllParametersAndMapToDistinctReportFields(queries: List<MultiphaseQuery>): List<FieldDefinition> {
     val distinctParameters =
       queries.map { maybeConvertToReportFields(it.parameters) }.filterNot { it.isEmpty() }.flatten().distinct()
     log.debug("Distinct multiphase converted fields from parameters: $distinctParameters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.AggregateTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardDefinition
@@ -30,6 +31,11 @@ class DashboardDefinitionMapper(
   identifiedHelper: IdentifiedHelper,
   establishmentCodesToWingsCacheService: EstablishmentCodesToWingsCacheService,
 ) : DefinitionMapper(syncDataApiService, identifiedHelper, establishmentCodesToWingsCacheService) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
   fun toDashboardDefinition(dashboard: Dashboard, allDatasets: List<Dataset>, userToken: DprAuthAwareAuthenticationToken? = null): DashboardDefinition {
     val dataset = identifiedHelper.findOrFail(allDatasets, dashboard.dataset)
 
@@ -65,7 +71,12 @@ class DashboardDefinitionMapper(
     )
   }
 
-  private fun collectAllParametersAndMapToDistinctReportFields(queries: List<DatasetQuery>): List<FieldDefinition> = queries.map { maybeConvertToReportFields(it.parameters) }.filterNot { it.isEmpty() }.flatten().distinct()
+  private fun collectAllParametersAndMapToDistinctReportFields(queries: List<DatasetQuery>): List<FieldDefinition> {
+    val distinctParameters =
+      queries.map { maybeConvertToReportFields(it.parameters) }.filterNot { it.isEmpty() }.flatten().distinct()
+    log.debug("Distinct multiphase converted fields from parameters: $distinctParameters")
+    return distinctParameters
+  }
 
   private fun mapToDashboardVisualisationColumnDefinitions(dashboardVisualisationColumns: List<DashboardVisualisationColumn>) = dashboardVisualisationColumns.map {
     DashboardVisualisationColumnDefinition(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -556,8 +556,9 @@ class AsyncDataApiServiceTest {
   @ValueSource(strings = ["NOMIS", "BODMIS"])
   fun `should call the AthenaApiRepository for nomis and bodmis with the statement execution ID when getDashboardStatementStatus is called`(datasourceName: String) {
     val productDefinitionRepository = mock<ProductDefinitionRepository>()
-    val singleReportProductDefinition = mock<SingleDashboardProductDefinition>()
+    val singleDashboardProductDefinition = mock<SingleDashboardProductDefinition>()
     val datasource = mock<Datasource>()
+    val dashboardDataset = mock<Dataset>()
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker)
     val definitionId = "definitionId"
     val dashboardId = "test-dashboard"
@@ -574,8 +575,9 @@ class AsyncDataApiServiceTest {
     )
     whenever(
       productDefinitionRepository.getSingleDashboardProductDefinition(definitionId, dashboardId),
-    ).thenReturn(singleReportProductDefinition)
-    whenever(singleReportProductDefinition.datasource).thenReturn(datasource)
+    ).thenReturn(singleDashboardProductDefinition)
+    whenever(singleDashboardProductDefinition.datasource).thenReturn(datasource)
+    whenever(singleDashboardProductDefinition.dashboardDataset).thenReturn(dashboardDataset)
     whenever(datasource.name).thenReturn(datasourceName)
     whenever(
       athenaApiRepository.getStatementStatus(statementId),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -387,6 +387,7 @@ class AsyncDataApiServiceTest {
     whenever(dashboard.filter).thenReturn(mock<ReportFilter>())
     whenever(singleDashboardProductDefinition.dashboardDataset).thenReturn(dashboardDataset)
     whenever(dashboardDataset.query).thenReturn(query)
+    whenever(dashboardDataset.multiphaseQuery).thenReturn(null)
     whenever(dashboardDataset.schema).thenReturn(schema)
     whenever(schema.field).thenReturn(listOf(field))
     whenever(field.name).thenReturn("fieldName")
@@ -1364,9 +1365,8 @@ class AsyncDataApiServiceTest {
   private fun dataset(schedule: String? = null): Dataset = Dataset(
     id = "10",
     name = "11",
-    query = "12",
     datasource = "12A",
-    schedule = schedule,
+    query = "12",
     schema = Schema(
       field = listOf(
         SchemaField(
@@ -1377,6 +1377,7 @@ class AsyncDataApiServiceTest {
         ),
       ),
     ),
+    schedule = schedule,
   )
 
   private fun definition(scheduled: Boolean, dataset: Dataset): SingleReportProductDefinition {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionMapperTest.kt
@@ -70,8 +70,8 @@ class ReportDefinitionMapperTest {
   private val fullDataset = Dataset(
     id = "10",
     name = "11",
-    query = "12",
     datasource = "12A",
+    query = "12",
     schema = Schema(
       field = listOf(
         SchemaField(
@@ -677,8 +677,8 @@ class ReportDefinitionMapperTest {
         reportDataset = Dataset(
           id = "10",
           name = "11",
-          query = "12",
           datasource = "12A",
+          query = "12",
           schema = Schema(
             field = listOf(
               SchemaField(
@@ -931,8 +931,8 @@ class ReportDefinitionMapperTest {
     val sourceDataset = Dataset(
       id = "10",
       name = "11",
-      query = "12",
       datasource = "12A",
+      query = "12",
       schema = Schema(
         field = listOf(
           SchemaField(
@@ -1182,8 +1182,8 @@ class ReportDefinitionMapperTest {
     Dataset(
       id = "10",
       name = "11",
-      query = "12",
       datasource = "12A",
+      query = "12",
       schema = Schema(
         field = listOf(
           SchemaField(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionServiceTest.kt
@@ -53,8 +53,8 @@ class ReportDefinitionServiceTest {
   private val dataset = Dataset(
     id = "10",
     name = "11",
-    query = "12",
     datasource = "12A",
+    query = "12",
     schema = Schema(emptyList()),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportDefinitionSummaryMapperTest.kt
@@ -34,8 +34,8 @@ class ReportDefinitionSummaryMapperTest {
   private val fullDataset = Dataset(
     id = "10",
     name = "11",
-    query = "12",
     datasource = "12A",
+    query = "12",
     schema = Schema(
       field = listOf(
         SchemaField(
@@ -159,8 +159,8 @@ class ReportDefinitionSummaryMapperTest {
         Dataset(
           id = "10",
           name = "11",
-          query = "12",
           datasource = "12A",
+          query = "12",
           schema = Schema(
             field = emptyList(),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -223,8 +223,8 @@ class SyncDataApiServiceTest {
     val filterDataset = Dataset(
       id = "establishment-dataset",
       name = "establishment-dataset-name",
-      query = "select * from table",
       datasource = "redshift",
+      query = "select * from table",
       schema = Schema(
         listOf(
           SchemaField(estCodeSchemaFieldName, ParameterType.String, "Establishment Code", null),
@@ -1207,7 +1207,13 @@ class SyncDataApiServiceTest {
   @Test
   fun `should call the configuredApiRepository with no sort column if none is provided and there is no default`() {
     val dataSet =
-      Dataset("datasetId", "datasetname", "redshift", "select *", Schema(listOf(SchemaField("9", ParameterType.String, display = "", filter = null))))
+      Dataset(
+        "datasetId",
+        "datasetname",
+        "redshift",
+        "select *",
+        Schema(listOf(SchemaField("9", ParameterType.String, display = "", filter = null))),
+      )
     val report = Report(
       id = "6",
       name = "7",


### PR DESCRIPTION
Changes to support running multiphase queries on dashboards.
These are non breaking changes allowing for running multiphase queries without breaking the existing functionality of running single queries.