### PR TITLE
DPR2-1873 fixed issue with replacing tableId in intermediate queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Below you can find the changes included in each release.
 
-# 8.0.3 - 8.0.9-alpha.0
+# 8.0.3 - 8.0.10
 Added support for multiphase queries for dashboards. This is an experimental feature at this point.
 
 # 8.0.2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -160,11 +160,11 @@ class AthenaApiRepository(
                 format = 'PARQUET'
               ) 
               AS (
-              ${listOf(buildContextQuery(userToken, false), buildPromptsQuery(prompts, false), buildDatasetQuery(intermediateQuery.query))
-        .joinToString(",") +
-        "\nSELECT * FROM $DATASET_"
-          .replace("\${tableId}", previousTableId)
-      }
+              ${(
+        listOf(buildContextQuery(userToken, false), buildPromptsQuery(prompts, false), buildDatasetQuery(intermediateQuery.query))
+          .joinToString(",") +
+          "\nSELECT * FROM $DATASET_"
+        ) .replace("\${tableId}", previousTableId)}
               )
       """.trimIndent()
       log.debug("Intermediate query at index ${i + 1}: {}", intermediateQueryString)


### PR DESCRIPTION
Changes to fix the issue in which ${tableId} was not replaced in intermediate queries.