### PR TITLE
DPR2-2005 added row-section and row-section-child templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 8.3.4
+Added `row-section`and `row-section-child` as supported report template types.
+
 # 8.3.1-alpha.0, 8.3.2 and 8.3.3
 Added sequenceNumber to the multiphase query Redhisft table to address the race condition of an earlier state change overwriting a later one.
 Added last_update to allow for cleaning up the table.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Template.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/Template.kt
@@ -10,4 +10,6 @@ enum class Template(@JsonValue val template: String) {
   SectionedSummary("summary-section"),
   ParentChild("parent-child"),
   ParentChildSection("parent-child-section"),
+  RowSection("row-section"),
+  RowSectionChild("row-section-child"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Template.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/Template.kt
@@ -23,4 +23,10 @@ enum class Template {
 
   @SerializedName("parent-child-section")
   ParentChildSection,
+
+  @SerializedName("row-section")
+  RowSection,
+
+  @SerializedName("row-section-child")
+  RowSectionChild,
 }


### PR DESCRIPTION
Added row-section and row-section-child templates to support the [corresponding FE changes](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-frontend/pull/426).