### PR TITLE
Dpr2 1860 sortdirection dpd field name all lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 9.1.1
+- Changed the sort direction field name in the DPD to be all lowercase for consistency with existing DPD field naming conventions.
+
 # 9.1.0
 - Adds support for sortDirection in DPDs
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
@@ -13,7 +13,6 @@ data class ReportField(
   val defaultSort: Boolean = false,
   @SerializedName("sortdirection")
   val sortDirection: SortDirection? = null,
-  // Formula and visible are not used yet. This is pending ticket https://dsdmoj.atlassian.net/browse/DPR2-241
   val formula: String? = null,
   val visible: Visible? = null,
 ) : Identified() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/ReportField.kt
@@ -11,6 +11,7 @@ data class ReportField(
   val sortable: Boolean = true,
   @SerializedName("defaultsort")
   val defaultSort: Boolean = false,
+  @SerializedName("sortdirection")
   val sortDirection: SortDirection? = null,
   // Formula and visible are not used yet. This is pending ticket https://dsdmoj.atlassian.net/browse/DPR2-241
   val formula: String? = null,

--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -180,7 +180,7 @@
         },
         "sortable" : true,
         "defaultsort" : true,
-        "sortDirection" : "asc"
+        "sortdirection" : "asc"
       }, {
         "name" : "$ref:origin",
         "display" : "From",


### PR DESCRIPTION
Changed the sort direction field name in the DPD to be all lowercase for consistency with existing DPD field naming conventions.