### PR TITLE
DPR2-1976 update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 Below you can find the changes included in each release.
 
-# 9.1.1
+# 9.1.0
+- Includes changes from `8.5.0` and `8.4.3` as these two versions were mistakenly published with lower version numbers.
+
+# 8.4.3
 - Changed the sort direction field name in the DPD to be all lowercase for consistency with existing DPD field naming conventions.
 
-# 9.1.0
+# 8.5.0
 - Adds support for sortDirection in DPDs
 
 # 9.0.0


### PR DESCRIPTION
Due to the sonatype migration the Github version publication workflow was using a stale xml file to get the latest version and  determine the next version to publish.
This resulted in versions `8.5.0` and `8.4.3` being published after `9.0.0` with more recent changes than what was in 9.0.0.
This has been documented in the changelog and version 9.1.0 has been published to include all latest changes and restore the order in the published versions.