### PR TITLE
DPR2-1897 revert deleting redshift async journey

### DIFF
--- a/src/test/resources/productDefinition.json
+++ b/src/test/resources/productDefinition.json
@@ -9,8 +9,12 @@
   },
   "datasource" : [
     {
-      "id": "datamart",
-      "name": "datamart"
+      "id": "nomis",
+      "name": "NOMIS",
+      "database": "nomis_db",
+      "catalog": "nomis",
+      "connection": "federated",
+      "dialect": "oracle/11g"
     }],
   "dataset" : [ {
     "id" : "external-movements",

--- a/src/test/resources/productDefinitionDatamart.json
+++ b/src/test/resources/productDefinitionDatamart.json
@@ -1,5 +1,5 @@
 {
-  "id" : "external-movements-with-parameters",
+  "id" : "external-movements",
   "name" : "External Movements",
   "description" : "Reports about prisoner external movements",
   "metadata" : {
@@ -9,39 +9,13 @@
   },
   "datasource" : [
     {
-      "id": "nomis",
-      "name": "NOMIS",
-      "database": "nomis_db",
-      "catalog": "nomis",
-      "connection": "federated",
-      "dialect": "oracle/11g"
+      "id": "datamart",
+      "name": "datamart"
     }],
   "dataset" : [ {
     "id" : "external-movements",
     "name" : "All movements",
     "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movement_movement as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
-    "parameters": [
-      {
-        "index": 0,
-        "name": "establishment_code",
-        "filterType": "autocomplete",
-        "reportFieldType": "string",
-        "display": "Establishment",
-        "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
-        "mandatory": "true",
-        "referenceType": "establishment"
-      },
-      {
-        "index": 1,
-        "name": "wing",
-        "filterType": "autocomplete",
-        "reportFieldType": "string",
-        "display": "Wing",
-        "description": "@Prompt('Enter NOMS Number',,,mono,free,Not_Persistent,User:1)",
-        "mandatory": "true",
-        "referenceType": "wing"
-      }
-    ],
     "schema" : {
       "field" : [ {
         "name" : "prisonNumber",
@@ -108,6 +82,19 @@
             "display": "Prisoner Name"
           }]
       }
+    },
+    {
+      "id": "summary-dataset",
+      "name": "Summary Dataset",
+      "datasource": "datamart",
+      "query": "SELECT COUNT(*) AS TOTAL FROM ${tableId}",
+      "schema": {
+        "field": [{
+          "name": "total",
+          "type": "int",
+          "display": "Total"
+        }]
+      }
     }
   ],
   "policy": [
@@ -141,6 +128,9 @@
     "id" : "last-month",
     "name" : "Last month",
     "description" : "All movements in the past month",
+    "metadata" : {
+      "hints" : ["interactive"]
+    },
     "created" : "2023-09-20T14:41:00.000Z",
     "classification": "report classification",
     "version" : "1.2.3",
@@ -153,8 +143,7 @@
     "specification" : {
       "template" : "list-section",
       "section": [ "$ref:direction" ],
-      "field" : [
-        {
+      "field" : [ {
         "name" : "$ref:prisonNumber",
         "sortable" : true,
         "defaultsort" : false,
@@ -190,7 +179,8 @@
           "default" : "today(-1,months) - today()"
         },
         "sortable" : true,
-        "defaultsort" : true
+        "defaultsort" : true,
+        "sortdirection" : "asc"
       }, {
         "name" : "$ref:origin",
         "display" : "From",
@@ -213,6 +203,7 @@
         "wordWrap" : "break-words",
         "filter" : {
           "type" : "Radio",
+          "interactive": true,
           "staticoptions" : [ {
             "name" : "in",
             "display" : "In"
@@ -262,9 +253,23 @@
             }
           ]
         }
+      },{
+        "name" : "$ref:origin_code",
+        "display": "Origin Code",
+        "sortable" : true,
+        "defaultsort" : false,
+        "filter" : {
+          "type" : "caseloads",
+          "mandatory": "false"
+        }
       } ]
     },
-    "destination" : [ ]
+    "destination" : [ ],
+    "summary": [{
+      "id": "summaryId",
+      "template": "page-header",
+      "dataset": "$ref:summary-dataset"
+    }]
   }, {
     "id" : "last-week",
     "name" : "Last week",

--- a/src/test/resources/productDefinitionWithDashboardDatamart.json
+++ b/src/test/resources/productDefinitionWithDashboardDatamart.json
@@ -1,0 +1,139 @@
+{
+  "id": "missing-ethnicity-metrics",
+  "name": "Missing Ethnicity Metrics",
+  "description": "Reports about Missing Ethnicity Metrics",
+  "metadata": {
+    "author": "Adam",
+    "version": "1.2.3",
+    "owner": "Eve"
+  },
+  "datasource": [
+    {
+      "id": "datamart",
+      "name": "datamart"
+    }  ],
+  "dataset": [
+    {
+      "id": "establishments",
+      "name": "Establishments",
+      "datasource": "datamart",
+      "query": "SELECT 'AAA' AS establishment_id, 'Aardvark' AS establishment_name UNION SELECT 'BBB' AS establishment_id, 'Bumblebee' AS establishment_name",
+      "schema": {
+        "field": [
+          {
+            "name": "establishment_id",
+            "type": "string",
+            "display": "Establishment ID"
+          },
+          {
+            "name": "establishment_name",
+            "type": "string",
+            "display": "Establishment Name"
+          }
+        ]
+      }
+    },
+    {
+      "id": "missing-ethnicity-dataset",
+      "name": "Missing Ethnicity By Establishment Dataset",
+      "datasource": "datamart",
+      "query": "SELECT establishment_id, has_ethnicity, ethnicity_is_missing FROM datamart.metrics.data_quality",
+      "schema": {
+        "field": [
+          {
+            "name": "establishment_id",
+            "type": "string",
+            "display": "Establishment ID",
+            "filter": {
+              "type": "select",
+              "dynamicoptions": {
+                "returnAsStaticOptions": true,
+                "dataset": "establishments",
+                "name": "establishment_id",
+                "display": "establishment_name",
+                "maximumOptions": 123
+              },
+              "interactive": true
+            }
+          },
+          {
+            "name": "has_ethnicity",
+            "type": "long",
+            "display": "No. of Prisoners without ethnicity"
+          },
+          {
+            "name": "ethnicity_is_missing",
+            "type": "long",
+            "display": "No. of Prisoners with ethnicity"
+          }
+        ]
+      }
+    }
+  ],
+  "dashboard": [
+    {
+      "id": "age-breakdown-dashboard-1",
+      "name": "Age Breakdown Dashboard",
+      "description": "Age Breakdown Dashboard Description",
+      "dataset": "missing-ethnicity-dataset",
+      "section": [
+        {
+          "id": "totals-breakdown",
+          "display": "Totals breakdown",
+          "visualisation": [
+            {
+              "id": "total-prisoners",
+              "type": "list",
+              "display": "Total prisoners by wing",
+              "column": {
+                "key": [
+                  {
+                    "id": "establishment_id",
+                    "display": "Establishmnent ID"
+                  },
+                  {
+                    "id": "wing",
+                    "display": "Wing"
+                  }
+                ],
+                "measure": [
+                  {
+                    "id": "establishment_id",
+                    "display": "Establishmnent ID"
+                  },
+                  {
+                    "id": "wing",
+                    "display": "Wing"
+                  },
+                  {
+                    "id": "total_prisoners",
+                    "display": "Total prisoners"
+                  }
+                ],
+                "expectNull": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "policy": [
+    {
+      "id": "caseload",
+      "type": "row-level",
+      "action": ["(establishment_id='${caseload}')"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "match": ["${role}", "ROLE_PRISONS_REPORTING_USER"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report": []
+}


### PR DESCRIPTION
The Redshift async journey stopped being supported in version 9.0.0 as part of [this PR](https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/pull/648).
However, there are clients, e.g. refer to [this link](https://github.com/ministryofjustice/hmpps-dpr-data-product-definitions/blob/main/dpd/prod/definitions/prisons/dps/activities/activities-waitlist-agg.json#L13),  who are still using this and the alternative to migrate them over to Athena federated queries to Redshift has not been implemented yet.
Hence in the meantime we need to keep supporting it. 
These changes revert the removal of the async Redshift journey support.