### PR TITLE
DPR2-2765 added type field to measures in the dashboard definition response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+# 15.5.0
+- Add an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures. 
+This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.    
+
 # 15.4.1
 - Handle Redshift Data API error response when an execution statement is not found and return 400 instead of 500. 
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardVisualisationColumnDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/DashboardVisualisationColumnDefinition.kt
@@ -8,4 +8,5 @@ data class DashboardVisualisationColumnDefinition(
   val displayValue: Boolean? = null,
   val axis: String? = null,
   val optional: Boolean? = null,
+  val type: FieldType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.D
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardVisualisationDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.DashboardVisualisationTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FieldType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.UnitTypeDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ValueVisualisationColumnDefinition
@@ -24,8 +25,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Identified.Companion.REF_PREFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEngine.Companion.MAKE_URL_FORMULA_PREFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.alert.AlertCategoryCacheService
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
 
@@ -75,7 +78,7 @@ class DashboardDefinitionMapper(
               description = visualisation.description,
               columns = DashboardVisualisationColumnsDefinition(
                 keys = visualisation.column.key?.let { mapToDashboardVisualisationColumnDefinitions(visualisation.column.key) },
-                measures = mapToDashboardVisualisationColumnDefinitions(visualisation.column.measure),
+                measures = mapToDashboardVisualisationColumnDefinitions(visualisation.column.measure, dataset),
                 filters = visualisation.column.filter?.map { ValueVisualisationColumnDefinition(it.id.removePrefix(REF_PREFIX), it.equals) },
                 expectNulls = visualisation.column.expectNull,
               ),
@@ -116,7 +119,8 @@ class DashboardDefinitionMapper(
     .filter { it.filter != null }
     .map { toFilterField(it, allDatasets, authToken, dataset, filters) }
 
-  private fun mapToDashboardVisualisationColumnDefinitions(dashboardVisualisationColumns: List<DashboardVisualisationColumn>) = dashboardVisualisationColumns.map {
+  private fun mapToDashboardVisualisationColumnDefinitions(dashboardVisualisationColumns: List<DashboardVisualisationColumn>, dataset: Dataset? = null) = dashboardVisualisationColumns.map {
+    val schemaField = identifiedHelper.findOrNull(dataset?.schema?.field, it.id)
     DashboardVisualisationColumnDefinition(
       it.id.removePrefix(REF_PREFIX),
       it.display,
@@ -125,7 +129,15 @@ class DashboardDefinitionMapper(
       it.displayValue,
       it.axis,
       it.optional,
+      schemaField?.let { scField -> populateType(scField) }
     )
+  }
+
+  private fun populateType(schemaField: SchemaField): FieldType {
+    if (schemaField.formula?.startsWith(MAKE_URL_FORMULA_PREFIX) == true) {
+      return FieldType.HTML
+    }
+    return convertParameterTypeToFieldType(schemaField.type)
   }
 
   private fun toFilterField(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapper.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Dataset
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.Identified.Companion.REF_PREFIX
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ReportField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SchemaField
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEngine.Companion.MAKE_URL_FORMULA_PREFIX
@@ -129,7 +128,7 @@ class DashboardDefinitionMapper(
       it.displayValue,
       it.axis,
       it.optional,
-      schemaField?.let { scField -> populateType(scField) }
+      schemaField?.let { scField -> populateType(scField) },
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DashboardDefinitionIntegrationTest.kt
@@ -54,7 +54,8 @@ class DashboardDefinitionIntegrationTest : IntegrationTestBase() {
                       "measures": [
                         {
                           "id": "establishment_id",
-                          "display": "Establishmnent ID"
+                          "display": "Establishmnent ID",
+                          "type": "HTML"
                         },
                         {
                           "id": "wing",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -1489,7 +1489,7 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     val expectedServiceResult = listOf(
       listOf(
         mapOf(
-          "establishment_id" to MetricData("1"),
+          "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/1' target=\"_blank\">1</a>"),
           "has_ethnicity" to MetricData("100"),
           "ethnicity_is_missing" to MetricData("30"),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/DashboardDefinitionMapperTest.kt
@@ -102,7 +102,7 @@ class DashboardDefinitionMapperTest {
                     DashboardVisualisationColumnDefinition(id = "wing", display = "Wing"),
                   ),
                   measures = listOf(
-                    DashboardVisualisationColumnDefinition(id = "establishment_id", display = "Establishmnent ID"),
+                    DashboardVisualisationColumnDefinition(id = "establishment_id", display = "Establishmnent ID", type = FieldType.HTML),
                     DashboardVisualisationColumnDefinition(id = "wing", display = "Wing"),
                     DashboardVisualisationColumnDefinition(id = "total_prisoners", display = "Total prisoners"),
                   ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -1428,7 +1428,7 @@ class SyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     )
     val expectedDashboardServiceResult = listOf(
       mapOf(
-        "establishment_id" to MetricData("OUT"),
+        "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/OUT' target=\"_blank\">OUT</a>"),
         "has_ethnicity" to MetricData("4000"),
         "ethnicity_is_missing" to MetricData("2"),
       ),

--- a/src/test/resources/productDefinitionWithDashboard.json
+++ b/src/test/resources/productDefinitionWithDashboard.json
@@ -58,7 +58,8 @@
                 "maximumOptions": 123
               },
               "interactive": true
-            }
+            },
+            "formula": "make_url('https://prisoner-${env}.digital.prison.service.justice.gov.uk/prison/${establishment_id}',${establishment_id},TRUE)"
           },
           {
             "name": "has_ethnicity",


### PR DESCRIPTION
Added an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures. 
This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.  
The reason for this is for the FE to be able to identify when the type of a measure is HTML and present it as a link. 
This makes it consistent with the reports.