### PR TITLE
DPR2-2765 added class and rel to html from make_url formula and removed unused getStatementStatus method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Below you can find the changes included in each release.
 
 # 15.5.0
 - Add an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures.
-  This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.    
+This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.    
 
 # 15.4.1
 - Handle Redshift Data API error response when an execution statement is not found and return 400 instead of 500. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 Below you can find the changes included in each release.
 
+# 15.5.1
+- Added `class="govuk-link"` to the produced HTML of the make_url formula and `rel="noreferrer noopener"` when the link opens in a new tab.
+- Removed unused getStatementStatus method from AsyncDataApiService.
+
 # 15.5.0
-- Add an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures. 
-This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.    
+- Add an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures.
+  This is computed in DashboardDefinitionMapper in a similar way as the ReportDefinitionMapper and not part of the DPD.    
 
 # 15.4.1
 - Handle Redshift Data API error response when an execution statement is not found and return 400 instead of 500. 
-
-# 15.4.1
-- Added `class="govuk-link"` to the produced HTML of the make_url formula and `rel="noreferrer noopener"` when the link opens in a new tab.
-- Removed unused getStatementStatus method from AsyncDataApiService.
 
 # 15.4.0
 - Update various spring-related and hmpps-spring related libs and gradle plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This is computed in DashboardDefinitionMapper in a similar way as the ReportDefi
 # 15.4.1
 - Handle Redshift Data API error response when an execution statement is not found and return 400 instead of 500. 
 
+# 15.4.1
+- Added `class="govuk-link"` to the produced HTML of the make_url formula and `rel="noreferrer noopener"` when the link opens in a new tab.
+- Removed unused getStatementStatus method from AsyncDataApiService.
+
 # 15.4.0
 - Update various spring-related and hmpps-spring related libs and gradle plugins
 - Updated aws libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Below you can find the changes included in each release.
 # 15.5.1
 - Added `class="govuk-link"` to the produced HTML of the make_url formula and `rel="noreferrer noopener"` when the link opens in a new tab.
 - Removed unused getStatementStatus method from AsyncDataApiService.
+- Handle Athena API error response from the status endpoint when an execution statement is not found and return 400 instead of 500.
 
 # 15.5.0
 - Add an optional `type` field to the DashboardVisualisationColumnDefinition and show this only for the measures.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/AthenaApiRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.athena.AthenaClient
 import software.amazon.awssdk.services.athena.model.AthenaError
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest
+import software.amazon.awssdk.services.athena.model.InvalidRequestException
 import software.amazon.awssdk.services.athena.model.QueryExecutionContext
 import software.amazon.awssdk.services.athena.model.QueryExecutionStatus
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SqlDial
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementCancellationResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionResponse
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshiftdata.StatementExecutionStatus
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.ExecutionStatementNotFound
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.TableIdGenerator
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Prompt
@@ -142,19 +144,23 @@ class AthenaApiRepository(
       .queryExecutionId(statementId)
       .build()
 
-    val getQueryExecutionResponse = athenaClient.getQueryExecution(getQueryExecutionRequest)
-    val status = getQueryExecutionResponse.queryExecution().status()
-    val stateChangeReason = status.stateChangeReason()
-    val error: AthenaError? = status.athenaError()
-    return StatementExecutionStatus(
-      status = mapAthenaStateToRedshiftState(status.state().toString()),
-      duration = calculateDuration(status),
-      resultRows = 0,
-      resultSize = 0,
-      error = error?.errorMessage(),
-      errorCategory = error?.errorCategory(),
-      stateChangeReason = stateChangeReason,
-    )
+    try {
+      val getQueryExecutionResponse = athenaClient.getQueryExecution(getQueryExecutionRequest)
+      val status = getQueryExecutionResponse.queryExecution().status()
+      val stateChangeReason = status.stateChangeReason()
+      val error: AthenaError? = status.athenaError()
+      return StatementExecutionStatus(
+        status = mapAthenaStateToRedshiftState(status.state().toString()),
+        duration = calculateDuration(status),
+        resultRows = 0,
+        resultSize = 0,
+        error = error?.errorMessage(),
+        errorCategory = error?.errorCategory(),
+        stateChangeReason = stateChangeReason,
+      )
+    } catch (e: InvalidRequestException) {
+      throw ExecutionStatementNotFound(statementId, e.message)
+    }
   }
 
   override fun cancelStatementExecution(statementId: String): StatementCancellationResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -180,16 +180,6 @@ class AsyncDataApiService(
     )
   }
 
-  fun getStatementStatus(statementId: String, tableId: String? = null): StatementExecutionStatus {
-    val statementStatus = redshiftDataApiRepository.getStatementStatus(statementId)
-    tableId?.takeIf { statementStatus.status == QUERY_FINISHED }?.let {
-      if (redshiftDataApiRepository.isTableMissing(tableId)) {
-        throw MissingTableException(tableId)
-      }
-    }
-    return statementStatus
-  }
-
   fun prepareAsyncDownloadContext(
     reportId: String,
     reportVariantId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngine.kt
@@ -114,7 +114,7 @@ class FormulaEngine(
       .split(",")
     val href = interpolateStandardFormula(hrefPlaceholder, row)
     val linkText = interpolateStandardFormula(linkTextPlaceholder, row)
-    return """<a href='$href' ${if (newTab.uppercase() == "TRUE") "target=\"_blank\"" else ""}>$linkText</a>"""
+    return """<a href='$href' class="govuk-link" ${if (newTab.uppercase() == "TRUE") "rel=\"noreferrer noopener\" target=\"_blank\"" else ""}>$linkText</a>"""
   }
 
   private fun interpolateDefaultValueFormula(formula: String, row: Map<String, Any?>): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
@@ -250,7 +250,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
           """[
         {"prisonNumber": "${movementPrisoner4[PRISON_NUMBER]}", "name": "${movementPrisoner4[NAME]}", "date": "01/05/2023", 
         "origin": "${movementPrisoner4[ORIGIN]}", "origin_code": "${movementPrisoner4[ORIGIN]}", 
-        "destination": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${movementPrisoner4[PRISON_NUMBER]}' target=\"_blank\">${movementPrisoner4[NAME]}</a>", 
+        "destination": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${movementPrisoner4[PRISON_NUMBER]}' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">${movementPrisoner4[NAME]}</a>", 
         "destination_code": "${movementPrisoner4[DESTINATION_CODE]}", 
         "direction": "${movementPrisoner4[DIRECTION]}", "type": "${movementPrisoner4[TYPE]}", "reason": "${movementPrisoner4[REASON]}"}
       ]       
@@ -294,7 +294,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
           """[
         {"prisonNumber": "${movementPrisoner4[PRISON_NUMBER]}", "name": "${movementPrisoner4[NAME]}", "date": "01/05/2023", 
         "origin": null, "origin_code": "", 
-        "destination": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${movementPrisoner4[PRISON_NUMBER]}' target=\"_blank\">${movementPrisoner4[NAME]}</a>", 
+        "destination": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${movementPrisoner4[PRISON_NUMBER]}' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">${movementPrisoner4[NAME]}</a>", 
         "destination_code": "${movementPrisoner4[DESTINATION_CODE]}", 
         "direction": "${movementPrisoner4[DIRECTION]}", "type": "${movementPrisoner4[TYPE]}", "reason": "${movementPrisoner4[REASON]}"}
       ]       
@@ -343,7 +343,7 @@ class DataApiIntegrationTest : IntegrationTestBase() {
               "raw": "LWSTMC"
             },
             "destination": {
-              "raw": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/G3411VR' target=\"_blank\">LastName5, F</a>"
+              "raw": "<a href='https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/G3411VR' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">LastName5, F</a>"
             },
             "destination_code": {
               "raw": "WWI"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -1083,6 +1083,11 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
 
   @Test
   fun `should call the RedshiftDataApiRepository with the statement execution ID when getStatementStatus is called`() {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("productDefinitionDatamart.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+      identifiedHelper = IdentifiedHelper(),
+    )
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker, s3ApiService)
     val statementId = "statementId"
     val status = "FINISHED"
@@ -1095,17 +1100,40 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
       resultRows,
       resultSize,
     )
+    val tableId = TableIdGenerator().generateNewExternalTableId()
+
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        authToken = any(),
+      ),
+    ).thenReturn(true)
+    whenever(
+      redshiftDataApiRepository.isTableMissing(tableId),
+    ).thenReturn(false)
     whenever(
       redshiftDataApiRepository.getStatementStatus(statementId),
     ).thenReturn(statementExecutionStatus)
 
-    val actual = asyncDataApiService.getStatementStatus(statementId)
+    val actual = asyncDataApiService.getStatementStatus(
+      statementId = statementId,
+      reportId = "external-movements",
+      reportVariantId = "last-month",
+      authToken = authToken,
+      tableId = tableId,
+    )
     verify(redshiftDataApiRepository, times(1)).getStatementStatus(statementId)
+    verify(redshiftDataApiRepository, times(1)).isTableMissing(eq(tableId), anyOrNull())
     assertEquals(statementExecutionStatus, actual)
   }
 
   @Test
   fun `should throw a MissingTableException when getStatementStatus is called with a tableId, the table is missing and the status is finished`() {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("productDefinitionDatamart.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+      identifiedHelper = IdentifiedHelper(),
+    )
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker, s3ApiService)
     val statementExecutionStatus = StatementExecutionStatus(
       "FINISHED",
@@ -1113,6 +1141,12 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
       10L,
       100L,
     )
+    whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        authToken = any(),
+      ),
+    ).thenReturn(true)
     whenever(
       redshiftDataApiRepository.getStatementStatus("statementId"),
     ).thenReturn(statementExecutionStatus)
@@ -1124,6 +1158,9 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     val exception = assertThrows<MissingTableException> {
       asyncDataApiService.getStatementStatus(
         statementId = "statementId",
+        reportId = "external-movements",
+        reportVariantId = "last-month",
+        authToken = authToken,
         tableId = tableId,
       )
     }
@@ -1134,6 +1171,11 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
 
   @Test
   fun `should not call isTableMissing when getStatementStatus is called for Redshift with a tableId and the status is not finished`() {
+    val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
+      listOf("productDefinitionDatamart.json"),
+      DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
+      identifiedHelper = IdentifiedHelper(),
+    )
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker, s3ApiService)
     val statementExecutionStatus = StatementExecutionStatus(
       QUERY_STARTED,
@@ -1143,11 +1185,23 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     )
     val statementId = "statementId"
     whenever(
+      productDefinitionTokenPolicyChecker.determineAuth(
+        withPolicy = any(),
+        authToken = any(),
+      ),
+    ).thenReturn(true)
+    whenever(
       redshiftDataApiRepository.getStatementStatus(statementId),
     ).thenReturn(statementExecutionStatus)
     val tableId = TableIdGenerator().generateNewExternalTableId()
 
-    val actual = asyncDataApiService.getStatementStatus(statementId = statementId, tableId = tableId)
+    val actual = asyncDataApiService.getStatementStatus(
+      statementId = statementId,
+      reportId = "external-movements",
+      reportVariantId = "last-month",
+      authToken = authToken,
+      tableId = tableId,
+    )
     assertEquals(statementExecutionStatus, actual)
     verify(redshiftDataApiRepository, times(1)).getStatementStatus(statementId)
     verify(redshiftDataApiRepository, times(0)).isTableMissing(any(), anyOrNull())
@@ -1156,7 +1210,7 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
   @Test
   fun `should return the status when the Redshift getStatementStatus method is called with a tableId and the table is not missing`() {
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
-      listOf("productDefinitionNomis.json"),
+      listOf("productDefinitionDatamart.json"),
       DefinitionGsonConfig().definitionGson(IsoLocalDateTimeTypeAdaptor()),
       identifiedHelper = IdentifiedHelper(),
     )
@@ -1190,6 +1244,9 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
 
     val actual = asyncDataApiService.getStatementStatus(
       statementId = statementId,
+      reportId = "external-movements",
+      reportVariantId = "last-month",
+      authToken = authToken,
       tableId = tableId,
     )
     verify(redshiftDataApiRepository, times(1)).getStatementStatus(statementId)
@@ -1439,7 +1496,7 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
       mapOf("PRISONNUMBER" to "1", "NAME" to "FirstName", "ORIGIN" to "OriginLocation", "destination" to "destinationLocation"),
     )
     val expectedServiceResult = listOf(
-      mapOf("prisonNumber" to "1", "name" to "FirstName", "origin" to "OriginLocation", "destination" to "<a href='https://prisoner.digital.prison.service.justice.gov.uk/prisoner/1' target=\"_blank\">FirstName</a>"),
+      mapOf("prisonNumber" to "1", "name" to "FirstName", "origin" to "OriginLocation", "destination" to "<a href='https://prisoner.digital.prison.service.justice.gov.uk/prisoner/1' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">FirstName</a>"),
     )
     val productDefinitionRepository: ProductDefinitionRepository = JsonFileProductDefinitionRepository(
       listOf("productDefinitionWithFormula.json"),
@@ -1489,7 +1546,7 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     val expectedServiceResult = listOf(
       listOf(
         mapOf(
-          "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/1' target=\"_blank\">1</a>"),
+          "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/1' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">1</a>"),
           "has_ethnicity" to MetricData("100"),
           "ethnicity_is_missing" to MetricData("30"),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/FormulaEngineTest.kt
@@ -278,7 +278,7 @@ class FormulaEngineTest {
     )
     val expectedRow: Map<String, Any> = mapOf(
       NAME to name,
-      PRISON_NUMBER to "<a href=\'https://prisoner-test.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' target=\"_blank\">$name</a>",
+      PRISON_NUMBER to "<a href=\'https://prisoner-test.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">$name</a>",
       DESTINATION to "Manchester",
       DESTINATION_CODE to "Manchester:MNCH:LastName6, F",
     )
@@ -308,7 +308,7 @@ class FormulaEngineTest {
     val expectedRow: Map<String, Any> = mapOf(
       NAME to name,
       PRISON_NUMBER to prisonNumber,
-      DESTINATION to "<a href=\'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' >$name</a>",
+      DESTINATION to "<a href=\'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' class=\"govuk-link\" >$name</a>",
       DESTINATION_CODE to "MNCH",
     )
     val formulaEngine = FormulaEngine(reportFields, "dev")
@@ -337,7 +337,7 @@ class FormulaEngineTest {
     val expectedRow: Map<String, Any> = mapOf(
       NAME to name,
       PRISON_NUMBER to prisonNumber,
-      DESTINATION to "<a href=\'https://prisoner.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' >$name</a>",
+      DESTINATION to "<a href=\'https://prisoner.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' class=\"govuk-link\" >$name</a>",
       DESTINATION_CODE to "MNCH",
     )
     val formulaEngine = FormulaEngine(reportFields)
@@ -373,7 +373,7 @@ class FormulaEngineTest {
     )
     val expectedRow: Map<String, Any> = mapOf(
       prisonCaseloadName to prisonCaseload,
-      nomisOffenderIdName to "<a href=\'https://${result}moic.service.justice.gov.uk/prisons/$prisonCaseload/prisoners/$nomisOffenderId/allocation/history' target=\"_blank\">$nomisOffenderId</a>",
+      nomisOffenderIdName to "<a href=\'https://${result}moic.service.justice.gov.uk/prisons/$prisonCaseload/prisoners/$nomisOffenderId/allocation/history' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">$nomisOffenderId</a>",
     )
     val formulaEngine = FormulaEngine(reportFields, environment)
     assertEquals(expectedRow, formulaEngine.applyFormulas(row))
@@ -400,7 +400,7 @@ class FormulaEngineTest {
     val expectedRow: Map<String, Any?> = mapOf(
       NAME to name,
       PRISON_NUMBER to null,
-      DESTINATION to "<a href=\'https://prisoner.digital.prison.service.justice.gov.uk/prisoner/\' >$name</a>",
+      DESTINATION to "<a href=\'https://prisoner.digital.prison.service.justice.gov.uk/prisoner/\' class=\"govuk-link\" >$name</a>",
       DESTINATION_CODE to "MNCH",
     )
     val formulaEngine = FormulaEngine(reportFields)
@@ -849,7 +849,7 @@ class FormulaEngineTest {
     val expectedRow: Map<String, Any> = mapOf(
       NAME to name,
       PRISON_NUMBER to prisonNumber,
-      DESTINATION to "<a href=\'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' target=\"_blank\">$name</a>",
+      DESTINATION to "<a href=\'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">$name</a>",
       DESTINATION_CODE to "MNCH",
     )
     val formulaEngine = FormulaEngine(reportFields, "dev")
@@ -877,7 +877,7 @@ class FormulaEngineTest {
     )
     val expectedRow: Map<String, Any> = mapOf(
       NAME to name,
-      PRISON_NUMBER to "<a href=\'https://prisoner-test.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' target=\"_blank\">$name</a>",
+      PRISON_NUMBER to "<a href=\'https://prisoner-test.digital.prison.service.justice.gov.uk/prisoner/${prisonNumber}\' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">$name</a>",
       DESTINATION to "Manchester",
       DESTINATION_CODE to "MNCH",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiServiceTest.kt
@@ -1428,7 +1428,7 @@ class SyncDataApiServiceTest : CommonDataApiServiceTestBase() {
     )
     val expectedDashboardServiceResult = listOf(
       mapOf(
-        "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/OUT' target=\"_blank\">OUT</a>"),
+        "establishment_id" to MetricData("<a href='https://prisoner.digital.prison.service.justice.gov.uk/prison/OUT' class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">OUT</a>"),
         "has_ethnicity" to MetricData("4000"),
         "ethnicity_is_missing" to MetricData("2"),
       ),


### PR DESCRIPTION
- Added `class="govuk-link"` to the produced HTML of the make_url formula and `rel="noreferrer noopener"` when the link opens in a new tab.
- Removed unused getStatementStatus method from AsyncDataApiService.
-   Handle Athena API error response from the status endpoint when an execution statement is not found and return 400 instead of 500.