### PR TITLE
DPR2-2799 fixed bug with new table existence endpoint when all tables are expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 16.1.2
+- Bugfix: When all the tables have expired returned expired: true for all of them  
+
 # 16.1.1
 - Added support for autocompletemulti filter type
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -408,7 +408,7 @@ class AsyncDataApiService(
   fun getResultTableExpiryState(tableIds: Set<String>): List<ResultTableExpiryState> {
     val existingTableIds = redshiftDataApiRepository.findExistingTables(tableIds).toHashSet()
     if (existingTableIds.isEmpty()) {
-      return tableIds.map { ResultTableExpiryState(it, false) }
+      return tableIds.map { ResultTableExpiryState(it, true) }
     }
     return tableIds.map { tableId -> ResultTableExpiryState(tableId = tableId, expired = tableId !in existingTableIds) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiServiceTest.kt
@@ -915,6 +915,24 @@ class AsyncDataApiServiceTest : CommonDataApiServiceTestBase() {
   }
 
   @Test
+  fun `getResultTableExpiryState should return as expired state the state of table IDs which do not exist in Redshift in the case when none exists`() {
+    val tableIdsRequested = setOf("1", "2", "3")
+    val tableIdsThatExist = emptyList<String>()
+    val expectedResult = listOf(
+      ResultTableExpiryState("1", true),
+      ResultTableExpiryState("2", true),
+      ResultTableExpiryState("3", true),
+    )
+    whenever(
+      redshiftDataApiRepository.findExistingTables(any(), anyOrNull()),
+    ).thenReturn(tableIdsThatExist)
+
+    val actual = asyncDataApiService.getResultTableExpiryState(tableIdsRequested)
+    assertEquals(expectedResult, actual)
+    verify(redshiftDataApiRepository, times(1)).findExistingTables(eq(tableIdsRequested), anyOrNull())
+  }
+
+  @Test
   fun `should call the AthenaApiRepository for datamart with the statement execution ID when report cancelStatementExecution is called`() {
     val asyncDataApiService = AsyncDataApiService(productDefinitionRepository, configuredApiRepository, redshiftDataApiRepository, athenaApiRepository, tableIdGenerator, identifiedHelper, productDefinitionTokenPolicyChecker, s3ApiService)
     val statementId = "statementId"


### PR DESCRIPTION
When all the tables have expired returned expired: true for all of them