### PR TITLE
DPR2-2799 Increased limit of the POST tableExpiryState endpoint to accept up to 200 tableIds from 50.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 16.1.3
+- Increased limit of the POST tableExpiryState endpoint to accept up to 200 tableIds from 50.
+
 # 16.1.2
 - Bugfix: When all the tables have expired returned expired: true for all of them  
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ResultTableExpiryStateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/model/ResultTableExpiryStateRequest.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model
 import jakarta.validation.constraints.Size
 
 data class ResultTableExpiryStateRequest(
-  @field:Size(max = 50)
+  @field:Size(max = 200)
   val tableIds: List<String>,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/RedshiftDataApiIntegrationTest.kt
@@ -782,7 +782,7 @@ class RedshiftDataApiIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Calling the reports tableExpiryState endpoint with more than 50 table IDs returns 400`() {
     val requestBody = ResultTableExpiryStateRequest(
-      tableIds = (1..51).map { it.toString() },
+      tableIds = (1..201).map { it.toString() },
     )
 
     webTestClient.post()


### PR DESCRIPTION
- Initially we wanted to test this with a conservative number of table Ids. Plus we thought more than 50 would be very rare in real cases.
- However, from initial tests we observed that frequently there can be more than 200 table ids in the request to the tableExpiryState endpoint.
- Currently the limit of the tableIds the endpoint accepts is 50. This is inefficient as the FE breaks them up to multiple requests until it covers all of them.
- Having tested on Redshift, it can handle 200 IDs in the IN clause with 100-200 ms added to the query time which is significantly better than making more 4 separate requests.