### PR TITLE
DPR2-2852 Added manage-users retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 16.3.1
+- Added retry logic with exponential backoff and jitter when calling manage users API.
+
 # 16.3.0
 - Check authSource of user against given env var `dpr.lib.user.requiredAuthSources` for allowed auth sources
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/ManageUsersClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/ManageUsersClient.kt
@@ -1,11 +1,20 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security
 
+import io.netty.channel.ConnectTimeoutException
+import io.netty.handler.timeout.ReadTimeoutException
+import io.netty.handler.timeout.TimeoutException
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import reactor.util.retry.Retry
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.authentication.AuthUser
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Caseload
 import uk.gov.justice.hmpps.kotlin.auth.AuthSource
+import java.io.IOException
+import java.time.Duration
 
 const val WARNING_NO_ACTIVE_CASELOAD = "User has not set an active caseload."
 const val WARNING_NO_CASELOADS = "User does not have any caseloads."
@@ -40,6 +49,7 @@ class ManageUsersClient(
     .header("Content-Type", "application/json")
     .retrieve()
     .bodyToMono(AuthUser::class.java)
+    .retryWhen(retryWithExponentialBackOffAndJitter)
     .block()!!
 
   fun getUsersRoles(username: String): List<String> = manageUsersWebClient.get()
@@ -47,6 +57,7 @@ class ManageUsersClient(
     .header("Content-Type", "application/json")
     .retrieve()
     .bodyToMono(ROLES)
+    .retryWhen(retryWithExponentialBackOffAndJitter)
     .block()!!.map { it.roleCode }
 
   fun fetchCaseloadInfo(username: String): CaseloadResponse = manageUsersWebClient.get()
@@ -63,6 +74,8 @@ class ManageUsersClient(
             activeCaseload = null,
           ),
         )
+      } else if (response.statusCode().is5xxServerError) {
+        response.createException().flatMap { Mono.error(it) }
       } else {
         response
           .bodyToMono(CaseloadResponse::class.java)
@@ -71,7 +84,28 @@ class ManageUsersClient(
           }
       }
     }
+    .retryWhen(retryWithExponentialBackOffAndJitter)
     .block()!!
+
+  private val retryWithExponentialBackOffAndJitter = Retry
+    .backoff(3, Duration.ofMillis(500))
+    .maxBackoff(Duration.ofSeconds(5))
+    .jitter(0.5)
+    .filter { throwable ->
+      when (throwable) {
+        is WebClientResponseException ->
+          throwable.statusCode.is5xxServerError
+
+        is WebClientRequestException,
+        is ConnectTimeoutException,
+        is ReadTimeoutException,
+        is TimeoutException,
+        is IOException,
+        -> true
+
+        else -> false
+      }
+    }
 }
 data class RolesResponse(val roleCode: String)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/IntegrationTestBase.kt
@@ -135,6 +135,7 @@ abstract class IntegrationTestBase {
   @BeforeEach
   fun setup() {
     wireMockServer.resetAll()
+    manageUsersMockServer.resetAll()
     stubDefinitionsResponse()
     hmppsAuthMockServer.stubGrantToken()
     manageUsersMockServer.stubLookupUsersRoles("request-user", listOf("INCIDENT_REPORTS__RO", "PRISONS_REPORTING_USER"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/wiremock/ManageUsersMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/wiremock/ManageUsersMockServer.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.integration.wirem
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
 import uk.gov.justice.hmpps.kotlin.auth.AuthSource
 
@@ -73,6 +76,72 @@ class ManageUsersMockServer : MockServer(MANAGE_USERS_WIREMOCK_PORT) {
     )
   }
 
+  fun stub500ResponseInitial(url: String) {
+    stubFor(
+      get("$urlPrefix/$url")
+        .inScenario("retry")
+        .whenScenarioStateIs(STARTED)
+        .willReturn(aResponse().withStatus(500))
+        .willSetStateTo("second"),
+    )
+  }
+
+  fun stub500ResponseSecondRequest(url: String) {
+    stubFor(
+      get("$urlPrefix/$url")
+        .inScenario("retry")
+        .whenScenarioStateIs("second")
+        .willReturn(aResponse().withStatus(500))
+        .willSetStateTo("success"),
+    )
+  }
+
+  fun stubSuccessInThirdRequest(url: String) {
+    stubFor(
+      get("$urlPrefix/$url")
+        .inScenario("retry")
+        .whenScenarioStateIs("success")
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(createPayload()),
+        ),
+    )
+  }
+
+  fun stubGetUserInfoSuccessAfterRetry(username: String = "request-user", authSource: AuthSource = AuthSource.NOMIS) {
+    stubFor(
+      get("$urlPrefix/users/$username")
+        .inScenario("retry")
+        .whenScenarioStateIs("success")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """{
+                "username":"$username",
+                "active":true,
+                "name":"$username",
+                "authSource":"${authSource.name}",
+                "staffId":488253,
+                "activeCaseLoadId":"KMI",
+                "userId":"488253",
+                "uuid":"bc04893a-1d41-4c66-9dc0-2f77c2b97c65"
+              }
+              """.trimMargin(),
+            ).withStatus(200),
+        ),
+    )
+  }
+
+  fun verifyTimesCalled(url: String, times: Int) {
+    verify(
+      times,
+      getRequestedFor(urlEqualTo(url)),
+    )
+  }
+
   fun stubLookupUsersRoles(username: String = "request-user", roles: List<String> = emptyList()) {
     stubFor(
       get("$urlPrefix/users/$username/roles")
@@ -111,4 +180,49 @@ class ManageUsersMockServer : MockServer(MANAGE_USERS_WIREMOCK_PORT) {
   data class RolesResponse(
     val roleCode: String,
   )
+
+  private fun createPayload(): String {
+    val username = "request-user"
+    val activeCaseloadId = "WWI"
+    val caseloads: String = """
+      [
+        {
+          "id": "WWI",
+          "name": "WANDSWORTH (HMP)"
+        },
+        {
+          "id": "AKI",
+          "name": "Acklington (HMP)"
+        },
+        {
+          "id": "LWSTMC",
+          "name": "Lowestoft (North East Suffolk) Magistrat"
+        }
+      ]
+    """.trimIndent()
+    val payloadArr = mutableListOf(
+      """
+          {
+            "username": "$username",
+            "authSource": "NOMIS",
+            "active": true,
+            "accountType": "GENERAL"
+      """.trimIndent(),
+    )
+
+    if (activeCaseloadId != null) {
+      payloadArr.add(
+        """
+        "activeCaseload": {
+          "id": "$activeCaseloadId",
+          "name": "WANDSWORTH (HMP)"
+        }
+        """.trimIndent(),
+      )
+    }
+
+    payloadArr.add("\"caseloads\":${(caseloads).trimIndent()}")
+
+    return payloadArr.joinToString(",") + "}"
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultUserPermissionProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/security/DefaultUserPermissionProviderTest.kt
@@ -75,6 +75,34 @@ class DefaultUserPermissionProviderTest : IntegrationTestBase() {
     assertEquals(info.activeCaseload, null)
   }
 
+  @Test
+  fun `should retry calling manage-users to retrieve caseloads twice and succeed after temporary 500 errors`() {
+    val username = "request-user"
+    val url = "prisonusers/$username/caseloads"
+    manageUsersMockServer.stub500ResponseInitial(url)
+    manageUsersMockServer.stub500ResponseSecondRequest(url)
+    manageUsersMockServer.stubSuccessInThirdRequest(url)
+    manageUsersMockServer.stubGetUserInfo(authSource = AuthSource.DELIUS)
+    val info = manageUsersClient.getCaseloads("request-user")
+
+    assertEquals(info.username, "request-user")
+    manageUsersMockServer.verifyTimesCalled("/prisonusers/request-user/caseloads", 3)
+  }
+
+  @Test
+  fun `should retry twice calling manage-users to get user info and succeed after temporary 500 errors`() {
+    val username = "request-user"
+    val url = "users/$username"
+    manageUsersMockServer.stubLookupUserCaseload("request-user", null)
+    manageUsersMockServer.stub500ResponseInitial(url)
+    manageUsersMockServer.stub500ResponseSecondRequest(url)
+    manageUsersMockServer.stubGetUserInfoSuccessAfterRetry(authSource = AuthSource.DELIUS)
+    val info = manageUsersClient.getCaseloads("request-user")
+
+    assertEquals(info.username, "request-user")
+    manageUsersMockServer.verifyTimesCalled("/users/request-user", 3)
+  }
+
   private fun mockWebClientCall(expectedCaseloadResponse: CaseloadResponse) {
     val requestHeadersUriSpec = mock<RequestHeadersUriSpec<*>>()
     whenever(webClient.get()).thenReturn(requestHeadersUriSpec)


### PR DESCRIPTION
Added retry logic with exponential backoff and jitter when calling manage users API to retry on network errors and 5xx responses.