### PR TITLE
MAPA-226 Add Excel (xlsx) download format for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Below you can find the changes included in each release.
 
+# 17.3.0
+- Added an Excel (xlsx) download format for reports, alongside the existing csv download:
+  - sync: `GET /reports/{reportId}/{reportVariantId}/download/xlsx`
+  - async: `GET /reports/{reportId}/{reportVariantId}/tables/{tableId}/download/xlsx`
+- Excel type-guesses every value in a csv when the file is opened, so values such as a room number `1.5.2` become dates and `007` loses its leading zeros. Quoting csv fields does not prevent this. In xlsx each cell carries its type explicitly, so text stays text. Columns declared in the schema as dates or numbers are still written as real dates and numbers, so sorting and filtering behave as expected.
+- Report row writing now sits behind a `ReportRowWriter` interface (`CsvRowWriter`, `XlsxRowWriter`). csv output is unchanged.
+- `SyncDataApiService.downloadCsv` and `AsyncDataApiService.downloadCsv` are deprecated in favour of `download(rowWriter, ...)`. The existing methods still work and still produce csv.
+
 # 17.2.0
 - Upgraded `uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter` dependency to 3.0.0-beta version to fix security issues.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,10 @@ dependencies {
   // Swagger
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
 
+  // Excel (xlsx) report downloads. Kept out of the public API surface, so `implementation`
+  // is enough - consumers get it transitively at runtime.
+  implementation("org.apache.poi:poi-ooxml:5.5.1")
+
   // Postgres dependencies
   implementation("org.flywaydb:flyway-core")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiAsyncController.kt
@@ -38,7 +38,9 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.redshif
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ManageUsersClient
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.AsyncDataApiService
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.CsvRowWriter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.CsvStreamingSupport
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.XlsxStreamingSupport
 import java.util.Collections.singletonList
 
 @Validated
@@ -49,6 +51,7 @@ class DataApiAsyncController(
   val asyncDataApiService: AsyncDataApiService,
   val filterHelper: FilterHelper,
   val csvStreamingSupport: CsvStreamingSupport,
+  val xlsxStreamingSupport: XlsxStreamingSupport,
   val manageUsersClient: ManageUsersClient,
   @Value("\${dpr.lib.hasProbationDatasources}")
   val hasProbationDatasources: Boolean,
@@ -618,8 +621,69 @@ class DataApiAsyncController(
       request,
       response,
     ) { writer ->
-      asyncDataApiService.downloadCsv(
-        writer = writer,
+      CsvRowWriter(writer).use { rowWriter ->
+        asyncDataApiService.download(
+          rowWriter = rowWriter,
+          tableId = tableId,
+          asyncDownloadContext = downloadContext,
+        )
+      }
+    }
+  }
+
+  @GetMapping(
+    "/reports/{reportId}/{reportVariantId}/tables/{tableId}/download/xlsx",
+    produces = [XlsxStreamingSupport.XLSX_CONTENT_TYPE],
+  )
+  @Operation(
+    description = "Streams the entire result set of the async query execution as an Excel (xlsx) file. " +
+      "Unlike the csv download, cell types are explicit, so values such as room numbers are not " +
+      "reinterpreted as dates when the file is opened in Excel.",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+  )
+  fun downloadXlsx(
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @RequestParam(
+      "dataProductDefinitionsPath",
+      defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    dataProductDefinitionsPath: String? = null,
+    @PathVariable("tableId") tableId: String,
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @Parameter(
+      description = "List of column names to include in the generated report. If not provided all the columns will be returned.",
+    )
+    @RequestParam(required = false)
+    columns: List<String>? = null,
+    @RequestParam sortColumn: String?,
+    @RequestParam sortedAsc: Boolean?,
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+  ) {
+    val downloadContext = asyncDataApiService.prepareAsyncDownloadContext(
+      reportId = reportId,
+      reportVariantId = reportVariantId,
+      dataProductDefinitionsPath = dataProductDefinitionsPath,
+      filters = filterHelper.filtersOnly(filters),
+      selectedColumns = columns,
+      sortedAsc = sortedAsc,
+      sortColumn = sortColumn,
+      executionContext = request.getUserContext(manageUsersClient, hasProbationDatasources),
+    )
+
+    xlsxStreamingSupport.streamXlsx(
+      reportId,
+      reportVariantId,
+      response,
+    ) { rowWriter ->
+      asyncDataApiService.download(
+        rowWriter = rowWriter,
         tableId = tableId,
         asyncDownloadContext = downloadContext,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/controller/DataApiSyncController.kt
@@ -26,8 +26,10 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.C
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.controller.model.ResponseHeader
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.NoDataAvailableException
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.ManageUsersClient
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.CsvRowWriter
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.CsvStreamingSupport
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.SyncDataApiService
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.XlsxStreamingSupport
 import java.util.Collections.singletonList
 
 @Validated
@@ -37,6 +39,7 @@ class DataApiSyncController(
   val dataApiSyncService: SyncDataApiService,
   val filterHelper: FilterHelper,
   val csvStreamingSupport: CsvStreamingSupport,
+  val xlsxStreamingSupport: XlsxStreamingSupport,
   val manageUsersClient: ManageUsersClient,
   @Value("\${dpr.lib.hasProbationDatasources}")
   val hasProbationDatasources: Boolean,
@@ -291,8 +294,67 @@ class DataApiSyncController(
       request,
       response,
     ) { writer ->
-      dataApiSyncService.downloadCsv(
-        writer = writer,
+      CsvRowWriter(writer).use { rowWriter ->
+        dataApiSyncService.download(
+          rowWriter = rowWriter,
+          downloadContext = downloadContext,
+        )
+      }
+    }
+  }
+
+  @GetMapping(
+    "/reports/{reportId}/{reportVariantId}/download/xlsx",
+    produces = [XlsxStreamingSupport.XLSX_CONTENT_TYPE],
+  )
+  @Operation(
+    description = "Streams the entire result set of the sync query execution as an Excel (xlsx) file. " +
+      "Unlike the csv download, cell types are explicit, so values such as room numbers are not " +
+      "reinterpreted as dates when the file is opened in Excel.",
+    security = [SecurityRequirement(name = "bearer-jwt")],
+  )
+  fun downloadXlsx(
+    @PathVariable("reportId") reportId: String,
+    @PathVariable("reportVariantId") reportVariantId: String,
+    @RequestParam(
+      "dataProductDefinitionsPath",
+      defaultValue = ReportDefinitionController.DATA_PRODUCT_DEFINITIONS_PATH_EXAMPLE,
+    )
+    dataProductDefinitionsPath: String? = null,
+    @Parameter(
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
+    )
+    @RequestParam
+    filters: Map<String, String>,
+    @Parameter(
+      description = "List of column names to include in the generated report. If not provided all the columns will be returned.",
+    )
+    @RequestParam(required = false)
+    columns: List<String>? = null,
+    @RequestParam sortColumn: String?,
+    @RequestParam sortedAsc: Boolean?,
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+  ) {
+    val downloadContext = dataApiSyncService.prepareSyncDownloadContext(
+      reportId = reportId,
+      reportVariantId = reportVariantId,
+      dataProductDefinitionsPath = dataProductDefinitionsPath,
+      filters = filterHelper.filtersOnly(filters),
+      selectedColumns = columns,
+      sortedAsc = sortedAsc,
+      sortColumn = sortColumn,
+      executionContext = request.getUserContext(manageUsersClient, hasProbationDatasources),
+    )
+
+    xlsxStreamingSupport.streamXlsx(
+      reportId,
+      reportVariantId,
+      response,
+    ) { rowWriter ->
+      dataApiSyncService.download(
+        rowWriter = rowWriter,
         downloadContext = downloadContext,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/AsyncDataApiService.kt
@@ -198,8 +198,8 @@ class AsyncDataApiService(
     ).first,
   )
 
-  fun downloadCsv(
-    writer: Writer,
+  fun download(
+    rowWriter: ReportRowWriter,
     tableId: String,
     asyncDownloadContext: AsyncDownloadContext,
   ) {
@@ -208,8 +208,20 @@ class AsyncDataApiService(
       filters = asyncDownloadContext.validatedFilters,
       sortedAsc = asyncDownloadContext.sortedAsc,
       sortColumn = asyncDownloadContext.sortColumn,
-      rowConsumer = populateRowConsumer(asyncDownloadContext, writer),
+      rowConsumer = populateRowConsumer(asyncDownloadContext, rowWriter),
     )
+  }
+
+  @Deprecated(
+    "Use download() with an explicit ReportRowWriter so the caller chooses the format.",
+    ReplaceWith("download(CsvRowWriter(writer), tableId, asyncDownloadContext)"),
+  )
+  fun downloadCsv(
+    writer: Writer,
+    tableId: String,
+    asyncDownloadContext: AsyncDownloadContext,
+  ) {
+    download(CsvRowWriter(writer), tableId, asyncDownloadContext)
     writer.flush()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CommonDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CommonDataApiService.kt
@@ -29,7 +29,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.FormulaEng
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.CoreDownloadContext
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.DownloadContext
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.model.Prompt
-import java.io.Writer
 import java.sql.ResultSet
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
@@ -319,33 +318,48 @@ abstract class CommonDataApiService(
 
   protected fun populateRowConsumer(
     downloadContext: DownloadContext,
-    writer: Writer,
+    rowWriter: ReportRowWriter,
   ): (ResultSet) -> Unit {
     var allColumnsFormattedAndValidated: List<String>? = null
-    lateinit var csvOutputColumns: List<String>
+    lateinit var outputColumns: List<String>
     return { rs ->
       if (allColumnsFormattedAndValidated == null) {
         allColumnsFormattedAndValidated = formatColumnNamesToSourceFieldNamesCasing(
           columnHeaders = extractColumnNames(rs),
           fieldNames = downloadContext.schemaFields.map(SchemaField::name),
         )
-        csvOutputColumns =
+        outputColumns =
           filterAndSortColumns(downloadContext.selectedAndValidatedColumns, allColumnsFormattedAndValidated)
-        writeCsvHeader(
-          writer = writer,
-          columns = formatColumnsToDisplayNames(
-            csvOutputColumns,
+        rowWriter.writeHeader(
+          buildReportColumns(
+            outputColumns,
             downloadContext.reportFields,
             downloadContext.schemaFields,
           ),
         )
       }
-      writeRowWithFormulaAsCsv(
+      writeRowWithFormula(
         rs = rs,
-        writer = writer,
+        rowWriter = rowWriter,
         formulaEngine = downloadContext.formulaEngine,
         allColumns = allColumnsFormattedAndValidated,
-        csvOutputColumns = csvOutputColumns,
+        outputColumns = outputColumns,
+      )
+    }
+  }
+
+  private fun buildReportColumns(
+    columnNames: List<String>,
+    reportFields: List<ReportField>?,
+    schemaFields: List<SchemaField>,
+  ): List<ReportColumn> {
+    val displayNames = formatColumnsToDisplayNames(columnNames, reportFields, schemaFields)
+    val typesByName = schemaFields.associate { it.name to it.type }
+    return columnNames.mapIndexed { index, name ->
+      ReportColumn(
+        name = name,
+        display = displayNames[index],
+        type = typesByName[name] ?: ParameterType.String,
       )
     }
   }
@@ -403,47 +417,20 @@ abstract class CommonDataApiService(
     }
   }
 
-  private fun writeCsvHeader(
-    writer: Writer,
-    columns: List<String>,
-  ) {
-    writer.write(
-      columns.joinToString(",") { escapeCsv(it) },
-    )
-    writer.write("\n")
-  }
-
   private fun extractColumnNames(rs: ResultSet): List<String> {
     val meta = rs.metaData
     return (1..meta.columnCount).map { meta.getColumnLabel(it) }
   }
 
-  private fun writeRowWithFormulaAsCsv(
+  private fun writeRowWithFormula(
     rs: ResultSet,
-    writer: Writer,
+    rowWriter: ReportRowWriter,
     formulaEngine: FormulaEngine,
     allColumns: List<String>,
-    csvOutputColumns: List<String>,
+    outputColumns: List<String>,
   ) {
     val fullRowWithFormulasApplied = formulaEngine.applyFormulas(buildRowWithAllColumns(allColumns, rs))
-    csvOutputColumns.forEachIndexed { index, col ->
-      if (index > 0) writer.write(",")
-      writer.write(escapeCsv(fullRowWithFormulasApplied[col]))
-    }
-    writer.write("\n")
-  }
-
-  private fun escapeCsv(value: Any?): String {
-    if (value == null) return ""
-
-    val str = value.toString()
-    val needsEscaping = str.contains(",") || str.contains("\"") || str.contains("\n")
-
-    return if (needsEscaping) {
-      "\"${str.replace("\"", "\"\"")}\""
-    } else {
-      str
-    }
+    rowWriter.writeRow(outputColumns.map { fullRowWithFormulasApplied[it] })
   }
 
   private fun buildRowWithAllColumns(columnNames: List<String>, rs: ResultSet): MutableMap<String, Any?> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CsvRowWriter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/CsvRowWriter.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import java.io.Writer
+
+/**
+ * Writes report rows as CSV.
+ *
+ * Values are quoted only when they contain a delimiter, a quote or a newline, which keeps
+ * the output identical to what this library has always produced. Note that quoting does
+ * not stop Excel type-guessing a value such as a room number `1.5.2` into a date when the
+ * file is opened by double-clicking it — quotes delimit fields, they do not declare types.
+ * Use [XlsxRowWriter] where that matters.
+ */
+class CsvRowWriter(private val writer: Writer) : ReportRowWriter {
+
+  override fun writeHeader(columns: List<ReportColumn>) {
+    writer.write(columns.joinToString(",") { escapeCsv(it.display) })
+    writer.write("\n")
+  }
+
+  override fun writeRow(values: List<Any?>) {
+    values.forEachIndexed { index, value ->
+      if (index > 0) writer.write(",")
+      writer.write(escapeCsv(value))
+    }
+    writer.write("\n")
+  }
+
+  override fun close() {
+    writer.flush()
+  }
+
+  private fun escapeCsv(value: Any?): String {
+    if (value == null) return ""
+
+    val str = value.toString()
+    val needsEscaping = str.contains(",") || str.contains("\"") || str.contains("\n")
+
+    return if (needsEscaping) {
+      "\"${str.replace("\"", "\"\"")}\""
+    } else {
+      str
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportRowWriter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/ReportRowWriter.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
+
+/**
+ * A sink for the rows of a report download.
+ *
+ * Decouples the row producing pipeline (column selection, ordering, display names and
+ * formulas, all in [CommonDataApiService.populateRowConsumer]) from the file format the
+ * rows end up in, so the same pipeline can emit CSV or XLSX.
+ */
+interface ReportRowWriter : AutoCloseable {
+
+  /**
+   * Called once, before any call to [writeRow], with the columns in output order.
+   */
+  fun writeHeader(columns: List<ReportColumn>)
+
+  /**
+   * Values are in the same order as the columns passed to [writeHeader].
+   */
+  fun writeRow(values: List<Any?>)
+}
+
+/**
+ * A column of a report download: its source field name, the heading shown to the user,
+ * and the type declared for it in the dataset schema.
+ */
+data class ReportColumn(
+  val name: String,
+  val display: String,
+  val type: ParameterType,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/SyncDataApiService.kt
@@ -208,8 +208,8 @@ class SyncDataApiService(
     )
   }
 
-  fun downloadCsv(
-    writer: Writer,
+  fun download(
+    rowWriter: ReportRowWriter,
     downloadContext: SyncDownloadContext,
   ) {
     configuredApiRepository.streamTableResult(
@@ -219,8 +219,19 @@ class SyncDataApiService(
       sortedAsc = downloadContext.sortedAsc,
       sortColumn = downloadContext.sortColumn,
       reportFilter = downloadContext.reportFilter,
-      rowConsumer = populateRowConsumer(downloadContext, writer),
+      rowConsumer = populateRowConsumer(downloadContext, rowWriter),
     )
+  }
+
+  @Deprecated(
+    "Use download() with an explicit ReportRowWriter so the caller chooses the format.",
+    ReplaceWith("download(CsvRowWriter(writer), downloadContext)"),
+  )
+  fun downloadCsv(
+    writer: Writer,
+    downloadContext: SyncDownloadContext,
+  ) {
+    download(CsvRowWriter(writer), downloadContext)
     writer.flush()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxRowWriter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxRowWriter.kt
@@ -1,0 +1,222 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.apache.poi.ss.SpreadsheetVersion
+import org.apache.poi.ss.usermodel.Cell
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.Sheet
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
+import java.io.OutputStream
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
+
+/**
+ * Writes report rows as an XLSX workbook.
+ *
+ * The reason this format exists: in a CSV every value is untyped text and Excel guesses a
+ * type for it on open, so a room number such as `1.5.2` is silently turned into a date and
+ * `007` into `7`. In XLSX each cell carries its type explicitly, so anything written as a
+ * string stays a string.
+ *
+ * Dates and numbers declared as such in the dataset schema are still written as real dates
+ * and numbers, so sorting and filtering behave as users expect. Everything else is written
+ * as text.
+ *
+ * Uses POI's streaming [SXSSFWorkbook] so memory stays bounded on large reports; rows
+ * beyond the access window are spilled to temp files, which [close] cleans up.
+ */
+class XlsxRowWriter(
+  private val out: OutputStream,
+  private val sheetName: String = "Report",
+) : ReportRowWriter {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    /** Rows POI keeps in memory before spilling to disk. */
+    private const val ROW_ACCESS_WINDOW_SIZE = 100
+
+    /** Excel refuses to open a workbook with a cell string longer than this. */
+    private const val MAX_CELL_TEXT_LENGTH = 32_767
+
+    /**
+     * Excel stores numbers as IEEE-754 doubles, so integers beyond this lose precision.
+     * Anything larger is written as text rather than silently corrupted.
+     */
+    private const val MAX_EXACT_INTEGER = 9_007_199_254_740_992L
+
+    private const val DATE_FORMAT = "dd/MM/yyyy"
+    private const val DATE_TIME_FORMAT = "dd/MM/yyyy HH:mm:ss"
+  }
+
+  private val workbook = SXSSFWorkbook(ROW_ACCESS_WINDOW_SIZE)
+
+  // Styles are created once per workbook: POI caps a workbook at 64k styles, so creating
+  // them per row would fail part way through a large report.
+  private val dateStyle: CellStyle = workbook.createCellStyle().apply {
+    dataFormat = workbook.creationHelper.createDataFormat().getFormat(DATE_FORMAT)
+  }
+  private val dateTimeStyle: CellStyle = workbook.createCellStyle().apply {
+    dataFormat = workbook.creationHelper.createDataFormat().getFormat(DATE_TIME_FORMAT)
+  }
+  private val headerStyle: CellStyle = workbook.createCellStyle().apply {
+    setFont(workbook.createFont().apply { bold = true })
+  }
+
+  private val maxRowsPerSheet = SpreadsheetVersion.EXCEL2007.maxRows
+
+  private lateinit var columns: List<ReportColumn>
+  private lateinit var sheet: Sheet
+  private var sheetCount = 0
+  private var rowIndexInSheet = 0
+
+  override fun writeHeader(columns: List<ReportColumn>) {
+    this.columns = columns
+    newSheet()
+  }
+
+  override fun writeRow(values: List<Any?>) {
+    // Excel caps a sheet at ~1,048,576 rows, so a larger report rolls onto another sheet
+    // with the header repeated rather than being silently truncated.
+    if (rowIndexInSheet >= maxRowsPerSheet) {
+      newSheet()
+    }
+
+    val row = sheet.createRow(rowIndexInSheet++)
+    values.forEachIndexed { index, value ->
+      writeCell(row.createCell(index), value, columns.getOrNull(index)?.type)
+    }
+  }
+
+  override fun close() {
+    try {
+      // A report with no rows never reaches writeHeader, and POI cannot write a workbook
+      // with no sheets, so give it an empty one.
+      if (sheetCount == 0) {
+        workbook.createSheet(sheetName)
+      }
+      workbook.write(out)
+      out.flush()
+    } finally {
+      // Since POI 5.3.0 close() also disposes of the temp files SXSSF spilled rows to,
+      // so there is no separate dispose() call to make. Without this every download leaks.
+      workbook.close()
+    }
+  }
+
+  private fun newSheet() {
+    sheetCount++
+    sheet = workbook.createSheet(if (sheetCount == 1) sheetName else "$sheetName ($sheetCount)")
+    rowIndexInSheet = 0
+
+    val header = sheet.createRow(rowIndexInSheet++)
+    columns.forEachIndexed { index, column ->
+      header.createCell(index).apply {
+        setCellValue(truncate(column.display))
+        cellStyle = headerStyle
+      }
+    }
+    sheet.createFreezePane(0, 1)
+  }
+
+  private fun writeCell(cell: Cell, value: Any?, type: ParameterType?) {
+    if (value == null) return
+
+    when (type) {
+      ParameterType.Date -> writeDateCell(cell, value, dateStyle)
+      ParameterType.DateTime, ParameterType.Timestamp -> writeDateCell(cell, value, dateTimeStyle)
+      ParameterType.Integer, ParameterType.Long -> writeIntegerCell(cell, value)
+      ParameterType.Double, ParameterType.Float -> writeDecimalCell(cell, value)
+      ParameterType.Boolean -> writeBooleanCell(cell, value)
+      // Strings, times and anything unrecognised stay text. This is the case that fixes
+      // room numbers, reference codes and identifiers with leading zeros.
+      else -> cell.setCellValue(truncate(value.toString()))
+    }
+  }
+
+  private fun writeDateCell(cell: Cell, value: Any?, style: CellStyle) {
+    val temporal = toLocalDateTime(value)
+    if (temporal == null) {
+      // A formula may have already rendered this into a display string, and some
+      // datasources hand back values that do not match the declared type. Either way,
+      // text is the safe answer.
+      cell.setCellValue(truncate(value.toString()))
+      return
+    }
+    cell.setCellValue(temporal)
+    cell.cellStyle = style
+  }
+
+  private fun writeIntegerCell(cell: Cell, value: Any?) {
+    val number = when (value) {
+      is Number -> value.toLong()
+      else -> value.toString().trim().toLongOrNull()
+    }
+    if (number == null || number >= MAX_EXACT_INTEGER || number <= -MAX_EXACT_INTEGER) {
+      cell.setCellValue(truncate(value.toString()))
+      return
+    }
+    cell.setCellValue(number.toDouble())
+  }
+
+  private fun writeDecimalCell(cell: Cell, value: Any?) {
+    val number = when (value) {
+      is Number -> value.toDouble()
+      else -> value.toString().trim().toDoubleOrNull()
+    }
+    if (number == null || number.isNaN() || number.isInfinite()) {
+      cell.setCellValue(truncate(value.toString()))
+      return
+    }
+    cell.setCellValue(number)
+  }
+
+  private fun writeBooleanCell(cell: Cell, value: Any?) {
+    when (value) {
+      is Boolean -> cell.setCellValue(value)
+      else -> when (value.toString().trim().lowercase()) {
+        "true" -> cell.setCellValue(true)
+        "false" -> cell.setCellValue(false)
+        else -> cell.setCellValue(truncate(value.toString()))
+      }
+    }
+  }
+
+  private fun toLocalDateTime(value: Any?): LocalDateTime? = when (value) {
+    is LocalDateTime -> value
+    is LocalDate -> value.atStartOfDay()
+    is Timestamp -> value.toLocalDateTime()
+    is java.sql.Date -> value.toLocalDate().atStartOfDay()
+    is java.util.Date -> LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault())
+    is OffsetDateTime -> value.toLocalDateTime()
+    is ZonedDateTime -> value.toLocalDateTime()
+    else -> parseTemporal(value.toString())
+  }
+
+  private fun parseTemporal(value: String): LocalDateTime? {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty()) return null
+    return try {
+      LocalDateTime.parse(trimmed)
+    } catch (_: DateTimeParseException) {
+      try {
+        LocalDate.parse(trimmed).atStartOfDay()
+      } catch (_: DateTimeParseException) {
+        null
+      }
+    }
+  }
+
+  private fun truncate(value: String): String = if (value.length <= MAX_CELL_TEXT_LENGTH) {
+    value
+  } else {
+    log.warn("Truncating a cell value of ${value.length} characters to the Excel limit of $MAX_CELL_TEXT_LENGTH.")
+    value.take(MAX_CELL_TEXT_LENGTH)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxStreamingSupport.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxStreamingSupport.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class XlsxStreamingSupport {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    const val XLSX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  }
+
+  /**
+   * Streams a report as XLSX.
+   *
+   * Unlike the CSV equivalent there is no gzip branch — XLSX is a zip container, so it is
+   * already compressed — and no UTF-8 BOM, which is a CSV-only hint to Excel.
+   */
+  fun streamXlsx(
+    reportId: String,
+    reportVariantId: String,
+    response: HttpServletResponse,
+    streamFun: (ReportRowWriter) -> Unit,
+  ) {
+    response.contentType = XLSX_CONTENT_TYPE
+    response.setHeader(
+      "Content-Disposition",
+      "attachment; filename=$reportId-$reportVariantId.xlsx",
+    )
+
+    log.debug("Streaming xlsx content...")
+    XlsxRowWriter(response.outputStream).use { rowWriter ->
+      streamFun(rowWriter)
+    }
+    log.debug("Successfully wrote the entire xlsx data.")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/integration/DataApiIntegrationTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.integration
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -33,7 +34,9 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ConfiguredApi
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ExternalMovementEntity
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.PrisonerEntity
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.WARNING_NO_ACTIVE_CASELOAD
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.XlsxStreamingSupport
 import uk.gov.justice.hmpps.kotlin.auth.AuthSource
+import java.io.ByteArrayInputStream
 import java.sql.DriverManager
 import java.time.LocalDateTime
 
@@ -218,6 +221,43 @@ class DataApiIntegrationTest : IntegrationTestBase() {
         """.trimIndent()
         assertThat(body?.startsWith("\uFEFF")).isTrue()
         assertThat(body?.trim()?.replace("\uFEFF", "")).isEqualTo(expected)
+      }
+  }
+
+  @Test
+  fun `Data API is streaming results to the downloaded xlsx file`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/reports/external-movements/last-month/download/xlsx")
+          .queryParam("columns", "prisonNumber")
+          .queryParam("columns", "name")
+          .queryParam("columns", "origin")
+          .queryParam("columns", "destination")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectHeader().contentType(XlsxStreamingSupport.XLSX_CONTENT_TYPE)
+      .expectHeader().valueEquals(
+        "Content-Disposition",
+        "attachment; filename=external-movements-last-month.xlsx",
+      )
+      .expectBody(ByteArray::class.java)
+      .value { body ->
+        val sheet = XSSFWorkbook(ByteArrayInputStream(body)).getSheetAt(0)
+
+        assertThat(sheet.getRow(0).map { it.stringCellValue })
+          .containsExactly("Prison Number", "Name", "From", "To")
+        // Every value carries its type, so Excel has nothing left to guess at on open.
+        assertThat(sheet.getRow(1).map { it.stringCellValue }).containsExactly(
+          movementPrisoner4[PRISON_NUMBER].toString(),
+          movementPrisoner4[NAME].toString(),
+          movementPrisoner4[ORIGIN].toString(),
+          movementPrisoner4[DESTINATION].toString(),
+        )
       }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxRowWriterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/XlsxRowWriterTest.kt
@@ -1,0 +1,183 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service
+
+import org.apache.poi.ss.usermodel.CellType
+import org.apache.poi.ss.usermodel.DateUtil
+import org.apache.poi.ss.usermodel.Sheet
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ParameterType
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class XlsxRowWriterTest {
+
+  private fun column(name: String, type: ParameterType) = ReportColumn(name, "The $name", type)
+
+  private fun write(columns: List<ReportColumn>, rows: List<List<Any?>>): Sheet {
+    val out = ByteArrayOutputStream()
+    XlsxRowWriter(out).use { writer ->
+      writer.writeHeader(columns)
+      rows.forEach(writer::writeRow)
+    }
+    return XSSFWorkbook(ByteArrayInputStream(out.toByteArray())).getSheetAt(0)
+  }
+
+  @Test
+  fun `values that Excel would misread as dates or numbers stay text`() {
+    // The bug this format exists to fix: opening the csv equivalent of this row in Excel
+    // turns 1.5.2 into a date, drops the leading zeros from 007 and expands 1E5.
+    val sheet = write(
+      columns = listOf(
+        column("room", ParameterType.String),
+        column("reference", ParameterType.String),
+        column("code", ParameterType.String),
+        column("received", ParameterType.String),
+      ),
+      rows = listOf(listOf("1.5.2", "007", "1E5", "1/2/2024")),
+    )
+
+    val row = sheet.getRow(1)
+    assertThat(row.map { it.cellType }).containsOnly(CellType.STRING)
+    assertThat(row.map { it.stringCellValue })
+      .containsExactly("1.5.2", "007", "1E5", "1/2/2024")
+  }
+
+  @Test
+  fun `the header row uses the column display names`() {
+    val sheet = write(
+      columns = listOf(column("room", ParameterType.String), column("wing", ParameterType.String)),
+      rows = listOf(listOf("1.5.2", "A")),
+    )
+
+    assertThat(sheet.getRow(0).map { it.stringCellValue }).containsExactly("The room", "The wing")
+  }
+
+  @Test
+  fun `columns declared as dates are written as real dates so sorting still works`() {
+    val sheet = write(
+      columns = listOf(
+        column("date", ParameterType.Date),
+        column("datetime", ParameterType.DateTime),
+        column("timestamp", ParameterType.Timestamp),
+      ),
+      rows = listOf(
+        listOf(
+          LocalDate.of(2024, 2, 1),
+          LocalDateTime.of(2024, 2, 1, 13, 30),
+          Timestamp.valueOf(LocalDateTime.of(2024, 2, 1, 13, 30)),
+        ),
+      ),
+    )
+
+    val row = sheet.getRow(1)
+    assertThat(row.map { it.cellType }).containsOnly(CellType.NUMERIC)
+    assertThat(row.map { DateUtil.isCellDateFormatted(it) }).containsOnly(true)
+    assertThat(row.getCell(0).localDateTimeCellValue).isEqualTo(LocalDateTime.of(2024, 2, 1, 0, 0))
+    assertThat(row.getCell(1).localDateTimeCellValue).isEqualTo(LocalDateTime.of(2024, 2, 1, 13, 30))
+    assertThat(row.getCell(2).localDateTimeCellValue).isEqualTo(LocalDateTime.of(2024, 2, 1, 13, 30))
+  }
+
+  @Test
+  fun `a date column whose value is not a date falls back to text`() {
+    // Formulas can render a date column into a display string before it reaches the writer.
+    val sheet = write(
+      columns = listOf(column("released", ParameterType.Date)),
+      rows = listOf(listOf("Not yet released")),
+    )
+
+    val cell = sheet.getRow(1).getCell(0)
+    assertThat(cell.cellType).isEqualTo(CellType.STRING)
+    assertThat(cell.stringCellValue).isEqualTo("Not yet released")
+  }
+
+  @Test
+  fun `numeric columns are written as numbers`() {
+    val sheet = write(
+      columns = listOf(
+        column("count", ParameterType.Long),
+        column("age", ParameterType.Integer),
+        column("rate", ParameterType.Double),
+      ),
+      rows = listOf(listOf(42L, "17", 1.5)),
+    )
+
+    val row = sheet.getRow(1)
+    assertThat(row.map { it.cellType }).containsOnly(CellType.NUMERIC)
+    assertThat(row.getCell(0).numericCellValue).isEqualTo(42.0)
+    assertThat(row.getCell(1).numericCellValue).isEqualTo(17.0)
+    assertThat(row.getCell(2).numericCellValue).isEqualTo(1.5)
+  }
+
+  @Test
+  fun `integers too large for Excel to hold exactly stay text rather than lose precision`() {
+    // Excel stores numbers as doubles, so anything past 2^53 would be silently rounded.
+    val sheet = write(
+      columns = listOf(column("id", ParameterType.Long)),
+      rows = listOf(listOf(9_007_199_254_740_993L)),
+    )
+
+    val cell = sheet.getRow(1).getCell(0)
+    assertThat(cell.cellType).isEqualTo(CellType.STRING)
+    assertThat(cell.stringCellValue).isEqualTo("9007199254740993")
+  }
+
+  @Test
+  fun `booleans are written as booleans and unparseable ones as text`() {
+    val sheet = write(
+      columns = listOf(
+        column("active", ParameterType.Boolean),
+        column("known", ParameterType.Boolean),
+      ),
+      rows = listOf(listOf(true, "unknown")),
+    )
+
+    assertThat(sheet.getRow(1).getCell(0).booleanCellValue).isTrue()
+    assertThat(sheet.getRow(1).getCell(1).stringCellValue).isEqualTo("unknown")
+  }
+
+  @Test
+  fun `nulls are written as blank cells`() {
+    val sheet = write(
+      columns = listOf(column("a", ParameterType.String), column("b", ParameterType.String)),
+      rows = listOf(listOf(null, "set")),
+    )
+
+    assertThat(sheet.getRow(1).getCell(0).cellType).isEqualTo(CellType.BLANK)
+    assertThat(sheet.getRow(1).getCell(1).stringCellValue).isEqualTo("set")
+  }
+
+  @Test
+  fun `values containing commas and quotes need no escaping`() {
+    // Unlike csv, the xlsx container carries these verbatim.
+    val sheet = write(
+      columns = listOf(column("notes", ParameterType.String)),
+      rows = listOf(listOf("""Smith, John said "hello"""")),
+    )
+
+    assertThat(sheet.getRow(1).getCell(0).stringCellValue).isEqualTo("""Smith, John said "hello"""")
+  }
+
+  @Test
+  fun `cell text longer than the Excel limit is truncated`() {
+    val sheet = write(
+      columns = listOf(column("notes", ParameterType.String)),
+      rows = listOf(listOf("x".repeat(40_000))),
+    )
+
+    assertThat(sheet.getRow(1).getCell(0).stringCellValue).hasSize(32_767)
+  }
+
+  @Test
+  fun `a report with no rows still produces a readable workbook`() {
+    val out = ByteArrayOutputStream()
+    XlsxRowWriter(out).use { }
+
+    val workbook = XSSFWorkbook(ByteArrayInputStream(out.toByteArray()))
+    assertThat(workbook.numberOfSheets).isEqualTo(1)
+    assertThat(workbook.getSheetAt(0).physicalNumberOfRows).isZero()
+  }
+}


### PR DESCRIPTION
## Why

Users downloading DPR/DataHub reports get CSV. Excel type-guesses every value when the file is opened, so a room number such as `1.5.2` becomes a date and `007` loses its leading zeros. The data in the file is correct — Excel corrupts it on open.

Two things worth stating up front, because both are the obvious first suggestions:

- **Quoting the CSV fields does not fix this.** CSV quotes are *text qualifiers*: they tell the parser where a field ends so embedded commas and newlines survive. Once the field is split out Excel discards the quotes and runs the same type-inference on the contents. `"1.5.2"` still becomes a date. We already quote correctly and already write a UTF-8 BOM, so the CSV itself was never the problem.
- **Excel cannot be configured out of it.** The Microsoft 365 *Automatic Data Conversion* settings only cover leading zeros, 15-digit truncation and scientific notation. Date conversion is listed as planned, not shipped.

So this stops asking Excel to guess: in xlsx each cell carries its type explicitly.

## What

New endpoints alongside the existing CSV ones:

- sync: `GET /reports/{reportId}/{reportVariantId}/download/xlsx`
- async: `GET /reports/{reportId}/{reportVariantId}/tables/{tableId}/download/xlsx`

Text stays text. Columns the schema declares as dates or numbers are still written as real dates and numbers so sorting and filtering behave as users expect. Integers past 2^53 are kept as text rather than being silently rounded by Excel's double storage.

Row writing now sits behind a `ReportRowWriter` interface (`CsvRowWriter`, `XlsxRowWriter`) so one row pipeline — column selection, ordering, display names, formulas — feeds both formats.

Implementation notes:
- Uses POI's streaming `SXSSFWorkbook` to keep memory bounded; `close()` cleans up the temp files it spills to disk.
- Rolls over to a new sheet at the Excel row limit rather than truncating.
- No gzip (xlsx is already a zip) and no BOM (a CSV-only hint).
- Cell styles are created once per workbook, not per row, to stay under POI's 64k style cap.

## Compatibility

CSV output is unchanged. `SyncDataApiService.downloadCsv` and `AsyncDataApiService.downloadCsv` are deprecated in favour of `download(rowWriter, ...)` but still work and still produce CSV.

## Testing

486 tests pass, ktlint clean.

- The existing CSV tests are the regression guard for the refactor and are untouched.
- 11 new unit tests on `XlsxRowWriter` asserting `1.5.2`, `007`, `1E5` and `1/2/2024` survive as `CellType.STRING`, that declared date columns come back as date-formatted numerics, and that oversized integers and text fall back safely.
- New integration test hitting the sync `/download/xlsx` endpoint, checking status, content type, `Content-Disposition` and that the body parses as a workbook.

## Follow-ups

- The UI does not offer the new format yet — that needs a change in `hmpps-digital-prison-reporting-frontend` (in progress).
- Separately: `escapeCsv` does not neutralise values starting with `=`, `+`, `-` or `@`, so the CSV download is exposed to formula injection if any report field carries user-supplied text. The xlsx path is immune. Worth its own ticket.