### PR TITLE
MAPA-226 Register XlsxStreamingSupport so consuming applications can start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 17.5.1
+- Registered `XlsxStreamingSupport` in `AutoConfiguration.imports`. It was added as a `@Component` in 17.5.0 and injected into `DataApiSyncController` and `DataApiAsyncController`, but never listed, so consuming applications failed to start with `No qualifying bean of type ... XlsxStreamingSupport`. 17.5.0 cannot be used and should be skipped.
+
 # 17.5.0
 - Added an Excel (xlsx) download format for reports, alongside the existing csv download:
   - sync: `GET /reports/{reportId}/{reportVariantId}/download/xlsx`

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -42,5 +42,6 @@ uk.gov.justice.digital.hmpps.digitalprisonreportinglib.productCollection.Product
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.productCollection.ProductCollectionRepository
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.S3ApiService
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.CsvStreamingSupport
+uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.XlsxStreamingSupport
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.JacksonConfig
 uk.gov.justice.digital.hmpps.digitalprisonreportinglib.config.CaseInsensitiveAuthSourceDeserializer


### PR DESCRIPTION
Fixes the failing build on [hmpps-dpr-tools-api#828](https://github.com/ministryofjustice/hmpps-dpr-tools-api/pull/828) (the 17.5.0 bump).

## What went wrong

#992 added `XlsxStreamingSupport` as a `@Component` and injected it into both `DataApiSyncController` and `DataApiAsyncController`, but did not add it to `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`. This library does not component scan for consumers — every bean is listed explicitly in that file — so the bean is never registered outside the library itself. Its sibling `CsvStreamingSupport` is listed; this one was missed.

Consumers fail to build the Spring context:

```
UnsatisfiedDependencyException: Error creating bean with name
'...controller.DataApiAsyncController': Unsatisfied dependency expressed
through constructor parameter 3: No qualifying bean of type
'...service.XlsxStreamingSupport' available
```

Worth being explicit that this is **a startup failure, not just a test failure**. `DataApiSyncController` takes the same parameter, so 17.5.0 will fail to boot in any consuming application. The 9 failing tools-api tests are just the first thing to touch the context. 17.5.0 should be skipped.

## Why CI was green on #992

The library's own test context component scans the whole package, so the bean exists there regardless of the imports file. Nothing in this repo consumes the published jar, so nothing exercised the path that breaks.

## The fix

One line, alongside the existing `CsvStreamingSupport` entry. I also swept the main sources for `@Component` / `@Service` / `@Repository` classes missing from the imports file — with this added there are none, so this was the only omission.

`XlsxRowWriter` and `CsvRowWriter` are constructed directly rather than injected, so they need no entry.

## Follow-up worth considering

Nothing catches this class of mistake at the moment: the imports file is maintained by hand, and the tests that would notice all run with a scanned context. A guard — either an `ApplicationContextRunner` test over `AutoConfigurations.of(...)`, or a test asserting every annotated component in main is listed in the file — would catch the next one. Happy to raise that separately rather than hold this up, since 17.5.1 needs publishing to unblock tools-api.
