### PR TITLE
DPR2-2899 fix match condition inconsistent behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+# 17.5.3
+- Fixed issue with match condition behaving inconsistently for roles versus any other cases.  
+
 # 17.5.2
 - Added extra information in the query comments we generate for Redshift and Athena queries
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -42,9 +42,10 @@ data class Condition(
   private fun isTheInterpolatedVarInTheList(
     matchList: List<String>,
     interpolateVariables: (String) -> String,
-  ) = matchList.map {
-    interpolateVariables(it)
-  }.toSet().count() == 1
+  ): Boolean {
+    if (matchList.size < 2) return false
+    return matchList.drop(1).contains(interpolateVariables(matchList.first()))
+  }
 
   private fun isNotNull(
     varPlaceholder: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/data/model/policyengine/Condition.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine
 
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.context.ExecutionContext
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.policyengine.Policy.PolicyResult.POLICY_DENY
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOAD
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.CASELOADS
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.PolicyEngine.VariableNames.ROLE
@@ -44,7 +45,9 @@ data class Condition(
     interpolateVariables: (String) -> String,
   ): Boolean {
     if (matchList.size < 2) return false
-    return matchList.drop(1).contains(interpolateVariables(matchList.first()))
+    val interpolatedPlaceholder = interpolateVariables(matchList.first())
+    if (interpolatedPlaceholder == POLICY_DENY) return false
+    return matchList.drop(1).contains(interpolatedPlaceholder)
   }
 
   private fun isNotNull(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -516,7 +516,31 @@ class PolicyEngineTest {
     val policy = Policy(
       id = "caseload",
       type = ACCESS,
-      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${caseload}"))))),
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = emptyList())))),
+    )
+    val policyEngine = PolicyEngine(listOf(policy), context)
+    assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
+  }
+
+  @Test
+  fun `policy engine returns FALSE for an access policy with a permit rule with a caseload match condition which has no active caseload`() {
+    val userRole = "DPR-USER"
+    val context = ExecutionContext(
+      CaseloadResponse(
+        username = testUsername,
+        active = true,
+        accountType = "GENERAL",
+        caseloads = listOf(testCaseload),
+        activeCaseload = null,
+      ),
+      listOf(userRole),
+      AuthUser(testUsername, true, testUsername, AuthSource.NOMIS, "abc123", "f23-f2-f32f23-f3223f"),
+      false,
+    )
+    val policy = Policy(
+      id = "caseload",
+      type = ACCESS,
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${caseload}", "FALSE"))))),
     )
     val policyEngine = PolicyEngine(listOf(policy), context)
     assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportinglib/service/PolicyEngineTest.kt
@@ -475,6 +475,54 @@ class PolicyEngineTest {
   }
 
   @Test
+  fun `policy engine returns TRUE for an access policy with a permit rule with a condition of matching a caseload when there is a matching active caseload`() {
+    val userRole = "DPR-USER"
+    val context = ExecutionContext(
+      CaseloadResponse(
+        username = testUsername,
+        active = true,
+        accountType = "GENERAL",
+        caseloads = listOf(testCaseload),
+        activeCaseload = testCaseload,
+      ),
+      listOf(userRole),
+      AuthUser(testUsername, true, testUsername, AuthSource.NOMIS, "abc123", "f23-f2-f32f23-f3223f"),
+      false,
+    )
+    val policy = Policy(
+      id = "caseload",
+      type = ACCESS,
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${caseload}", "ABC", "DEF"))))),
+    )
+    val policyEngine = PolicyEngine(listOf(policy), context)
+    assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_PERMIT)
+  }
+
+  @Test
+  fun `policy engine returns FALSE for an access policy with a permit rule with a match condition which has less than two elements`() {
+    val userRole = "DPR-USER"
+    val context = ExecutionContext(
+      CaseloadResponse(
+        username = testUsername,
+        active = true,
+        accountType = "GENERAL",
+        caseloads = listOf(testCaseload),
+        activeCaseload = testCaseload,
+      ),
+      listOf(userRole),
+      AuthUser(testUsername, true, testUsername, AuthSource.NOMIS, "abc123", "f23-f2-f32f23-f3223f"),
+      false,
+    )
+    val policy = Policy(
+      id = "caseload",
+      type = ACCESS,
+      rule = listOf(Rule(Effect.PERMIT, listOf(Condition(match = listOf("\${caseload}"))))),
+    )
+    val policyEngine = PolicyEngine(listOf(policy), context)
+    assertThat(policyEngine.execute()).isEqualTo(PolicyResult.POLICY_DENY)
+  }
+
+  @Test
   fun `policy engine returns FALSE for an access policy with a permit rule with a condition of matching a role when no role matches`() {
     val context = ExecutionContext(
       CaseloadResponse(


### PR DESCRIPTION
Currently this is bug is because our current access condition works fine for roles like for example:
```
 "condition": [
            {
              "match": [
                "${role}",
                "ROLE_ACTIVITY_HUB",
                "ROLE_PRISONS_REPORTING_USER"
              ]
            }
          ]
But if you do the same for a caseload it produces the wrong result.
For example the match condition currently for this:
"condition": [
            {
              "match": [
                "${caseload}",
                "ABC",
                "DEF"
              ]
            }
          ]
```
will produce a deny result even if the user active caseload is ABC.